### PR TITLE
Replace opts by argparse in dumppdf.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Unhandled AssertionError when dumping pdf containing reference to object id 0 ([#318](https://github.com/pdfminer/pdfminer.six/pull/318))
 
+### Changed
+- Using argparse instead of getopt for command line interface of dumppdf.py ([#321](https://github.com/pdfminer/pdfminer.six/pull/321))
+
 ### Removed
 - Files for external applications such as django, cgi and pyinstaller ([#314](https://github.com/pdfminer/pdfminer.six/issues/314))
 

--- a/tests/test_tools_dumppdf.py
+++ b/tests/test_tools_dumppdf.py
@@ -8,10 +8,10 @@ def run(filename, options=None):
     absolute_path = absolute_sample_path(filename)
     with NamedTemporaryFile() as output_file:
         if options:
-            s = 'dumppdf -o%s %s %s' % (output_file.name, options, absolute_path)
+            s = 'dumppdf -o %s %s %s' % (output_file.name, options, absolute_path)
         else:
-            s = 'dumppdf -o%s %s' % (output_file.name, absolute_path)
-        dumppdf.main(s.split(' '))
+            s = 'dumppdf -o %s %s' % (output_file.name, absolute_path)
+        dumppdf.main(s.split(' ')[1:])
 
 
 class TestDumpPDF():

--- a/tools/dumppdf.py
+++ b/tools/dumppdf.py
@@ -243,8 +243,13 @@ def create_parser():
     parse_params = parser.add_argument_group(
         'Parser', description='Used during PDF parsing')
     parse_params.add_argument(
-        '-p', '--page-numbers', default=None, nargs='+',
-        help='A space-seperated list of page numbers to parse.')
+        "--page-numbers", type=int, default=None, nargs="+",
+        help="A space-seperated list of page numbers to parse.")
+    parse_params.add_argument(
+        "-p", "--pagenos", type=str,
+        help="A comma-separated list of page numbers to parse. Included for "
+             "legacy applications, use --page-numbers for more idiomatic "
+             "argument entry.")
     parse_params.add_argument(
         '-i', '--objects', type=str,
         help='Comma separated list of object numbers to extract')
@@ -293,7 +298,9 @@ def main(argv=None):
         objids = []
 
     if args.page_numbers:
-        pagenos = {int(x)-1 for x in args.page_numbers.split(',')}
+        pagenos = {x-1 for x in args.page_numbers}
+    elif args.pagenos:
+        pagenos = {int(x)-1 for x in args.pagenos.split(',')}
     else:
         pagenos = set()
 

--- a/tools/dumppdf.py
+++ b/tools/dumppdf.py
@@ -107,7 +107,7 @@ def dumpallobjs(out, doc, codec=None):
                 dumpxml(out, obj, codec=codec)
                 out.write('\n</object>\n\n')
             except PDFObjectNotFound as e:
-                print('not found: %r' % e, file=sys.stderr)
+                print('not found: %r' % e)
     dumptrailers(out, doc)
     out.write('</pdf>')
     return
@@ -186,7 +186,7 @@ def extractembedded(outfp, fname, objids, pagenos, password='',
         path = os.path.join(extractdir, filename)
         if os.path.exists(path):
             raise IOError('file exists: %r' % path)
-        print('extracting: %r' % path, file=sys.stderr)
+        print('extracting: %r' % path)
         out = open(path, 'wb')
         out.write(fileobj.get_data())
         out.close()

--- a/tools/dumppdf.py
+++ b/tools/dumppdf.py
@@ -262,7 +262,7 @@ def create_parser():
         '-i', '--objects', type=str,
         help='Comma separated list of object numbers to extract')
     parse_params.add_argument(
-        '-a', '--dump-all', default=False, action='store_true',
+        '-a', '--all', default=False, action='store_true',
         help='If the structure of all objects should be extracted')
     parse_params.add_argument(
         '-P', '--password', type=str, default='',
@@ -337,7 +337,7 @@ def main(argv=None):
 
     for fname in args.files:
         proc(outfp, fname, objids, pagenos, password=password,
-             dumpall=args.dump_all, codec=codec, extractdir=extractdir)
+             dumpall=args.all, codec=codec, extractdir=extractdir)
     outfp.close()
 
 


### PR DESCRIPTION
**Description**

Replace opts by argparse in dumppdf.py. This improves the command line functionality with a help prompt and better error handling. 

Fixes #175 

**How Has This Been Tested?**

Several tests are in place to test dumppdf.py functionality. That still works. 

**Checklist**

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the [README.md](../README.md) and other documentation, or I am sure that this is not necessary
- [x] I have added a consice human-readable description of the change to [CHANGELOG.md](../CHANGELOG.md)
- [x] I have added docstrings to newly created methods and classes
- [x] I have optimized the code at least one time after creating the initial version
