### PR TITLE
only check for bytes input to enc() in python3

### DIFF
--- a/pdfminer/utils.py
+++ b/pdfminer/utils.py
@@ -275,7 +275,7 @@ def decode_text(s):
 # enc
 def enc(x, codec='ascii'):
     """Encodes a string for SGML/XML/HTML"""
-    if isinstance(x, bytes):
+    if six.PY3 and isinstance(x, bytes):
         return ''
     x = x.replace('&', '&amp;').replace('>', '&gt;').replace('<', '&lt;').replace('"', '&quot;')
     if codec:


### PR DESCRIPTION
In python2, isinstance("", bytes) is true, causing enc() to
suppress any string input. This results in fontnames being lost
when running pdf2txt.py in python2.

As this check was not present in the original python2 version of
pdfminer, restrict it to only check when running in python3.