### PR TITLE
Fix unicode to str error in python2

### DIFF
--- a/pdfminer/converter.py
+++ b/pdfminer/converter.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 import logging
 import re
+import sys
 from .pdfdevice import PDFTextDevice
 from .pdffont import PDFUnicodeNotDefined
 from .layout import LTContainer
@@ -271,6 +272,8 @@ class HTMLConverter(PDFConverter):
     def write(self, text):
         if self.codec:
             text = text.encode(self.codec)
+        if sys.version_info < (3, 0):
+            text = str(text)
         self.outfp.write(text)
         return
 


### PR DESCRIPTION
I can't believe that Python2 is giving us so much trouble during its last moments.

**Description**

For some reason I had to convert the unicode var into a string so it could work properly in python 2.

Fixes the issue found at #329 

**How Has This Been Tested?**

Passed on `tox`
