### PR TITLE
Add warning about dropping python2 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Deprecated
+- Support for Python 2 is dropped at January 1st, 2020 ([#307](https://github.com/pdfminer/pdfminer.six/pull/307))
+
 ### Added
 - Contribution guidelines in [CONTRIBUTING.md](CONTRIBUTING.md) ([#259](https://github.com/pdfminer/pdfminer.six/pull/259))
 - Support new encodings OneByteEncoding and DLIdent for CMaps ([#283](https://github.com/pdfminer/pdfminer.six/pull/283))

--- a/pdfminer/__init__.py
+++ b/pdfminer/__init__.py
@@ -10,7 +10,15 @@ It includes a PDF converter that can transform PDF files into other text
 formats (such as HTML). It has an extensible PDF parser that can be used for
 other purposes instead of text analysis.
 """
+import sys
+import warnings
+
 __version__ = '20181108'
+
+
+if sys.version_info < (3, 0):
+    warnings.warn('On January 1st, 2020, pdfminer.six will stop supporting Python 2. Please upgrade to Python 3. For '
+                  'more information see https://github.com/pdfminer/pdfminer.six/issues/194')
 
 if __name__ == '__main__':
     print(__version__)


### PR DESCRIPTION
Fix #303 by adding warning about dropping Python2 support at January 1st, 2020. 

I did not use `DeprecationWarning` because these are ignored by default. 