### PR TITLE
Add string expressions to asserts, showing local data

### DIFF
--- a/pdfminer/ascii85.py
+++ b/pdfminer/ascii85.py
@@ -35,7 +35,7 @@ def ascii85decode(data):
                 out += struct.pack('>L', b)
                 n = b = 0
         elif c == b'z':
-            assert n == 0
+            assert n == 0, str(n)
             out += b'\0\0\0\0'
         elif c == b'~':
             if n:
@@ -63,11 +63,11 @@ def asciihexdecode(data):
     def decode(x):
         i=int(x,16)
         return six.int2byte(i)
-    
-    out=b''    
+
+    out=b''
     for x in hex_re.findall(data):
         out+=decode(x)
-        
+
     m = trail_re.search(data)
     if m:
         out+=decode(m.group(1)+b'0')

--- a/pdfminer/cmapdb.py
+++ b/pdfminer/cmapdb.py
@@ -80,7 +80,7 @@ class CMap(CMapBase):
         return '<CMap: %s>' % self.attrs.get('CMapName')
 
     def use_cmap(self, cmap):
-        assert isinstance(cmap, CMap)
+        assert isinstance(cmap, CMap), str(type(cmap))
 
         def copy(dst, src):
             for (k, v) in src.iteritems():
@@ -158,7 +158,7 @@ class UnicodeMap(CMapBase):
 class FileCMap(CMap):
 
     def add_code2cid(self, code, cid):
-        assert isinstance(code, str) and isinstance(cid, int)
+        assert isinstance(code, str) and isinstance(cid, int), str((type(code), type(cid)))
         d = self.code2cid
         for c in code[:-1]:
             c = ord(c)
@@ -178,7 +178,7 @@ class FileCMap(CMap):
 class FileUnicodeMap(UnicodeMap):
 
     def add_cid2unichr(self, cid, code):
-        assert isinstance(cid, int)
+        assert isinstance(cid, int), str(type(cid))
         if isinstance(code, PSLiteral):
             # Interpret as an Adobe glyph name.
             self.cid2unichr[cid] = name2unicode(code.name)
@@ -304,7 +304,7 @@ class CMapParser(PSStackParser):
     KEYWORD_ENDBFCHAR = KWD(b'endbfchar')
     KEYWORD_BEGINNOTDEFRANGE = KWD(b'beginnotdefrange')
     KEYWORD_ENDNOTDEFRANGE = KWD(b'endnotdefrange')
-    
+
     def do_keyword(self, pos, token):
         if token is self.KEYWORD_BEGINCMAP:
             self._in_cmap = True
@@ -359,7 +359,7 @@ class CMapParser(PSStackParser):
                 s1 = nunpack(svar)
                 e1 = nunpack(evar)
                 vlen = len(svar)
-                #assert s1 <= e1
+                #assert s1 <= e1, str((s1, e1))
                 for i in range(e1-s1+1):
                     x = sprefix+struct.pack('>L', s1+i)[-vlen:]
                     self.cmap.add_code2cid(x, cid+i)
@@ -386,7 +386,7 @@ class CMapParser(PSStackParser):
                         continue
                 s1 = nunpack(s)
                 e1 = nunpack(e)
-                #assert s1 <= e1
+                #assert s1 <= e1, str((s1, e1))
                 if isinstance(code, list):
                     for i in range(e1-s1+1):
                         self.cmap.add_cid2unichr(s1+i, code[i])

--- a/pdfminer/converter.py
+++ b/pdfminer/converter.py
@@ -48,8 +48,8 @@ class PDFLayoutAnalyzer(PDFTextDevice):
         return
 
     def end_page(self, page):
-        assert not self._stack
-        assert isinstance(self.cur_item, LTPage)
+        assert not self._stack, str(len(stack))
+        assert isinstance(self.cur_item, LTPage), str(type(self.cur_item))
         if self.laparams is not None:
             self.cur_item.analyze(self.laparams)
         self.pageno += 1
@@ -63,13 +63,13 @@ class PDFLayoutAnalyzer(PDFTextDevice):
 
     def end_figure(self, _):
         fig = self.cur_item
-        assert isinstance(self.cur_item, LTFigure)
+        assert isinstance(self.cur_item, LTFigure), str(type(self.cur_item))
         self.cur_item = self._stack.pop()
         self.cur_item.add(fig)
         return
 
     def render_image(self, name, stream):
