### PR TITLE
Send color to XML conversion

### DIFF
--- a/pdfminer/converter.py
+++ b/pdfminer/converter.py
@@ -112,7 +112,7 @@ class PDFLayoutAnalyzer(PDFTextDevice):
             evenodd, gstate.scolor, gstate.ncolor))
         return
 
-    def render_char(self, matrix, font, fontsize, scaling, rise, cid):
+    def render_char(self, matrix, font, fontsize, scaling, rise, cid, ncs, graphicstate):
         try:
             text = font.to_unichr(cid)
             assert isinstance(text, six.text_type), str(type(text))
@@ -120,7 +120,7 @@ class PDFLayoutAnalyzer(PDFTextDevice):
             text = self.handle_undefined_char(font, cid)
         textwidth = font.char_width(cid)
         textdisp = font.char_disp(cid)
-        item = LTChar(matrix, font, fontsize, scaling, rise, text, textwidth, textdisp)
+        item = LTChar(matrix, font, fontsize, scaling, rise, text, textwidth, textdisp, ncs, graphicstate)
         self.cur_item.add(item)
         return item.adv
 
@@ -520,8 +520,9 @@ class XMLConverter(PDFConverter):
                     render(child)
                 self.write('</textbox>\n')
             elif isinstance(item, LTChar):
-                self.write('<text font="%s" bbox="%s" size="%.3f">' %
-                                 (enc(item.fontname, None), bbox2str(item.bbox), item.size))
+                self.write('<text font="%s" bbox="%s" colourspace="%s" ncolour=%s" size="%.3f">' %
+                           (enc(item.fontname, None), bbox2str(item.bbox),
+                            item.ncs.name, item.graphicstate.ncolor, item.size))
                 self.write_text(item.get_text())
                 self.write('</text>\n')
             elif isinstance(item, LTText):

--- a/pdfminer/converter.py
+++ b/pdfminer/converter.py
@@ -520,7 +520,7 @@ class XMLConverter(PDFConverter):
                     render(child)
                 self.write('</textbox>\n')
             elif isinstance(item, LTChar):
-                self.write('<text font="%s" bbox="%s" colourspace="%s" ncolour=%s" size="%.3f">' %
+                self.write('<text font="%s" bbox="%s" colourspace="%s" ncolour="%s" size="%.3f">' %
                            (enc(item.fontname, None), bbox2str(item.bbox),
                             item.ncs.name, item.graphicstate.ncolor, item.size))
                 self.write_text(item.get_text())

--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -228,11 +228,13 @@ class LTAnno(LTItem, LTText):
 class LTChar(LTComponent, LTText):
 
     def __init__(self, matrix, font, fontsize, scaling, rise,
-                 text, textwidth, textdisp):
+                 text, textwidth, textdisp, ncs, graphicstate):
         LTText.__init__(self)
         self._text = text
         self.matrix = matrix
         self.fontname = font.fontname
+        self.ncs = ncs
+        self.graphicstate = graphicstate
         self.adv = textwidth * fontsize * scaling
         # compute the boundary rectangle.
         if font.is_vertical():

--- a/pdfminer/pdfcolor.py
+++ b/pdfminer/pdfcolor.py
@@ -1,4 +1,4 @@
-
+import collections
 from .psparser import LIT
 
 import six #Python 2+3 compatibility
@@ -21,17 +21,16 @@ class PDFColorSpace(object):
         return '<PDFColorSpace: %s, ncomponents=%d>' % (self.name, self.ncomponents)
 
 
-PREDEFINED_COLORSPACE = {}
-for (name, n) in six.iteritems({
-    'CalRGB': 3,
-    'CalGray': 1,
-    'Lab': 3,
-    'DeviceRGB': 3,
-    'DeviceCMYK': 4,
-    'DeviceGray': 1,
-    'Separation': 1,
-    'Indexed': 1,
-    'Pattern': 1,
-}) :
+PREDEFINED_COLORSPACE = collections.OrderedDict()
+for (name, n) in [
+    ('CalRGB', 3),
+    ('CalGray', 1),
+    ('Lab', 3),
+    ('DeviceRGB', 3),
+    ('DeviceCMYK', 4),
+    ('DeviceGray', 1),
+    ('Separation', 1),
+    ('Indexed', 1),
+    ('Pattern', 1),
+]:
     PREDEFINED_COLORSPACE[name]=PDFColorSpace(name, n)
-    

