### PR TITLE
Speed up layout of text boxes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,6 @@ install:
   - pip install six
   - pip install pycryptodome
   - pip install chardet
+  - pip install sortedcontainers
 script:
   nosetests --nologcapture

--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -657,7 +657,7 @@ class LTLayoutContainer(LTContainer):
                 group = LTTextGroupLRTB([obj1, obj2])
             plane.remove(obj1)
             plane.remove(obj2)
-            removed = {obj1, obj2}
+            removed = [obj1, obj2]
             to_remove = [ (c,d,obj1,obj2) for (c,d,obj1,obj2) in dists
                       if (obj1 in removed or obj2 in removed) ]
             for r in to_remove:

--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -450,7 +450,7 @@ class LTTextBoxVertical(LTTextBox):
 
     def analyze(self, laparams):
         LTTextBox.analyze(self, laparams)
-        self._objs.sort(key=lambda obj: -obj.y1)
+        self._objs.sort(key=lambda obj: -obj.x1)
         return
 
     def get_writing_mode(self):

--- a/pdfminer/utils.py
+++ b/pdfminer/utils.py
@@ -145,13 +145,6 @@ def uniq(objs):
     return
 
 
-# csort
-def csort(objs, key):
-    """Order-preserving sorting function."""
-    idxs = dict((obj, i) for (i, obj) in enumerate(objs))
-    return sorted(objs, key=lambda obj: (key(obj), idxs[obj]))
-
-
 # fsplit
 def fsplit(pred, objs):
     """Split a list into two classes according to the predicate."""

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import sys
 
 import pdfminer as package
 
-requires = ['six', 'pycryptodome']
+requires = ['six', 'pycryptodome', 'sortedcontainers']
 if sys.version_info >= (3, 0):
     requires.append('chardet')
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,3 +8,4 @@ deps =
 	pycryptodome
 	chardet
 	nose
+	sortedcontainers


### PR DESCRIPTION
Processing some PDFs takes a lot of time in `layout.py`; in particular (for one PDF I've tried) in `LTLayoutContainer.group_textboxes()`.

This PR has two changes:

1. Remove `utils.csort()` and replace all uses with native `list.sort()`
2. In `group_textboxes()`, make `dists` a `sortedcontainers.SortedListWithKey()` instead of a list, which removes the need to re-sort `dists` repeatedly

Note that replacing `csort()` (which uses "Decorate-Sort-Undecorate" to ensure the sort is stable) with the native sort doesn't change the behaviour, since Python sorting is [stable since Python 2.2](https://wiki.python.org/moin/HowTo/Sorting/#Sort_Stability_and_Complex_Sorts).

For the test PDF I have (which motivated these changes), running `pdf2txt.py` now takes around 7 seconds instead of 17 seconds.

(I also tested these changes with the file in #128, but no speed up was seen for that input.)