-        assert isinstance(self.cur_item, LTFigure)
+        assert isinstance(self.cur_item, LTFigure), str(type(self.cur_item))
         item = LTImage(name, stream,
                        (self.cur_item.x0, self.cur_item.y0,
                         self.cur_item.x1, self.cur_item.y1))
@@ -115,7 +115,7 @@ class PDFLayoutAnalyzer(PDFTextDevice):
     def render_char(self, matrix, font, fontsize, scaling, rise, cid):
         try:
             text = font.to_unichr(cid)
-            assert isinstance(text, six.text_type), text
+            assert isinstance(text, six.text_type), str(type(text))
         except PDFUnicodeNotDefined:
             text = self.handle_undefined_char(font, cid)
         textwidth = font.char_width(cid)
@@ -535,7 +535,7 @@ class XMLConverter(PDFConverter):
                     self.write('<image width="%d" height="%d" />\n' %
                                      (item.width, item.height))
             else:
-                assert 0, item
+                assert False, str(('Unhandled', item))
             return
         render(ltpage)
         return

--- a/pdfminer/image.py
+++ b/pdfminer/image.py
@@ -34,9 +34,9 @@ class BMPWriter(object):
         self.datasize = self.linesize * self.height
         headersize = 14+40+ncols*4
         info = struct.pack('<IiiHHIIIIII', 40, self.width, self.height, 1, self.bits, 0, self.datasize, 0, 0, ncols, 0)
-        assert len(info) == 40, len(info)
+        assert len(info) == 40, str(len(info))
         header = struct.pack('<ccIHHI', b'B', b'M', headersize+self.datasize, 0, 0, headersize)
-        assert len(header) == 14, len(header)
+        assert len(header) == 14, str(len(header))
         self.fp.write(header)
         self.fp.write(info)
         if ncols == 2:

--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -114,36 +114,36 @@ class LTComponent(LTItem):
         return self.width <= 0 or self.height <= 0
 
     def is_hoverlap(self, obj):
-        assert isinstance(obj, LTComponent)
+        assert isinstance(obj, LTComponent), str(type(obj))
         return obj.x0 <= self.x1 and self.x0 <= obj.x1
 
     def hdistance(self, obj):
-        assert isinstance(obj, LTComponent)
+        assert isinstance(obj, LTComponent), str(type(obj))
         if self.is_hoverlap(obj):
             return 0
         else:
             return min(abs(self.x0-obj.x1), abs(self.x1-obj.x0))
 
     def hoverlap(self, obj):
-        assert isinstance(obj, LTComponent)
+        assert isinstance(obj, LTComponent), str(type(obj))
         if self.is_hoverlap(obj):
             return min(abs(self.x0-obj.x1), abs(self.x1-obj.x0))
         else:
             return 0
 
     def is_voverlap(self, obj):
-        assert isinstance(obj, LTComponent)
+        assert isinstance(obj, LTComponent), str(type(obj))
         return obj.y0 <= self.y1 and self.y0 <= obj.y1
 
     def vdistance(self, obj):
-        assert isinstance(obj, LTComponent)
+        assert isinstance(obj, LTComponent), str(type(obj))
         if self.is_voverlap(obj):
             return 0
         else:
             return min(abs(self.y0-obj.y1), abs(self.y1-obj.y0))
 
     def voverlap(self, obj):
-        assert isinstance(obj, LTComponent)
+        assert isinstance(obj, LTComponent), str(type(obj))
         if self.is_voverlap(obj):
             return min(abs(self.y0-obj.y1), abs(self.y1-obj.y0))
         else:
@@ -603,7 +603,7 @@ class LTLayoutContainer(LTContainer):
 
     # group_textboxes: group textboxes hierarchically.
     def group_textboxes(self, laparams, boxes):
