### PR TITLE
Please replace pycrypto with pycryptodome

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,10 @@ python:
   - "2.7"
   - "3.4"
   - "3.5"
+  - "3.6"
 install:
   - pip install six
-  - pip install pycrypto
+  - pip install pycryptodome
   - pip install chardet
 script:
   nosetests --nologcapture

--- a/pdfminer/__init__.py
+++ b/pdfminer/__init__.py
@@ -1,6 +1,6 @@
 
 # -*- coding: utf-8 -*-
-__version__ = '20170419'
+__version__ = '20170510'
 
 if __name__ == '__main__':
     print (__version__)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 from pdfminer import __version__
 import sys
 
-requires = ['six', 'pycrypto']
+requires = ['six', 'pycryptodome']
 if sys.version_info >= (3, 0):
     requires.append('chardet')
 


### PR DESCRIPTION
Hi,

pycrypto becomes an obsolete package, it is really hard to compile it on Windows, there are no binary releases for Python 3.5 and 3.6. 

pycryptodome is a drop-in replacement which has better support. 

Please consider replacing pycrypto with pycryptodome, as in this pull request. No source changes in pdf miner.six are required, 

as Python 3 is your area of interest, pycryptodome will give us better support for pdf miner.six on Windows. 

thank you for a great package BTW!