### PR TITLE
utils.py: Fixing assertion in drange to allow equal inputs

### DIFF
--- a/pdfminer/utils.py
+++ b/pdfminer/utils.py
@@ -161,7 +161,6 @@ def fsplit(pred, objs):
 # drange
 def drange(v0, v1, d):
     """Returns a discrete range."""
-    assert v0 <= v1, str((v0, v1, d))
     return range(int(v0)//d, int(v1+d)//d)
 
 

--- a/pdfminer/utils.py
+++ b/pdfminer/utils.py
@@ -1,61 +1,63 @@
-
 """
 Miscellaneous Routines.
 """
 import struct
-# from sys import maxint as INF #doesn't work anymore under Python3,
-# but PDF still uses 32 bits ints
-INF = (1<<31) - 1
 
-import six  #Python 2+3 compatibility
+import six
+
+# from sys import maxint as INF doesn't work anymore under Python3, but PDF still uses 32 bits ints
+INF = (1 << 31) - 1
 
 if six.PY3:
     import chardet  # For str encoding detection in Py3
+
     unicode = str
 
+
 def make_compat_bytes(in_str):
-    "In Py2, does nothing. In Py3, converts to bytes, encoding to unicode."
+    """In Py2, does nothing. In Py3, converts to bytes, encoding to unicode."""
     assert isinstance(in_str, str), str(type(in_str))
     if six.PY2:
         return in_str
     else:
         return in_str.encode()
 
+
 def make_compat_str(in_str):
-    "In Py2, does nothing. In Py3, converts to string, guessing encoding."
+    """In Py2, does nothing. In Py3, converts to string, guessing encoding."""
     assert isinstance(in_str, (bytes, str, unicode)), str(type(in_str))
     if six.PY3 and isinstance(in_str, bytes):
         enc = chardet.detect(in_str)
         in_str = in_str.decode(enc['encoding'])
     return in_str
 
+
 def compatible_encode_method(bytesorstring, encoding='utf-8', erraction='ignore'):
-    "When Py2 str.encode is called, it often means bytes.encode in Py3. This does either."
+    """When Py2 str.encode is called, it often means bytes.encode in Py3. This does either."""
     if six.PY2:
         assert isinstance(bytesorstring, (str, unicode)), str(type(bytesorstring))
         return bytesorstring.encode(encoding, erraction)
     if six.PY3:
-        if isinstance(bytesorstring, str): return bytesorstring
+        if isinstance(bytesorstring, str):
+            return bytesorstring
         assert isinstance(bytesorstring, bytes), str(type(bytesorstring))
         return bytesorstring.decode(encoding, erraction)
 
-##  PNG Predictor
-##
+
 def apply_png_predictor(pred, colors, columns, bitspercomponent, data):
     if bitspercomponent != 8:
         # unsupported
         raise ValueError("Unsupported `bitspercomponent': %d" %
                          bitspercomponent)
     nbytes = colors * columns * bitspercomponent // 8
-    i = 0
     buf = b''
     line0 = b'\x00' * columns
-    for i in range(0, len(data), nbytes+1):
+    for i in range(0, len(data), nbytes + 1):
         ft = data[i]
         if six.PY2:
             ft = six.byte2int(ft)
         i += 1
-        line1 = data[i:i+nbytes]
+        line1 = data[i:i + nbytes]
         line2 = b''
         if ft == 0:
             # PNG none
@@ -66,14 +68,14 @@ def apply_png_predictor(pred, colors, columns, bitspercomponent, data):
             for b in line1:
                 if six.PY2:
                     b = six.byte2int(b)
-                c = (c+b) & 255
+                c = (c + b) & 255
                 line2 += six.int2byte(c)
         elif ft == 2:
             # PNG up
             for (a, b) in zip(line0, line1):
                 if six.PY2:
                     a, b = six.byte2int(a), six.byte2int(b)
-                c = (a+b) & 255
+                c = (a + b) & 255
                 line2 += six.int2byte(c)
         elif ft == 3:
             # PNG average (UNTESTED)
@@ -81,7 +83,7 @@ def apply_png_predictor(pred, colors, columns, bitspercomponent, data):
             for (a, b) in zip(line0, line1):
                 if six.PY2:
                     a, b = six.byte2int(a), six.byte2int(b)
-                c = ((c+a+b)//2) & 255
+                c = ((c + a + b) // 2) & 255
                 line2 += six.int2byte(c)
         else:
             # unsupported
@@ -91,8 +93,7 @@ def apply_png_predictor(pred, colors, columns, bitspercomponent, data):
     return buf
 
 
-##  Matrix operations
-##
+#  Matrix operations
 MATRIX_IDENTITY = (1, 0, 0, 1, 0, 0)
 
 
@@ -100,40 +101,38 @@ def mult_matrix(m1, m0):
     (a1, b1, c1, d1, e1, f1) = m1
     (a0, b0, c0, d0, e0, f0) = m0
     """Returns the multiplication of two matrices."""
-    return (a0*a1+c0*b1,    b0*a1+d0*b1,
-            a0*c1+c0*d1,    b0*c1+d0*d1,
-            a0*e1+c0*f1+e0, b0*e1+d0*f1+f0)
+    return (a0 * a1 + c0 * b1, b0 * a1 + d0 * b1,
+            a0 * c1 + c0 * d1, b0 * c1 + d0 * d1,
+            a0 * e1 + c0 * f1 + e0, b0 * e1 + d0 * f1 + f0)
 
 
 def translate_matrix(m, v):
     """Translates a matrix by (x, y)."""
     (a, b, c, d, e, f) = m
     (x, y) = v
-    return (a, b, c, d, x*a+y*c+e, x*b+y*d+f)
+    return a, b, c, d, x * a + y * c + e, x * b + y * d + f
 
 
 def apply_matrix_pt(m, v):
     (a, b, c, d, e, f) = m
     (x, y) = v
     """Applies a matrix to a point."""
-    return (a*x+c*y+e, b*x+d*y+f)
+    return a * x + c * y + e, b * x + d * y + f
 
 
 def apply_matrix_norm(m, v):
     """Equivalent to apply_matrix_pt(M, (p,q)) - apply_matrix_pt(M, (0,0))"""
     (a, b, c, d, e, f) = m
     (p, q) = v
-    return (a*p+c*q, b*p+d*q)
+    return a * p + c * q, b * p + d * q
 
 
-##  Utility functions
-##
+#  Utility functions
 
-# isnumber
 def isnumber(x):
     return isinstance(x, (six.integer_types, float))
 
-# uniq
+
 def uniq(objs):
     """Eliminates duplicated elements."""
     done = set()
@@ -145,7 +144,6 @@ def uniq(objs):
     return
 
 
-# fsplit
 def fsplit(pred, objs):
     """Split a list into two classes according to the predicate."""
     t = []
@@ -155,16 +153,14 @@ def fsplit(pred, objs):
             t.append(obj)
         else:
             f.append(obj)
-    return (t, f)
+    return t, f
 
 
-# drange
 def drange(v0, v1, d):
     """Returns a discrete range."""
-    return range(int(v0)//d, int(v1+d)//d)
+    return range(int(v0) // d, int(v1 + d) // d)
 
 
-# get_bound
 def get_bound(pts):
     """Compute a minimal rectangle that covers all the points."""
     (x0, y0, x1, y1) = (INF, INF, -INF, -INF)
@@ -173,10 +169,9 @@ def get_bound(pts):
         y0 = min(y0, y)
         x1 = max(x1, x)
         y1 = max(y1, y)
-    return (x0, y0, x1, y1)
+    return x0, y0, x1, y1
 
 
-# pick
 def pick(seq, func, maxobj=None):
     """Picks the object obj where func(obj) has the highest value."""
     maxscore = None
@@ -187,7 +182,6 @@ def pick(seq, func, maxobj=None):
     return maxobj
 
 
-# choplist
 def choplist(n, seq):
     """Groups every n elements of the list."""
     r = []
@@ -199,7 +193,6 @@ def choplist(n, seq):
     return
 
 
-# nunpack
 def nunpack(s, default=0):
     """Unpacks 1 to 4 or 8 byte integers (big endian)."""
     l = len(s)
@@ -210,7 +203,7 @@ def nunpack(s, default=0):
     elif l == 2:
         return struct.unpack('>H', s)[0]
     elif l == 3:
-        return struct.unpack('>L', b'\x00'+s)[0]
+        return struct.unpack('>L', b'\x00' + s)[0]
     elif l == 4:
         return struct.unpack('>L', s)[0]
     elif l == 8:
@@ -219,7 +212,6 @@ def nunpack(s, default=0):
         raise TypeError('invalid length: %d' % l)
 
 
-# decode_text
 PDFDocEncoding = ''.join(six.unichr(x) for x in (
     0x0000, 0x0001, 0x0002, 0x0003, 0x0004, 0x0005, 0x0006, 0x0007,
     0x0008, 0x0009, 0x000a, 0x000b, 0x000c, 0x000d, 0x000e, 0x000f,
@@ -264,7 +256,6 @@ def decode_text(s):
         return ''.join(PDFDocEncoding[c] for c in s)
 
 
-# enc
 def enc(x, codec='ascii'):
     """Encodes a string for SGML/XML/HTML"""
     if six.PY3 and isinstance(x, bytes):
@@ -284,6 +275,7 @@ def matrix2str(m):
     (a, b, c, d, e, f) = m
     return '[%.2f,%.2f,%.2f,%.2f, (%.2f,%.2f)]' % (a, b, c, d, e, f)
 
+
 def vecBetweenBoxes(obj1, obj2):
     """A distance function between two TextBoxes.
 
@@ -297,38 +289,37 @@ def vecBetweenBoxes(obj1, obj2):
     """
     (x0, y0) = (min(obj1.x0, obj2.x0), min(obj1.y0, obj2.y0))
     (x1, y1) = (max(obj1.x1, obj2.x1), max(obj1.y1, obj2.y1))
-    (ow, oh) = (x1-x0, y1-y0)
-    (iw, ih) = (ow-obj1.width-obj2.width, oh-obj1.height-obj2.height)
-    if iw<0 and ih<0:
+    (ow, oh) = (x1 - x0, y1 - y0)
+    (iw, ih) = (ow - obj1.width - obj2.width, oh - obj1.height - obj2.height)
+    if iw < 0 and ih < 0:
         # if one is inside another we compute euclidean distance
-        (xc1, yc1) = ( (obj1.x0+obj1.x1)/2, (obj1.y0+obj1.y1)/2 )
-        (xc2, yc2) = ( (obj2.x0+obj2.x1)/2, (obj2.y0+obj2.y1)/2 )
-        return (xc1-xc2, yc1-yc2)
+        (xc1, yc1) = ((obj1.x0 + obj1.x1) / 2, (obj1.y0 + obj1.y1) / 2)
+        (xc2, yc2) = ((obj2.x0 + obj2.x1) / 2, (obj2.y0 + obj2.y1) / 2)
+        return xc1 - xc2, yc1 - yc2
     else:
-        return (max(0, iw), max(0, ih))
+        return max(0, iw), max(0, ih)
 
-##  Plane
-##
-##  A set-like data structure for objects placed on a plane.
-##  Can efficiently find objects in a certain rectangular area.
-##  It maintains two parallel lists of objects, each of
-##  which is sorted by its x or y coordinate.
-##
+
 class Plane(object):
+    """A set-like data structure for objects placed on a plane.
+
+    Can efficiently find objects in a certain rectangular area.
+    It maintains two parallel lists of objects, each of
+    which is sorted by its x or y coordinate.
+    """
 
     def __init__(self, bbox, gridsize=50):
-        self._seq = []          # preserve the object order.
+        self._seq = []  # preserve the object order.
         self._objs = set()
         self._grid = {}
         self.gridsize = gridsize
         (self.x0, self.y0, self.x1, self.y1) = bbox
-        return
 
     def __repr__(self):
-        return ('<Plane objs=%r>' % list(self))
+        return '<Plane objs=%r>' % list(self)
 
     def __iter__(self):
-        return ( obj for obj in self._seq if obj in self._objs )
+        return (obj for obj in self._seq if obj in self._objs)
 
     def __len__(self):
         return len(self._objs)
@@ -338,25 +329,22 @@ class Plane(object):
 
     def _getrange(self, bbox):
         (x0, y0, x1, y1) = bbox
-        if (x1 <= self.x0 or self.x1 <= x0 or
-            y1 <= self.y0 or self.y1 <= y0): return
+        if x1 <= self.x0 or self.x1 <= x0 or y1 <= self.y0 or self.y1 <= y0:
+            return
         x0 = max(self.x0, x0)
         y0 = max(self.y0, y0)
         x1 = min(self.x1, x1)
         y1 = min(self.y1, y1)
-        for y in drange(y0, y1, self.gridsize):
-            for x in drange(x0, x1, self.gridsize):
-                yield (x, y)
-        return
+        for grid_y in drange(y0, y1, self.gridsize):
+            for grid_x in drange(x0, x1, self.gridsize):
+                yield (grid_x, grid_y)
 
-    # extend(objs)
     def extend(self, objs):
         for obj in objs:
             self.add(obj)
-        return
 
-    # add(obj): place an object.
     def add(self, obj):
+        """place an object."""
         for k in self._getrange((obj.x0, obj.y0, obj.x1, obj.y1)):
             if k not in self._grid:
                 r = []
@@ -366,20 +354,18 @@ class Plane(object):
             r.append(obj)
         self._seq.append(obj)
         self._objs.add(obj)
-        return
 
-    # remove(obj): displace an object.
     def remove(self, obj):
+        """displace an object."""
         for k in self._getrange((obj.x0, obj.y0, obj.x1, obj.y1)):
             try:
                 self._grid[k].remove(obj)
             except (KeyError, ValueError):
                 pass
         self._objs.remove(obj)
-        return
 
-    # find(): finds objects that are in a certain area.
     def find(self, bbox):
+        """finds objects that are in a certain area."""
         (x0, y0, x1, y1) = bbox
         done = set()
         for k in self._getrange(bbox):
@@ -389,8 +375,6 @@ class Plane(object):
                 if obj in done:
                     continue
                 done.add(obj)
-                if (obj.x1 <= x0 or x1 <= obj.x0 or
-                    obj.y1 <= y0 or y1 <= obj.y0):
+                if obj.x1 <= x0 or x1 <= obj.x0 or obj.y1 <= y0 or y1 <= obj.y0:
                     continue
                 yield obj
-        return

--- a/pdfminer/utils.py
+++ b/pdfminer/utils.py
@@ -161,7 +161,7 @@ def fsplit(pred, objs):
 # drange
 def drange(v0, v1, d):
     """Returns a discrete range."""
-    assert v0 < v1, str((v0, v1, d))
+    assert v0 <= v1, str((v0, v1, d))
     return range(int(v0)//d, int(v1+d)//d)
 
 

--- a/pdfminer/utils.py
+++ b/pdfminer/utils.py
@@ -1,63 +1,61 @@
+
 """
 Miscellaneous Routines.
 """
 import struct
+# from sys import maxint as INF #doesn't work anymore under Python3,
+# but PDF still uses 32 bits ints
+INF = (1<<31) - 1
 
-import six
-
-# from sys import maxint as INF doesn't work anymore under Python3, but PDF still uses 32 bits ints
-INF = (1 << 31) - 1
+import six  #Python 2+3 compatibility
 
 if six.PY3:
     import chardet  # For str encoding detection in Py3
-
     unicode = str
 
-
 def make_compat_bytes(in_str):
-    """In Py2, does nothing. In Py3, converts to bytes, encoding to unicode."""
+    "In Py2, does nothing. In Py3, converts to bytes, encoding to unicode."
     assert isinstance(in_str, str), str(type(in_str))
     if six.PY2:
         return in_str
     else:
         return in_str.encode()
 
-
 def make_compat_str(in_str):
-    """In Py2, does nothing. In Py3, converts to string, guessing encoding."""
+    "In Py2, does nothing. In Py3, converts to string, guessing encoding."
     assert isinstance(in_str, (bytes, str, unicode)), str(type(in_str))
     if six.PY3 and isinstance(in_str, bytes):
         enc = chardet.detect(in_str)
         in_str = in_str.decode(enc['encoding'])
     return in_str
 
-
 def compatible_encode_method(bytesorstring, encoding='utf-8', erraction='ignore'):
-    """When Py2 str.encode is called, it often means bytes.encode in Py3. This does either."""
+    "When Py2 str.encode is called, it often means bytes.encode in Py3. This does either."
     if six.PY2:
         assert isinstance(bytesorstring, (str, unicode)), str(type(bytesorstring))
         return bytesorstring.encode(encoding, erraction)
     if six.PY3:
-        if isinstance(bytesorstring, str):
-            return bytesorstring
+        if isinstance(bytesorstring, str): return bytesorstring
         assert isinstance(bytesorstring, bytes), str(type(bytesorstring))
         return bytesorstring.decode(encoding, erraction)
 
-
+##  PNG Predictor
+##
 def apply_png_predictor(pred, colors, columns, bitspercomponent, data):
     if bitspercomponent != 8:
         # unsupported
         raise ValueError("Unsupported `bitspercomponent': %d" %
                          bitspercomponent)
     nbytes = colors * columns * bitspercomponent // 8
+    i = 0
     buf = b''
     line0 = b'\x00' * columns
-    for i in range(0, len(data), nbytes + 1):
+    for i in range(0, len(data), nbytes+1):
         ft = data[i]
         if six.PY2:
             ft = six.byte2int(ft)
         i += 1
-        line1 = data[i:i + nbytes]
+        line1 = data[i:i+nbytes]
         line2 = b''
         if ft == 0:
             # PNG none
@@ -68,14 +66,14 @@ def apply_png_predictor(pred, colors, columns, bitspercomponent, data):
             for b in line1:
                 if six.PY2:
                     b = six.byte2int(b)
-                c = (c + b) & 255
+                c = (c+b) & 255
                 line2 += six.int2byte(c)
         elif ft == 2:
             # PNG up
             for (a, b) in zip(line0, line1):
                 if six.PY2:
                     a, b = six.byte2int(a), six.byte2int(b)
-                c = (a + b) & 255
+                c = (a+b) & 255
                 line2 += six.int2byte(c)
         elif ft == 3:
             # PNG average (UNTESTED)
@@ -83,7 +81,7 @@ def apply_png_predictor(pred, colors, columns, bitspercomponent, data):
             for (a, b) in zip(line0, line1):
                 if six.PY2:
                     a, b = six.byte2int(a), six.byte2int(b)
-                c = ((c + a + b) // 2) & 255
+                c = ((c+a+b)//2) & 255
                 line2 += six.int2byte(c)
         else:
             # unsupported
@@ -93,7 +91,8 @@ def apply_png_predictor(pred, colors, columns, bitspercomponent, data):
     return buf
 
 
-#  Matrix operations
+##  Matrix operations
+##
 MATRIX_IDENTITY = (1, 0, 0, 1, 0, 0)
 
 
@@ -101,38 +100,40 @@ def mult_matrix(m1, m0):
     (a1, b1, c1, d1, e1, f1) = m1
     (a0, b0, c0, d0, e0, f0) = m0
     """Returns the multiplication of two matrices."""
-    return (a0 * a1 + c0 * b1, b0 * a1 + d0 * b1,
-            a0 * c1 + c0 * d1, b0 * c1 + d0 * d1,
-            a0 * e1 + c0 * f1 + e0, b0 * e1 + d0 * f1 + f0)
+    return (a0*a1+c0*b1,    b0*a1+d0*b1,
+            a0*c1+c0*d1,    b0*c1+d0*d1,
+            a0*e1+c0*f1+e0, b0*e1+d0*f1+f0)
 
 
 def translate_matrix(m, v):
     """Translates a matrix by (x, y)."""
     (a, b, c, d, e, f) = m
     (x, y) = v
-    return a, b, c, d, x * a + y * c + e, x * b + y * d + f
+    return (a, b, c, d, x*a+y*c+e, x*b+y*d+f)
 
 
 def apply_matrix_pt(m, v):
     (a, b, c, d, e, f) = m
     (x, y) = v
     """Applies a matrix to a point."""
-    return a * x + c * y + e, b * x + d * y + f
+    return (a*x+c*y+e, b*x+d*y+f)
 
 
 def apply_matrix_norm(m, v):
     """Equivalent to apply_matrix_pt(M, (p,q)) - apply_matrix_pt(M, (0,0))"""
     (a, b, c, d, e, f) = m
     (p, q) = v
-    return a * p + c * q, b * p + d * q
+    return (a*p+c*q, b*p+d*q)
 
 
-#  Utility functions
+##  Utility functions
+##
 
+# isnumber
 def isnumber(x):
     return isinstance(x, (six.integer_types, float))
 
-
+# uniq
 def uniq(objs):
     """Eliminates duplicated elements."""
     done = set()
@@ -144,6 +145,7 @@ def uniq(objs):
     return
 
 
+# fsplit
 def fsplit(pred, objs):
     """Split a list into two classes according to the predicate."""
     t = []
@@ -153,14 +155,16 @@ def fsplit(pred, objs):
             t.append(obj)
         else:
             f.append(obj)
-    return t, f
+    return (t, f)
 
 
+# drange
 def drange(v0, v1, d):
     """Returns a discrete range."""
-    return range(int(v0) // d, int(v1 + d) // d)
+    return range(int(v0)//d, int(v1+d)//d)
 
 
+# get_bound
 def get_bound(pts):
     """Compute a minimal rectangle that covers all the points."""
     (x0, y0, x1, y1) = (INF, INF, -INF, -INF)
@@ -169,9 +173,10 @@ def get_bound(pts):
         y0 = min(y0, y)
         x1 = max(x1, x)
         y1 = max(y1, y)
-    return x0, y0, x1, y1
+    return (x0, y0, x1, y1)
 
 
+# pick
 def pick(seq, func, maxobj=None):
     """Picks the object obj where func(obj) has the highest value."""
     maxscore = None
@@ -182,6 +187,7 @@ def pick(seq, func, maxobj=None):
     return maxobj
 
 
+# choplist
 def choplist(n, seq):
     """Groups every n elements of the list."""
     r = []
@@ -193,6 +199,7 @@ def choplist(n, seq):
     return
 
 
+# nunpack
 def nunpack(s, default=0):
     """Unpacks 1 to 4 or 8 byte integers (big endian)."""
     l = len(s)
@@ -203,7 +210,7 @@ def nunpack(s, default=0):
     elif l == 2:
         return struct.unpack('>H', s)[0]
     elif l == 3:
-        return struct.unpack('>L', b'\x00' + s)[0]
+        return struct.unpack('>L', b'\x00'+s)[0]
     elif l == 4:
         return struct.unpack('>L', s)[0]
     elif l == 8:
@@ -212,6 +219,7 @@ def nunpack(s, default=0):
         raise TypeError('invalid length: %d' % l)
 
 
+# decode_text
 PDFDocEncoding = ''.join(six.unichr(x) for x in (
     0x0000, 0x0001, 0x0002, 0x0003, 0x0004, 0x0005, 0x0006, 0x0007,
     0x0008, 0x0009, 0x000a, 0x000b, 0x000c, 0x000d, 0x000e, 0x000f,
@@ -256,6 +264,7 @@ def decode_text(s):
         return ''.join(PDFDocEncoding[c] for c in s)
 
 
+# enc
 def enc(x, codec='ascii'):
     """Encodes a string for SGML/XML/HTML"""
     if six.PY3 and isinstance(x, bytes):
@@ -275,7 +284,6 @@ def matrix2str(m):
     (a, b, c, d, e, f) = m
     return '[%.2f,%.2f,%.2f,%.2f, (%.2f,%.2f)]' % (a, b, c, d, e, f)
 
-
 def vecBetweenBoxes(obj1, obj2):
     """A distance function between two TextBoxes.
 
@@ -289,37 +297,38 @@ def vecBetweenBoxes(obj1, obj2):
     """
     (x0, y0) = (min(obj1.x0, obj2.x0), min(obj1.y0, obj2.y0))
     (x1, y1) = (max(obj1.x1, obj2.x1), max(obj1.y1, obj2.y1))
-    (ow, oh) = (x1 - x0, y1 - y0)
-    (iw, ih) = (ow - obj1.width - obj2.width, oh - obj1.height - obj2.height)
-    if iw < 0 and ih < 0:
+    (ow, oh) = (x1-x0, y1-y0)
+    (iw, ih) = (ow-obj1.width-obj2.width, oh-obj1.height-obj2.height)
+    if iw<0 and ih<0:
         # if one is inside another we compute euclidean distance
-        (xc1, yc1) = ((obj1.x0 + obj1.x1) / 2, (obj1.y0 + obj1.y1) / 2)
-        (xc2, yc2) = ((obj2.x0 + obj2.x1) / 2, (obj2.y0 + obj2.y1) / 2)
-        return xc1 - xc2, yc1 - yc2
+        (xc1, yc1) = ( (obj1.x0+obj1.x1)/2, (obj1.y0+obj1.y1)/2 )
+        (xc2, yc2) = ( (obj2.x0+obj2.x1)/2, (obj2.y0+obj2.y1)/2 )
+        return (xc1-xc2, yc1-yc2)
     else:
-        return max(0, iw), max(0, ih)
+        return (max(0, iw), max(0, ih))
 
-
+##  Plane
+##
+##  A set-like data structure for objects placed on a plane.
+##  Can efficiently find objects in a certain rectangular area.
+##  It maintains two parallel lists of objects, each of
+##  which is sorted by its x or y coordinate.
+##
 class Plane(object):
-    """A set-like data structure for objects placed on a plane.
-
-    Can efficiently find objects in a certain rectangular area.
-    It maintains two parallel lists of objects, each of
-    which is sorted by its x or y coordinate.
-    """
 
     def __init__(self, bbox, gridsize=50):
-        self._seq = []  # preserve the object order.
+        self._seq = []          # preserve the object order.
         self._objs = set()
         self._grid = {}
         self.gridsize = gridsize
         (self.x0, self.y0, self.x1, self.y1) = bbox
+        return
 
     def __repr__(self):
-        return '<Plane objs=%r>' % list(self)
+        return ('<Plane objs=%r>' % list(self))
 
     def __iter__(self):
-        return (obj for obj in self._seq if obj in self._objs)
+        return ( obj for obj in self._seq if obj in self._objs )
 
     def __len__(self):
         return len(self._objs)
@@ -329,22 +338,25 @@ class Plane(object):
 
     def _getrange(self, bbox):
         (x0, y0, x1, y1) = bbox
-        if x1 <= self.x0 or self.x1 <= x0 or y1 <= self.y0 or self.y1 <= y0:
-            return
+        if (x1 <= self.x0 or self.x1 <= x0 or
+            y1 <= self.y0 or self.y1 <= y0): return
         x0 = max(self.x0, x0)
         y0 = max(self.y0, y0)
         x1 = min(self.x1, x1)
         y1 = min(self.y1, y1)
-        for grid_y in drange(y0, y1, self.gridsize):
-            for grid_x in drange(x0, x1, self.gridsize):
-                yield (grid_x, grid_y)
+        for y in drange(y0, y1, self.gridsize):
+            for x in drange(x0, x1, self.gridsize):
+                yield (x, y)
+        return
 
+    # extend(objs)
     def extend(self, objs):
         for obj in objs:
             self.add(obj)
+        return
 
+    # add(obj): place an object.
     def add(self, obj):
-        """place an object."""
         for k in self._getrange((obj.x0, obj.y0, obj.x1, obj.y1)):
             if k not in self._grid:
                 r = []
@@ -354,18 +366,20 @@ class Plane(object):
             r.append(obj)
         self._seq.append(obj)
         self._objs.add(obj)
+        return
 
+    # remove(obj): displace an object.
     def remove(self, obj):
-        """displace an object."""
         for k in self._getrange((obj.x0, obj.y0, obj.x1, obj.y1)):
             try:
                 self._grid[k].remove(obj)
             except (KeyError, ValueError):
                 pass
         self._objs.remove(obj)
+        return
 
+    # find(): finds objects that are in a certain area.
     def find(self, bbox):
-        """finds objects that are in a certain area."""
         (x0, y0, x1, y1) = bbox
         done = set()
         for k in self._getrange(bbox):
@@ -375,6 +389,8 @@ class Plane(object):
                 if obj in done:
                     continue
                 done.add(obj)
-                if obj.x1 <= x0 or x1 <= obj.x0 or obj.y1 <= y0 or y1 <= obj.y0:
+                if (obj.x1 <= x0 or x1 <= obj.x0 or
+                    obj.y1 <= y0 or y1 <= obj.y0):
                     continue
                 yield obj
+        return

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,40 @@
+from nose.tools import assert_equal
+
+from pdfminer.layout import LTComponent
+from pdfminer.utils import make_compat_str, Plane
+
+
+class TestPlane(object):
+    def test_find_nothing_in_empty_bbox(self):
+        plane, _ = self.given_plane_with_one_object()
+        result = list(plane.find((50, 50, 100, 100)))
+        assert_equal(result, [])
+
+    def test_find_nothing_after_removing(self):
+        plane, obj = self.given_plane_with_one_object()
+        plane.remove(obj)
+        result = list(plane.find((0, 0, 100, 100)))
+        assert_equal(result, [])
+
+    def test_find_object_in_whole_plane(self):
+        plane, obj = self.given_plane_with_one_object()
+        result = list(plane.find((0, 0, 100, 100)))
+        assert_equal(result, [obj])
+
+    def test_find_if_object_is_smaller_than_gridsize(self):
+        plane, obj = self.given_plane_with_one_object(object_size=1, gridsize=100)
+        result = list(plane.find((0, 0, 100, 100)))
+        assert_equal(result, [obj])
+
+    def test_find_object_if_much_larger_than_gridsize(self):
+        plane, obj = self.given_plane_with_one_object(object_size=100, gridsize=10)
+        result = list(plane.find((0, 0, 100, 100)))
+        assert_equal(result, [obj])
+
+    @staticmethod
+    def given_plane_with_one_object(object_size=50, gridsize=50):
+        bounding_box = (0, 0, 100, 100)
+        plane = Plane(bounding_box, gridsize)
+        obj = LTComponent((0, 0, object_size, object_size))
+        plane.add(obj)
+        return plane, obj


### PR DESCRIPTION
We should allow `drange` to allow the same input value for `v0` and `v1`. In this case, `drange` will return an iterator of one element: `v0 // d`.

I ran into an issue when using [Camelot](https://github.com/socialcopsdev/camelot), where the values passed into `v0` and `v1` were the same. The original assertion in `drange` will fail when values for `v0` and `v1` are the same. However, I don't see why they can't be the same. In this case, `drange` will return a `range` iterator with just a single element equal to `v0 // d`. Making this change fixed the assertion without any incorrect change in the output of my code.

I am not very familiar with the codebases of `pdfminer` or `Camelot`, so I'd like an active contributor to take a look and see if there are any obvious issues. In the meanwhile, I'll continue to do some more investigation to see if this change could pose a problem somewhere, and I'll update this PR with anything I find.