-        assert boxes
+        assert boxes, str((laparams, boxes))
 
         def dist(obj1, obj2):
             """A distance function between two TextBoxes.
@@ -666,7 +666,7 @@ class LTLayoutContainer(LTContainer):
                 dists.append((0, dist(group, other), group, other))
             dists = csort(dists, key=key_obj)
             plane.add(group)
-        assert len(plane) == 1
+        assert len(plane) == 1, str(len(plane))
         return list(plane)
 
     def analyze(self, laparams):

--- a/pdfminer/pdfdevice.py
+++ b/pdfminer/pdfdevice.py
@@ -171,7 +171,7 @@ class TagExtractor(PDFDevice):
         return
 
     def end_tag(self):
-        assert self._stack
+        assert self._stack, str(self.pageno)
         tag = self._stack.pop(-1)
         out_s = '</%s>' % utils.enc(tag.name)
         self.outfp.write(utils.make_compat_bytes(out_s))

--- a/pdfminer/pdfdocument.py
+++ b/pdfminer/pdfdocument.py
@@ -136,7 +136,7 @@ class PDFXRef(PDFBaseXRef):
     def load_trailer(self, parser):
         try:
             (_, kwd) = parser.nexttoken()
-            assert kwd is KWD(b'trailer')
+            assert kwd is KWD(b'trailer'), str(kwd)
             (_, dic) = parser.nextobject()
         except PSEOF:
             x = parser.pop(1)
@@ -571,7 +571,7 @@ class PDFDocument(object):
                 continue
             # If there's an encryption info, remember it.
             if 'Encrypt' in trailer:
-                #assert not self.encryption
+                #assert not self.encryption, str(self.encryption)
                 self.encryption = (list_value(trailer['ID']),
                                    dict_value(trailer['Encrypt']))
                 self._initialize_password(password)
@@ -649,7 +649,7 @@ class PDFDocument(object):
         # #### hack around malformed pdf files
         # copied from https://github.com/jaepil/pdfminer3k/blob/master/pdfminer/pdfparser.py#L399
         #to solve https://github.com/pdfminer/pdfminer.six/issues/56
-        #assert objid1 == objid, (objid, objid1)
+        #assert objid1 == objid, str((objid1, objid))
         if objid1 != objid:
             x = []
             while kwd is not self.KEYWORD_OBJ:

--- a/pdfminer/pdffont.py
+++ b/pdfminer/pdffont.py
@@ -357,7 +357,7 @@ class CFFFont(object):
                     sid += 1
         elif format == b'\x02':
             # Format 2
-            assert 0
+            assert False, str(('Unhandled', format))
         else:
             raise ValueError('unsupported charset format: %r' % format)
         #print self.code2gid
@@ -444,7 +444,7 @@ class TrueTypeFont(object):
                         for c in range(sc, ec+1):
                             char2gid[c] = (c + idd) & 0xffff
             else:
-                assert 0
+                assert False, str(('Unhandled', fmttype))
         # create unicode map
         unicode_map = FileUnicodeMap()
         for (char, gid) in char2gid.iteritems():

--- a/pdfminer/pdftypes.py
+++ b/pdfminer/pdftypes.py
@@ -184,7 +184,7 @@ def stream_value(x):
 class PDFStream(PDFObject):
 
     def __init__(self, attrs, rawdata, decipher=None):
-        assert isinstance(attrs, dict)
+        assert isinstance(attrs, dict), str(type(attrs))
         self.attrs = attrs
         self.rawdata = rawdata
         self.decipher = decipher
@@ -236,7 +236,7 @@ class PDFStream(PDFObject):
         return list(zip(filters, params)) #solves https://github.com/pdfminer/pdfminer.six/issues/15
 
     def decode(self):
-        assert self.data is None and self.rawdata is not None
+        assert self.data is None and self.rawdata is not None, str((self.data, self.rawdata))
         data = self.rawdata
         if self.decipher:
             # Handle encryption

--- a/pdfminer/rijndael.py
+++ b/pdfminer/rijndael.py
@@ -833,7 +833,7 @@ def rijndaelSetupDecrypt(key, keybits):
 
 
 def rijndaelEncrypt(rk, nrounds, plaintext):
-    assert len(plaintext) == 16
+    assert len(plaintext) == 16, str(len(plaintext))
 
     # map byte array block to cipher state
     # and add initial round key:
@@ -931,12 +931,12 @@ def rijndaelEncrypt(rk, nrounds, plaintext):
       rk[p+3])
     ciphertext += PUTU32(s3)
 
-    assert len(ciphertext) == 16
+    assert len(ciphertext) == 16, str(len(ciphertext))
     return ciphertext
 
 
 def rijndaelDecrypt(rk, nrounds, ciphertext):
-    assert len(ciphertext) == 16
+    assert len(ciphertext) == 16, str(len(ciphertext))
 
     # map byte array block to cipher state
     # and add initial round key:
@@ -1034,7 +1034,7 @@ def rijndaelDecrypt(rk, nrounds, ciphertext):
       rk[p+3])
     plaintext += PUTU32(s3)
 
-    assert len(plaintext) == 16
+    assert len(plaintext) == 16, str(len(plaintext))
     return plaintext
 
 
@@ -1049,14 +1049,14 @@ class RijndaelDecryptor(object):
     """
 
     def __init__(self, key, keybits=256):
