### PR TITLE
name2unicode(): handle hexadecimal literals for unicode glyphs in text extraction

### DIFF
--- a/pdfminer/encodingdb.py
+++ b/pdfminer/encodingdb.py
@@ -6,7 +6,7 @@ from .latin_enc import ENCODING
 
 import six # Python 2+3 compatibility
 
-STRIP_NAME = re.compile(r'[0-9]+')
+STRIP_NAME = re.compile(r'[0-9A-Fa-f]+')
 
 
 ##  name2unicode
@@ -18,7 +18,7 @@ def name2unicode(name):
     m = STRIP_NAME.search(name)
     if not m:
         raise KeyError(name)
-    return six.unichr(int(m.group(0)))
+    return six.unichr(int(m.group(0), base=16))
 
 
 ##  EncodingDB


### PR DESCRIPTION
This is based on a slight tweak to the fix proposed by @janslifka in #183 (handling of lowercase hex literals, because those showed up in the sample PDF from issue #229).

Fixes #183, #229 
