### PR TITLE
Fix type of an argument to PDFFont#decode to bytes in py3

### DIFF
--- a/pdfminer/pdfdevice.py
+++ b/pdfminer/pdfdevice.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+
+import six
 
 from .pdffont import PDFUnicodeNotDefined
 
@@ -142,8 +145,9 @@ class TagExtractor(PDFDevice):
         font = textstate.font
         text = ''
         for obj in seq:
-            obj = utils.make_compat_str(obj)
-            if not isinstance(obj, str):
+            if isinstance(obj, six.text_type):
+                obj = utils.make_compat_bytes(obj)
+            if not isinstance(obj, six.binary_type):
                 continue
             chars = font.decode(obj)
             for cid in chars:


### PR DESCRIPTION
The `bytes` argument of PDFFront#decode requires binary type, in Python 3 `bytes` and in Python 2 `str`.  But the current code converts `bytes` to `str` in Python 3, eventually causes TypeError in later process (e.g. `struct.unpack`). This patch fixes this issue.