### PR TITLE
DRY: Only define dependencies in install_requires

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ python:
   - "3.5"
   - "3.6"
 install:
-  - pip install six
-  - pip install pycryptodome
-  - pip install chardet
-  - pip install sortedcontainers
+  - pip install tox-travis
 script:
-  nosetests --nologcapture
+  - tox

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,3 +30,20 @@ Any contribution is appreciated! You might want to:
 * Code changes should conform to PEP8 coding style (with a line-width of 120). Existing code may stay as it is. 
 * New features should be well documented using docstrings.
 * Check spelling and grammar.
+
+## Dev setup
+
+```sh
+# Clone the repo
+git clone https://github.com/pdfminer/pdfminer.six
+cd pdfminer.six
+
+# Install dev dependencies
+pip install -e .[dev]
+
+# Run tests on all Python versions
+tox
+
+# Run tests on a single version
+tox -e py36
+```

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     packages=['pdfminer'],
     package_data={'pdfminer': ['cmap/*.pickle.gz']},
     install_requires=[
-        'chardet ; python_version > "3.0"'
+        'chardet ; python_version > "3.0"',
         'pycryptodome',
         'six',
         'sortedcontainers',

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
         'six',
         'sortedcontainers',
     ],
+    extras_require={"dev": ["nose", "tox"]},
     description='PDF parser and analyzer',
     long_description=package.__doc__,
     license='MIT/X',

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,18 @@
 from setuptools import setup
-import sys
 
 import pdfminer as package
-
-requires = ['six', 'pycryptodome', 'sortedcontainers', 'chardet ; python_version > "3.0"']
 
 setup(
     name='pdfminer.six',
     version=package.__version__,
     packages=['pdfminer'],
     package_data={'pdfminer': ['cmap/*.pickle.gz']},
-    install_requires=requires,
+    install_requires=[
+        'chardet ; python_version > "3.0"'
+        'pycryptodome',
+        'six',
+        'sortedcontainers',
+    ],
     description='PDF parser and analyzer',
     long_description=package.__doc__,
     license='MIT/X',

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
-envlist = py26,py27,py34,py35,py36
+envlist = py{26, 27, 34, 35, 36}
 
 [testenv]
+extras = dev
 commands = nosetests --nologcapture
-deps =
-       nose

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,4 @@ envlist = py26,py27,py34,py35,py36
 [testenv]
 commands = nosetests --nologcapture
 deps =
-	six
-	pycryptodome
-	chardet
-	nose
-	sortedcontainers
+       nose


### PR DESCRIPTION
* Fixes #299.
* Alternative to #300.

Instead of defining the installation dependencies in `.travis.yml`, `tox.ini` and `setup.py`, only define the in `setup.py`. `requirements.txt` is not needed.

`tox.ini` does not need to duplicate them: it will run `python setup.py install` anyway, and install them from `setup.py`'s `install_requires`.

Let's also use tox on Travis CI, no need to list them there either.
