### PR TITLE
Added generation of dimensions for characters of a fallback font

### DIFF
--- a/pdfminer/pdffont.py
+++ b/pdfminer/pdffont.py
@@ -114,7 +114,7 @@ def compute_fallback_font_metrics(FONT_METRICS):
                     res[k]=v
             yield res
     def selectBBoxMetrics():
-        for fd in FONT_METRICS.values()
+        for fd in FONT_METRICS.values():
             yield fd[0]['FontBBox']
     restMetrics = compute_stat(selectNumericMetrics())
     restMetrics['FontBBox'] = list(compute_stat(selectBBoxMetrics()).values())

--- a/pdfminer/utils.py
+++ b/pdfminer/utils.py
@@ -308,6 +308,16 @@ def vecBetweenBoxes(obj1, obj2):
     else:
         return (max(0, iw), max(0, ih))
 
+
+def mean(it):
+    return sum(it) / len(it)
+
+def universal_key_value_iterator(it):
+    if isinstance(it, (list, tuple)):
+        return enumerate(it)
+    elif isinstance(it, dict):
+        return it.items()
+
 ##  Plane
 ##
 ##  A set-like data structure for objects placed on a plane.


### PR DESCRIPTION
This fixes treatment of incorrect PDFs where fonts are not specified; In the previous version they were set to zeros in that cases which prevents the characters from being merged into words and lines.
Added some useful functions

* `universal_key_value_iterator` to treat an array and a dict uniformly
* `mean` to compute a mean of numbers in an iter