### PR TITLE
Microoptimization for singlebyte fonts

### DIFF
--- a/pdfminer/pdffont.py
+++ b/pdfminer/pdffont.py
@@ -494,7 +494,7 @@ class PDFFont(object):
         return False
 
     def decode(self, bytes):
-        return [six.indexbytes(bytes, i) for i,_ in enumerate(bytes)] # map(ord, bytes)
+        return bytearray(bytes)  # map(ord, bytes)
 
     def get_ascent(self):
         return self.ascent * self.vscale


### PR DESCRIPTION
Instead of list comprehension which will call a function to get the integer value of the bytes, directly convert it to `bytearray` which is more optimal structure for storing list of bytes.

Also conversion will happen in C instead of in Python.