### PR TITLE
use conditional requirements to ensure "chardet" is always required on Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,7 @@ import sys
 
 import pdfminer as package
 
-requires = ['six', 'pycryptodome', 'sortedcontainers']
-if sys.version_info >= (3, 0):
-    requires.append('chardet')
+requires = ['six', 'pycryptodome', 'sortedcontainers', 'chardet ; python_version > "3.0"']
 
 setup(
     name='pdfminer.six',


### PR DESCRIPTION
Previously "chardet" was added only added when setup.py was run with Python 3. However wheels contain a static list of requirements and a wheel-based install will never execute setup.py at installation time.

pdfminer.six uses universal wheels for Python 2 and Python 3 so the requirements will always be wrong on one version (see #213).

The solution is to use conditional requirements as specified in PEP 496 which are evaluated at installation time.