### PR TITLE
Update pdftypes.py

### DIFF
--- a/pdfminer/pdftypes.py
+++ b/pdfminer/pdftypes.py
@@ -275,7 +275,7 @@ class PDFStream(PDFObject):
             else:
                 raise PDFNotImplementedError('Unsupported filter: %r' % f)
             # apply predictors
-            if 'Predictor' in params:
+            if params and 'Predictor' in params:
                 pred = int_value(params['Predictor'])
                 if pred == 1:
                     # no predictor


### PR DESCRIPTION
Fix errors with:
  File "/app/python/lib/python3.5/site-packages/pdfminer/pdfinterp.py", line 850, in process_page
    self.render_contents(page.resources, page.contents, ctm=ctm)
  File "/app/python/lib/python3.5/site-packages/pdfminer/pdfinterp.py", line 860, in render_contents
    self.init_resources(resources)
  File "/app/python/lib/python3.5/site-packages/pdfminer/pdfinterp.py", line 360, in init_resources
    self.fontmap[fontid] = self.rsrcmgr.get_font(objid, spec)
  File "/app/python/lib/python3.5/site-packages/pdfminer/pdfinterp.py", line 210, in get_font
    font = self.get_font(None, subspec)
  File "/app/python/lib/python3.5/site-packages/pdfminer/pdfinterp.py", line 201, in get_font
    font = PDFCIDFont(self, spec)
  File "/app/python/lib/python3.5/site-packages/pdfminer/pdffont.py", line 667, in __init__
    BytesIO(self.fontfile.get_data()))
  File "/app/python/lib/python3.5/site-packages/pdfminer/pdftypes.py", line 297, in get_data
    self.decode()
  File "/app/python/lib/python3.5/site-packages/pdfminer/pdftypes.py", line 278, in decode
    if 'Predictor' in params:
TypeError: argument of type 'NoneType' is not iterable