### PR TITLE
TextConverter: Use same error handler for decoding and encoding

### DIFF
--- a/pdfminer/converter.py
+++ b/pdfminer/converter.py
@@ -182,16 +182,17 @@ class PDFConverter(PDFLayoutAnalyzer):
 class TextConverter(PDFConverter):
 
     def __init__(self, rsrcmgr, outfp, codec='utf-8', pageno=1, laparams=None,
-                 showpageno=False, imagewriter=None):
+                 showpageno=False, imagewriter=None, erraction='ignore'):
         PDFConverter.__init__(self, rsrcmgr, outfp, codec=codec, pageno=pageno, laparams=laparams)
         self.showpageno = showpageno
         self.imagewriter = imagewriter
+        self.erraction = erraction
         return
 
     def write_text(self, text):
-        text = utils.compatible_encode_method(text, self.codec, 'ignore')
+        text = utils.compatible_encode_method(text, self.codec, self.erraction)
         if six.PY3 and self.outfp_binary:
-            text = text.encode()
+            text = text.encode(errors=self.erraction)
         self.outfp.write(text)
         return
 


### PR DESCRIPTION
utils.compatible_encode_method() is using a configurable error handler (default: ignore). For re-encoding the text, standard error handler (Python default: strict) is used. With this patch, decode() and encode() are using the same configurable error handler.