### PR TITLE
Fix ordering of grouping textboxes. The first grouping of textboxes should be skipped if there are intermediate textboxes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-Nothing yet
+### Fixed
+- Wrong order of text box grouping introduced by PR #315 ([#335](https://github.com/pdfminer/pdfminer.six/pull/335))
 
 ## [20191107] - 2019-11-07
 

--- a/docs/source/tutorials/highlevel.rst
+++ b/docs/source/tutorials/highlevel.rst
@@ -17,22 +17,22 @@ The most simple way to extract text from a PDF is to use
 
     >>> text = extract_text('samples/simple1.pdf')
     >>> print(repr(text))
-    'Hello \n\nWorld\n\nWorld\n\nHello \n\nH e l l o  \n\nH e l l o  \n\nW o r l d\n\nW o r l d\n\n\x0c'
+    'Hello \n\nWorld\n\nHello \n\nWorld\n\nH e l l o  \n\nW o r l d\n\nH e l l o  \n\nW o r l d\n\n\x0c'
     >>> print(text)
     ... # doctest: +NORMALIZE_WHITESPACE
     Hello
     <BLANKLINE>
     World
     <BLANKLINE>
-    World
-    <BLANKLINE>
     Hello
     <BLANKLINE>
-    H e l l o
+    World
     <BLANKLINE>
     H e l l o
     <BLANKLINE>
     W o r l d
+    <BLANKLINE>
+    H e l l o
     <BLANKLINE>
     W o r l d
     <BLANKLINE>

--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -682,10 +682,6 @@ class LTLayoutContainer(LTContainer):
             (skip_isany, d, id1, id2, obj1, obj2) = heapq.heappop(dists)
             # Skip objects that are already merged
             if (id1 not in done) and (id2 not in done):
-                logger.debug('Grouping: {:50.50s}   and   {:50.50s}'.format(
-                    shorten_str(obj1.get_text(), 50),
-                    shorten_str(obj2.get_text(), 50)))
-
                 if skip_isany and isany(obj1, obj2):
                     heapq.heappush(dists, (True, d, id1, id2, obj1, obj2))
                     continue

--- a/pdfminer/utils.py
+++ b/pdfminer/utils.py
@@ -32,6 +32,14 @@ def make_compat_str(in_str):
     return in_str
 
 
+def shorten_str(s, size):
+    if len(s) > size:
+        length = (size - 5) // 2
+        return '{} ... {}'.format(s[:length], s[-length:])
+    else:
+        return s
+
+
 def compatible_encode_method(bytesorstring, encoding='utf-8', erraction='ignore'):
     """When Py2 str.encode is called, it often means bytes.encode in Py3. This does either."""
     if six.PY2:

--- a/pdfminer/utils.py
+++ b/pdfminer/utils.py
@@ -33,6 +33,8 @@ def make_compat_str(in_str):
 
 
 def shorten_str(s, size):
+    if size < 7:
+        return s[:size]
     if len(s) > size:
         length = (size - 5) // 2
         return '{} ... {}'.format(s[:length], s[-length:])

--- a/tests/test_highlevel_extracttext.py
+++ b/tests/test_highlevel_extracttext.py
@@ -11,7 +11,7 @@ def run(sample_path):
 
 
 test_strings = {
-    "simple1.pdf": "Hello \n\nWorld\n\nWorld\n\nHello \n\nH e l l o  \n\nH e l l o  \n\nW o r l d\n\nW o r l d\n\n\f",
+    "simple1.pdf": "Hello \n\nWorld\n\nHello \n\nWorld\n\nH e l l o  \n\nW o r l d\n\nH e l l o  \n\nW o r l d\n\n\f",
     "simple2.pdf": "\f",
     "simple3.pdf": "HelloHello\n\nWorld\n\nWorld\n\n\f",
 }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 from nose.tools import assert_equal
 
 from pdfminer.layout import LTComponent
-from pdfminer.utils import Plane
+from pdfminer.utils import Plane, shorten_str
 
 
 class TestPlane(object):
@@ -38,3 +38,9 @@ class TestPlane(object):
         obj = LTComponent((0, 0, object_size, object_size))
         plane.add(obj)
         return plane, obj
+
+
+class TestFunctions(object):
+    def test_shorten_str(self):
+        s = shorten_str('Hello there World', 15)
+        assert_equal(s, 'Hello ... World')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -44,3 +44,10 @@ class TestFunctions(object):
     def test_shorten_str(self):
         s = shorten_str('Hello there World', 15)
         assert_equal(s, 'Hello ... World')
+
+    def test_shorten_short_str_is_same(self):
+        s = 'Hello World'
+        assert_equal(s, shorten_str(s, 50))
+
+    def test_shorten_to_really_short(self):
+        assert_equal('Hello', shorten_str('Hello World', 5))


### PR DESCRIPTION
**Description**

#315 introduces a bug by replacing `0` by `True` and `1` by `False` in the ordening of textbox distances. Consequently, all the text boxes that are checked once (for intermediate textboxes) have priority over those that are never checked. Therefore it merges the same text box over and over again. 

@mikkkee, can you have a look at this?

Fixes #334 

**How Has This Been Tested?**

- [x] I've use the pdf in #334 to check the output
- [x] I've added a debug log statement to see the order in which text boxes are grouped. 
- [x] The doctests in the documentation improved
- [x] Check speedup improvement from #315

**Checklist**

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the [README.md](../README.md) and other documentation, or I am sure that this is not necessary
- [x] I have added a consice human-readable description of the change to [CHANGELOG.md](../CHANGELOG.md)
- [x] I have added docstrings to newly created methods and classes
- [x] I have optimized the code at least one time after creating the initial version
