### PR TITLE
Use resolve_all on PdfFont widths and bbox

### DIFF
--- a/pdfminer/pdffont.py
+++ b/pdfminer/pdffont.py
@@ -16,7 +16,7 @@ from . import settings
 from .psparser import PSLiteral
 from .psparser import literal_name
 from .pdftypes import PDFException
-from .pdftypes import resolve1
+from .pdftypes import resolve1, resolve_all
 from .pdftypes import int_value
 from .pdftypes import num_value
 from .pdftypes import list_value
@@ -476,7 +476,7 @@ class PDFFont(object):
 
     def __init__(self, descriptor, widths, default_width=None):
         self.descriptor = descriptor
-        self.widths = widths
+        self.widths = resolve_all(widths)
         self.fontname = resolve1(descriptor.get('FontName', 'unknown'))
         if isinstance(self.fontname, PSLiteral):
             self.fontname = literal_name(self.fontname)
@@ -486,7 +486,7 @@ class PDFFont(object):
         self.italic_angle = num_value(descriptor.get('ItalicAngle', 0))
         self.default_width = default_width or num_value(descriptor.get('MissingWidth', 0))
         self.leading = num_value(descriptor.get('Leading', 0))
-        self.bbox = list_value(descriptor.get('FontBBox', (0, 0, 0, 0)))
+        self.bbox = list_value(resolve_all(descriptor.get('FontBBox', (0, 0, 0, 0))))
         self.hscale = self.vscale = .001
         return
 


### PR DESCRIPTION
As discussed in #268, I'm recreating the [PR](https://github.com/euske/pdfminer/pull/185) from @shenker.
Fixes #268 