### PR TITLE
Significant Layout speedup [2-5x]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# List of changes
+
+## Version 20181108
+ - PR #141 to speedup layout analysis
+ - PR #173 for using argparse and replace deprecated getopt
+ - PR #142 to compile pdfminer.six with cython, successfully

--- a/pdfminer/__init__.py
+++ b/pdfminer/__init__.py
@@ -10,7 +10,7 @@ It includes a PDF converter that can transform PDF files into other text
 formats (such as HTML). It has an extensible PDF parser that can be used for
 other purposes instead of text analysis.
 """
-__version__ = '20170720'
+__version__ = '20181108'
 
 if __name__ == '__main__':
     print(__version__)


### PR DESCRIPTION
Speedup by:

1. Using a plain list instead of a SortedList.
2. Avoid potentially huge number of variable assignments in list comprehension.
3. Avoid repeatedly evaluating `obj is obj` in list comprehension by storing `id(obj)`.

I was parsing the attached PDF file using camelot and noticed it was extremely slow (150s for 1 page). Did a quick profiling and it turned out that 85% of the time was spent at [this](https://github.com/pdfminer/pdfminer.six/blob/41d1efac7ef3ac71164eeb8200af39a2bfa09c59/pdfminer/layout.py#L663) list comprehension . 

This commit speeds up the parsing time of the attached 01.pdf by 5 times (75s vs 15s). All 50 tests have been executed and passed.

I do see a previous [commit](https://github.com/pdfminer/pdfminer.six/commit/2dda2b12b4f70253da2fc380a383f61be798a024) to use `SortedListWithKey` instead of calling `csort` in every iteration to improve the performance. But why do we need to keep the list `dists` sorted in the first place? [Comments](https://github.com/euske/pdfminer/blob/9a30406a9043490be75a647d48c2a5e707b72f67/pdfminer/layout.py#L641) in the old pdfminer repo says it was to avoid random test results. I don't think we want to sacrifice performance just for this reason.

Please kindly have a look and let me know if this can be merged or not.

Many thanks!

## To reproduce and validate

Testing on my machine with below script shows a 5x speed up (75s vs 15s). `nosetests` is also about 2.5x faster (109s vs 45s)

The PDF file used for testing: [01.pdf](https://github.com/pdfminer/pdfminer.six/files/3746661/01.pdf)

```python
import time

from pdfminer.pdfparser import PDFParser
from pdfminer.pdfdocument import PDFDocument
from pdfminer.pdfpage import PDFPage
from pdfminer.pdfinterp import PDFResourceManager, PDFPageInterpreter
from pdfminer.converter import PDFPageAggregator
from pdfminer.layout import LAParams

start = time.time()
with open('01.pdf', "rb") as f:
        parser = PDFParser(f)
        document = PDFDocument(parser)
        laparams = LAParams(
            char_margin=1.0,
            line_margin=0.5,
            word_margin=0.1,
            detect_vertical=True,
            all_texts=True,
        )
        rsrcmgr = PDFResourceManager()
        device = PDFPageAggregator(rsrcmgr, laparams=laparams)
        interpreter = PDFPageInterpreter(rsrcmgr, device)
        for page in PDFPage.create_pages(document):
            interpreter.process_page(page)
end = time.time()
print("Time elapsed: {}s".format(end-start))
```
