### PR TITLE
render_string must have 5 params in all PDFDevice classes

### DIFF
--- a/pdfminer/pdfdevice.py
+++ b/pdfminer/pdfdevice.py
@@ -58,7 +58,7 @@ class PDFDevice(object):
     def render_image(self, name, stream):
         return
 
-    def render_string(self, textstate, seq):
+    def render_string(self, textstate, seq, ncs, graphicstate):
         return
 
 
@@ -145,7 +145,7 @@ class TagExtractor(PDFDevice):
         self._stack = []
         return
 
-    def render_string(self, textstate, seq):
+    def render_string(self, textstate, seq, ncs, graphicstate):
         font = textstate.font
         text = ''
         for obj in seq:


### PR DESCRIPTION
PR #129 added 2 params to 
```
class PDFTextDevice(PDFDevice):
  def render_string(self, textstate, seq, ncs, graphicstate)
```
but not to
```
class TagExtractor(PDFDevice)
  def render_string(self, textstate, seq):
```
(nor to the PDFDevice base class abstract method)

which caused errors when parsing files with the TagExtractor