### PR TITLE
Remove self refference on python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Features
 How to Install
 --------------
 
- * Install Python 2.7 or newer. (Python 3.x is supported in pdfminer.six)
+ * Install Python 2.7 or newer.
  * Install
 
     `pip install pdfminer.six`


### PR DESCRIPTION
This *is* the 'six' repo, so no need to mention that again in the readme