### PR TITLE
Speed up handling of PDFs with large images

### DIFF
--- a/pdfminer/pdfparser.py
+++ b/pdfminer/pdfparser.py
@@ -102,7 +102,7 @@ class PDFParser(PSStackParser):
                 return
             pos += len(line)
             self.fp.seek(pos)
-            data_list = [self.fp.read(objlen)]
+            data = bytearray(self.fp.read(objlen))
             self.seek(pos+objlen)
             while 1:
                 try:
@@ -115,12 +115,11 @@ class PDFParser(PSStackParser):
                     i = line.index(b'endstream')
                     objlen += i
                     if self.fallback:
-                        data_list.append(line[:i])
+                        data += line[:i]
                     break
                 objlen += len(line)
                 if self.fallback:
-                    data_list.append(line)
-            data = b''.join(data_list)
+                    data += line
             self.seek(pos+objlen)
             # XXX limit objlen not to exceed object boundary
             log.debug('Stream: pos=%d, objlen=%d, dic=%r, data=%r...', pos, objlen, dic, data[:10])

--- a/pdfminer/pdfparser.py
+++ b/pdfminer/pdfparser.py
@@ -102,7 +102,7 @@ class PDFParser(PSStackParser):
                 return
             pos += len(line)
             self.fp.seek(pos)
-            data = self.fp.read(objlen)
+            data_list = [self.fp.read(objlen)]
             self.seek(pos+objlen)
             while 1:
                 try:
@@ -115,11 +115,12 @@ class PDFParser(PSStackParser):
                     i = line.index(b'endstream')
                     objlen += i
                     if self.fallback:
-                        data += line[:i]
+                        data_list.append(line[:i])
                     break
                 objlen += len(line)
                 if self.fallback:
-                    data += line
+                    data_list.append(line)
+            data = b''.join(data_list)
             self.seek(pos+objlen)
             # XXX limit objlen not to exceed object boundary
             log.debug('Stream: pos=%d, objlen=%d, dic=%r, data=%r...', pos, objlen, dic, data[:10])

--- a/pdfminer/pdfparser.py
+++ b/pdfminer/pdfparser.py
@@ -120,6 +120,7 @@ class PDFParser(PSStackParser):
                 objlen += len(line)
                 if self.fallback:
                     data += line
+            data = bytes(data)
             self.seek(pos+objlen)
             # XXX limit objlen not to exceed object boundary
             log.debug('Stream: pos=%d, objlen=%d, dic=%r, data=%r...', pos, objlen, dic, data[:10])


### PR DESCRIPTION
I discovered that `pdf2txt.py` can be very slow dealing with files containing large images. For example, a 12.5 MB PDF (containing one line of text and a 7.5 MB PNG image file) took 5 minutes and 45 seconds to process on my system.

Through profiling, I found that the majority of this time was spent repeatedly concatenating byte strings in `PDFParser.do_keyword()`. This pull request includes the simple fix of forming a list of the byte strings, which are then concatenated only once at the end.

With this fix, the above file is processed in under 2 seconds.

(I also tested the fix with the file in #128, but no significant speed up was seen for that input.)