-        assert len(key) == KEYLENGTH(keybits)
+        assert len(key) == KEYLENGTH(keybits), str((len(key), KEYLENGTH(keybits)))
         (self.rk, self.nrounds) = rijndaelSetupDecrypt(key, keybits)
-        assert len(self.rk) == RKLENGTH(keybits)
-        assert self.nrounds == NROUNDS(keybits)
+        assert len(self.rk) == RKLENGTH(keybits), str((len(self.rk), RKLENGTH(keybits)))
+        assert self.nrounds == NROUNDS(keybits), str((self.nrounds, NROUNDS(keybits)))
         return
 
     def decrypt(self, ciphertext):
-        assert len(ciphertext) == 16
+        assert len(ciphertext) == 16, str(len(ciphertext))
         return rijndaelDecrypt(self.rk, self.nrounds, ciphertext)
 
 
@@ -1064,13 +1064,12 @@ class RijndaelDecryptor(object):
 class RijndaelEncryptor(object):
 
     def __init__(self, key, keybits=256):
-        assert len(key) == KEYLENGTH(keybits)
+        assert len(key) == KEYLENGTH(keybits), str((len(key), KEYLENGTH(keybits)))
         (self.rk, self.nrounds) = rijndaelSetupEncrypt(key, keybits)
-        assert len(self.rk) == RKLENGTH(keybits)
-        assert self.nrounds == NROUNDS(keybits)
+        assert len(self.rk) == RKLENGTH(keybits), str((len(self.rk), RKLENGTH(keybits)))
+        assert self.nrounds == NROUNDS(keybits), str((self.nrounds, NROUNDS(keybits)))
         return
 
     def encrypt(self, plaintext):
-        assert len(plaintext) == 16
+        assert len(plaintext) == 16, str(len(plaintext))
         return rijndaelEncrypt(self.rk, self.nrounds, plaintext)
-

--- a/pdfminer/utils.py
+++ b/pdfminer/utils.py
@@ -15,7 +15,7 @@ if six.PY3:
 
 def make_compat_bytes(in_str):
     "In Py2, does nothing. In Py3, converts to bytes, encoding to unicode."
-    assert isinstance(in_str, str)
+    assert isinstance(in_str, str), str(type(in_str))
     if six.PY2:
         return in_str
     else:
@@ -23,7 +23,7 @@ def make_compat_bytes(in_str):
 
 def make_compat_str(in_str):
     "In Py2, does nothing. In Py3, converts to string, guessing encoding."
-    assert isinstance(in_str, (bytes, str, unicode))
+    assert isinstance(in_str, (bytes, str, unicode)), str(type(in_str))
     if six.PY3 and isinstance(in_str, bytes):
         enc = chardet.detect(in_str)
         in_str = in_str.decode(enc['encoding'])
@@ -32,13 +32,11 @@ def make_compat_str(in_str):
 def compatible_encode_method(bytesorstring, encoding='utf-8', erraction='ignore'):
     "When Py2 str.encode is called, it often means bytes.encode in Py3. This does either."
     if six.PY2:
-        assert isinstance(bytesorstring, (str, unicode)), ("Error: Assumed was calling"
-            " encode() on a string in Py2: {}").format(type(bytesorstring))
+        assert isinstance(bytesorstring, (str, unicode)), str(type(bytesorstring))
         return bytesorstring.encode(encoding, erraction)
     if six.PY3:
         if isinstance(bytesorstring, str): return bytesorstring
-        assert isinstance(bytesorstring, bytes), ("Error: Assumed was calling"
-            " encode() on a bytes in Py3: {}").format(type(bytesorstring))
+        assert isinstance(bytesorstring, bytes), str(type(bytesorstring))
         return bytesorstring.decode(encoding, erraction)
 
 ##  PNG Predictor
@@ -170,7 +168,7 @@ def fsplit(pred, objs):
 # drange
 def drange(v0, v1, d):
     """Returns a discrete range."""
-    assert v0 < v1
+    assert v0 < v1, str((v0, v1, d))
     return range(int(v0)//d, int(v1+d)//d)
 
 

--- a/tools/conv_cmap.py
+++ b/tools/conv_cmap.py
@@ -53,7 +53,7 @@ class CMapConverter(object):
             if not line: continue
             values = line.split('\t')
             if encs is None:
-                assert values[0] == 'CID'
+                assert values[0] == 'CID', str(values)
                 encs = values
                 continue
 


### PR DESCRIPTION
I find it's helpful to dump out locally-available details of assert failures.
