### PR TITLE
Better Support for colour extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ tests/*.xml
 tests/*.txt
 .idea/
 .tox/
+.vscode

--- a/pdfminer/converter.py
+++ b/pdfminer/converter.py
@@ -85,8 +85,13 @@ class PDFLayoutAnalyzer(PDFTextDevice):
             (x0, y0) = apply_matrix_pt(self.ctm, (x0, y0))
             (x1, y1) = apply_matrix_pt(self.ctm, (x1, y1))
             if x0 == x1 or y0 == y1:
-                self.cur_item.add(LTLine(gstate.linewidth, (x0, y0), (x1, y1),
-                    stroke, fill, evenodd, gstate.scolor, gstate.ncolor))
+                self.cur_item.add(LTLine(
+                    gstate.linewidth, 
+                    (x0, y0), (x1, y1),
+                    stroke, fill, evenodd, 
+                    stroking_color=gstate.scolor, 
+                    fill_color=gstate.ncolor,
+                ))
                 return
         if shape == 'mlllh':
             # rectangle
@@ -100,16 +105,26 @@ class PDFLayoutAnalyzer(PDFTextDevice):
             (x3, y3) = apply_matrix_pt(self.ctm, (x3, y3))
             if ((x0 == x1 and y1 == y2 and x2 == x3 and y3 == y0) or
                 (y0 == y1 and x1 == x2 and y2 == y3 and x3 == x0)):
-                self.cur_item.add(LTRect(gstate.linewidth, (x0, y0, x2, y2),
-                    stroke, fill, evenodd, gstate.scolor, gstate.ncolor))
+                self.cur_item.add(LTRect(
+                    gstate.linewidth, 
+                    (x0, y0, x2, y2),
+                    stroke, fill, evenodd, 
+                    stroking_color=gstate.scolor, 
+                    fill_color=gstate.ncolor,
+                ))
                 return
         # other shapes
         pts = []
         for p in path:
             for i in range(1, len(p), 2):
                 pts.append(apply_matrix_pt(self.ctm, (p[i], p[i+1])))
-        self.cur_item.add(LTCurve(gstate.linewidth, pts, stroke, fill,
-            evenodd, gstate.scolor, gstate.ncolor))
+        self.cur_item.add(LTCurve(
+            gstate.linewidth, 
+            pts, 
+            stroke, fill, evenodd,
+            stroking_color=gstate.scolor, 
+            fill_color=gstate.ncolor
+        ))
         return
 
     def render_char(self, matrix, font, fontsize, scaling, rise, cid, ncs, graphicstate):
@@ -275,18 +290,18 @@ class HTMLConverter(PDFConverter):
         return
 
     def write_header(self):
-        self.write('<html><head>\n')
+        self.write('<html>\n<head>\n')
         if self.codec:
             self.write('<meta http-equiv="Content-Type" content="text/html; charset=%s">\n' % self.codec)
         else:
             self.write('<meta http-equiv="Content-Type" content="text/html">\n')
-        self.write('</head><body>\n')
+        self.write('</head>\n<body>\n')
         return
 
     def write_footer(self):
         self.write('<div style="position:absolute; top:0px;">Page: %s</div>\n' %
                    ', '.join('<a href="#%s">%s</a>' % (i, i) for i in range(1, self.pageno)))
-        self.write('</body></html>\n')
+        self.write('</body>\n</html>\n')
         return
 
     def write_text(self, text):

--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -165,9 +165,9 @@ class LTCurve(LTComponent):
         LTComponent.__init__(self, get_bound(pts))
         self.pts = pts
         self.linewidth = linewidth
-        self.stroke = stroke
-        self.fill = fill
         self.evenodd = evenodd
+        self.has_stroke = stroke
+        self.has_fill = fill
         self.stroking_color = stroking_color
         self.fill_color = fill_color
         return

--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -154,7 +154,14 @@ class LTComponent(LTItem):
 ##
 class LTCurve(LTComponent):
 
-    def __init__(self, linewidth, pts, stroke = False, fill = False, evenodd = False, stroking_color = None, non_stroking_color = None):
+    def __init__(self, linewidth, 
+                        pts, 
+                        stroke = False, 
+                        fill = False, 
+                        evenodd = False, 
+                        stroking_color = None, 
+                        fill_color = None
+                ):
         LTComponent.__init__(self, get_bound(pts))
         self.pts = pts
         self.linewidth = linewidth
@@ -162,7 +169,7 @@ class LTCurve(LTComponent):
         self.fill = fill
         self.evenodd = evenodd
         self.stroking_color = stroking_color
-        self.non_stroking_color = non_stroking_color
+        self.fill_color = fill_color
         return
 
     def get_pts(self):
@@ -173,8 +180,8 @@ class LTCurve(LTComponent):
 ##
 class LTLine(LTCurve):
 
-    def __init__(self, linewidth, p0, p1, stroke = False, fill = False, evenodd = False, stroking_color = None, non_stroking_color = None):
-        LTCurve.__init__(self, linewidth, [p0, p1], stroke, fill, evenodd, stroking_color, non_stroking_color)
+    def __init__(self, linewidth, p0, p1, stroke = False, fill = False, evenodd = False, stroking_color = None, fill_color = None):
+        LTCurve.__init__(self, linewidth, [p0, p1], stroke, fill, evenodd, stroking_color, fill_color)
         return
 
 
@@ -182,9 +189,9 @@ class LTLine(LTCurve):
 ##
 class LTRect(LTCurve):
 
-    def __init__(self, linewidth, bbox, stroke = False, fill = False, evenodd = False, stroking_color = None, non_stroking_color = None):
+    def __init__(self, linewidth, bbox, stroke = False, fill = False, evenodd = False, stroking_color = None, fill_color = None):
         (x0, y0, x1, y1) = bbox
-        LTCurve.__init__(self, linewidth, [(x0, y0), (x1, y0), (x1, y1), (x0, y1)], stroke, fill, evenodd, stroking_color, non_stroking_color)
+        LTCurve.__init__(self, linewidth, [(x0, y0), (x1, y0), (x1, y1), (x0, y1)], stroke, fill, evenodd, stroking_color, fill_color)
         return
 
 
@@ -257,7 +264,7 @@ class LTChar(LTComponent, LTText):
             ty = descent + rise
             bll = (0, ty)
             bur = (self.adv, ty+height)
-        (a, b, c, d, e, f) = self.matrix
+        (a, b, c, d, _, _) = self.matrix
         self.upright = (0 < a*d*scaling and b*c <= 0)
         (x0, y0) = apply_matrix_pt(self.matrix, bll)
         (x1, y1) = apply_matrix_pt(self.matrix, bur)

--- a/pdfminer/pdfinterp.py
+++ b/pdfminer/pdfinterp.py
@@ -115,12 +115,12 @@ class PDFGraphicStateColor:
 
     @property
     def rgb(self):
-        if self.__rgb is not None: return [*self.__rgb]
+        if self.__rgb is not None: return self.__rgb
         else: raise self.ColorNotSet
 
     @property
     def cmyk(self):
-        if self.__cmyk is not None: return [*self.__cmyk]
+        if self.__cmyk is not None: return self.__cmyk
         else: raise self.ColorNotSet
 
     @property
@@ -149,9 +149,9 @@ class PDFGraphicStateColor:
 
     def __repr__(self):
         rep = "<PDFGraphicStateColor"
-        if self.__gray is not None: rep += f' gray={self.__gray}'
-        if self.__rgb is not None: rep += f' rgb=[{",".join(map(str, self.__rgb))}]'
-        if self.__cmyk is not None: rep += f' cmyk=[{",".join(map(str, self.__cmyk))}]'
+        if self.__gray is not None: rep += ' gray=%r' % str(self.__gray)
+        if self.__rgb is not None: rep += ' rgb=[%r]' % ",".join(map(str, self.__rgb))
+        if self.__cmyk is not None: rep += ' cmyk=[%r]' % ",".join(map(str, self.__cmyk))
         return rep + '/>'
 
 ##  PDFGraphicState


### PR DESCRIPTION
The current version of pdfminer.six, does not support extracting colours from the pdf for curves.
I added a `PDFGraphicStateColor` class which at the moment is only used for stroke and fill colours in curves.

It is my hope that I could continue on this generalisation for the final output of colours in curve-shapes, thus improving the output of the various converters (which at the moment seem to be broken).