--- a/pdfminer/pdfcolor.py
+++ b/pdfminer/pdfcolor.py
@@ -23,12 +23,12 @@ class PDFColorSpace(object):
 
 PREDEFINED_COLORSPACE = collections.OrderedDict()
 for (name, n) in [
+    ('DeviceGray', 1),  # default value first
     ('CalRGB', 3),
     ('CalGray', 1),
     ('Lab', 3),
     ('DeviceRGB', 3),
     ('DeviceCMYK', 4),
-    ('DeviceGray', 1),
     ('Separation', 1),
     ('Indexed', 1),
     ('Pattern', 1),

--- a/pdfminer/pdfcolor.py
+++ b/pdfminer/pdfcolor.py
@@ -21,7 +21,11 @@ class PDFColorSpace(object):
         return '<PDFColorSpace: %s, ncomponents=%d>' % (self.name, self.ncomponents)
 
 
-PREDEFINED_COLORSPACE = collections.OrderedDict()
+if six.PY2:
+    PREDEFINED_COLORSPACE = {}
+else:
+    PREDEFINED_COLORSPACE = collections.OrderedDict()
+
 for (name, n) in [
     ('DeviceGray', 1),  # default value first
     ('CalRGB', 3),

--- a/pdfminer/pdfdevice.py
+++ b/pdfminer/pdfdevice.py
@@ -63,7 +63,7 @@ class PDFDevice(object):
 ##
 class PDFTextDevice(PDFDevice):
 
-    def render_string(self, textstate, seq):
+    def render_string(self, textstate, seq, ncs, graphicstate):
         matrix = utils.mult_matrix(textstate.matrix, self.ctm)
         font = textstate.font
         fontsize = textstate.fontsize
@@ -77,15 +77,16 @@ class PDFTextDevice(PDFDevice):
         if font.is_vertical():
             textstate.linematrix = self.render_string_vertical(
                 seq, matrix, textstate.linematrix, font, fontsize,
-                scaling, charspace, wordspace, rise, dxscale)
+                scaling, charspace, wordspace, rise, dxscale, ncs, graphicstate)
         else:
             textstate.linematrix = self.render_string_horizontal(
                 seq, matrix, textstate.linematrix, font, fontsize,
-                scaling, charspace, wordspace, rise, dxscale)
+                scaling, charspace, wordspace, rise, dxscale, ncs, graphicstate)
         return
 
     def render_string_horizontal(self, seq, matrix, pos,
-                                 font, fontsize, scaling, charspace, wordspace, rise, dxscale):
+                                 font, fontsize, scaling, charspace, wordspace,
+                                 rise, dxscale, ncs, graphicstate):
         (x, y) = pos
         needcharspace = False
         for obj in seq:
@@ -97,14 +98,16 @@ class PDFTextDevice(PDFDevice):
                     if needcharspace:
                         x += charspace
                     x += self.render_char(utils.translate_matrix(matrix, (x, y)),
-                                          font, fontsize, scaling, rise, cid)
+                                          font, fontsize, scaling, rise, cid,
+                                          ncs, graphicstate)
                     if cid == 32 and wordspace:
                         x += wordspace
                     needcharspace = True
         return (x, y)
 
     def render_string_vertical(self, seq, matrix, pos,
-                               font, fontsize, scaling, charspace, wordspace, rise, dxscale):
+                               font, fontsize, scaling, charspace, wordspace,
+                               rise, dxscale, ncs, graphicstate):
         (x, y) = pos
         needcharspace = False
         for obj in seq:
@@ -116,13 +119,14 @@ class PDFTextDevice(PDFDevice):
                     if needcharspace:
                         y += charspace
                     y += self.render_char(utils.translate_matrix(matrix, (x, y)),
-                                          font, fontsize, scaling, rise, cid)
+                                          font, fontsize, scaling, rise, cid,
+                                          ncs, graphicstate)
                     if cid == 32 and wordspace:
                         y += wordspace
                     needcharspace = True
         return (x, y)
 
-    def render_char(self, matrix, font, fontsize, scaling, rise, cid):
+    def render_char(self, matrix, font, fontsize, scaling, rise, cid, ncs, graphicstate):
         return 0
 
 

--- a/pdfminer/pdfinterp.py
+++ b/pdfminer/pdfinterp.py
@@ -586,13 +586,13 @@ class PDFPageInterpreter(object):
 
     # setgray-stroking
     def do_G(self, gray):
-        self.graphicstate.color = gray
+        self.graphicstate.scolor = gray
         #self.do_CS(LITERAL_DEVICE_GRAY)
         return
 
     # setgray-non-stroking
     def do_g(self, gray):
-        self.graphicstate.color = gray
+        self.graphicstate.ncolor = gray
         #self.do_cs(LITERAL_DEVICE_GRAY)
         return
 
@@ -769,7 +769,7 @@ class PDFPageInterpreter(object):
             if settings.STRICT:
                 raise PDFInterpreterError('No font specified!')
             return
-        self.device.render_string(self.textstate, seq)
+        self.device.render_string(self.textstate, seq, self.ncs, self.graphicstate.copy())
         return
 
     # show


### PR DESCRIPTION
The change can be tested with the following snippet:

```
import contextlib
import io
import sys

from pdfminer.converter import XMLConverter
from pdfminer.pdfinterp import PDFResourceManager, PDFPageInterpreter
from pdfminer.pdfpage import PDFPage
from pdfminer.layout import LAParams


with open(sys.argv[1], 'rb') as in_fp:
    out_fp = io.BytesIO()
    rsc_mgr = PDFResourceManager(caching=True)
    laparams = LAParams()
    converter = XMLConverter(rsc_mgr, out_fp, codec='UTF-8', laparams=laparams)

    with contextlib.closing(converter) as device:
        interpreter = PDFPageInterpreter(rsc_mgr, device)
        for page in PDFPage.get_pages(in_fp):
            interpreter.process_page(page)

    print(out_fp.getvalue().decode('UTF-8'))
```