### PR TITLE
Add -o outfile option to dumppdf.py usage string (Issue #178).

### DIFF
--- a/tools/dumppdf.py
+++ b/tools/dumppdf.py
@@ -234,7 +234,7 @@ def dumppdf(outfp, fname, objids, pagenos, password='',
 def main(argv):
     import getopt
     def usage():
-        print ('usage: %s [-d] [-a] [-p pageid] [-P password] [-r|-b|-t] [-T] [-E directory] [-i objid] file ...' % argv[0])
+        print ('usage: %s [-d] [-a] [-p pageid] [-P password] [-r|-b|-t] [-T] [-E directory] [-o outfile] [-i objid] file ...' % argv[0])
         return 100
     try:
         (opts, args) = getopt.getopt(argv[1:], 'dap:P:rbtTE:i:o:')


### PR DESCRIPTION
Adds the `-o outfile` option to the dumppdf.py usage string.

**Before:**
```
$ dumppdf.py -h
usage: {path}/dumppdf.py [-d] [-a] [-p pageid] [-P password] [-r|-b|-t] [-T] [-E directory] [-i objid] file ...
```

**After:**
```
$ dumppdf.py -h
usage: {path}/dumppdf.py [-d] [-a] [-p pageid] [-P password] [-r|-b|-t] [-T] [-E directory] [-o outfile] [-i objid] file ...
```

(Full path is abbreviated in the above examples.)

**Fixes:** #178.