### PR TITLE
addressing: some time, the order of return text is not left to right, top to bottom #290 

### DIFF
--- a/pdfminer/high_level.py
+++ b/pdfminer/high_level.py
@@ -158,6 +158,7 @@ def extract_pages(pdf_file, password='', page_numbers=None, maxpages=0,
          selts the lrtb token list and context.
          selts is a list of objects {"x1":x1,"y1":y1,"x0":x0,"y0":y0,"txt":text}
          (x0,y0),(x1,y1) are the coordinates of the box surrounding the object
+         if callback return False, lrtd_parse_page quits
     :param context: a caller context object for storing some data and passed to callback
     """
     rsrcmgr = PDFResourceManager()

--- a/pdfminer/high_level.py
+++ b/pdfminer/high_level.py
@@ -149,7 +149,7 @@ def extract_pages(pdf_file, password='', page_numbers=None, maxpages=0,
             layout = device.get_result()
             yield layout
 
- def lrtd_parse_page(document,callback,context):
+def lrtd_parse_page(document,callback,context):
     """Parse page and yield text token left to right and top down (lrtd)
     
     :param document: open stream to the PDF file to be worked on
@@ -171,7 +171,7 @@ def extract_pages(pdf_file, password='', page_numbers=None, maxpages=0,
             layout = device.get_result()
             elts=[]
             m = 0
-            mindelatheight = 1000
+            mindeltaheight = 1000
             """
             breakdown lines into string (w/o \n) calculate new coordinates
             """
@@ -197,7 +197,6 @@ def extract_pages(pdf_file, password='', page_numbers=None, maxpages=0,
                     if m < element.y1:
                         m = element.y1
             n = len(elts)
-            elts1 = []
             """
             tune strings coordinate to get them aligned in the same "line" if not too far apart 
             (less than 1/2 the min line height of the page)

--- a/pdfminer/high_level.py
+++ b/pdfminer/high_level.py
@@ -164,7 +164,6 @@ def extract_pages(pdf_file, password='', page_numbers=None, maxpages=0,
     laparams = LAParams()
     device = PDFPageAggregator(rsrcmgr, laparams=laparams)
     interpreter = PDFPageInterpreter(rsrcmgr, device)
-    i=0
     p=0
     for page in PDFPage.get_pages(document):
             interpreter.process_page(page)
@@ -172,6 +171,9 @@ def extract_pages(pdf_file, password='', page_numbers=None, maxpages=0,
             elts=[]
             m = 0
             mindelatheight = 1000
+            """
+            breakdown lines into string (w/o \n) calculate new coordinates
+            """
             for element in layout:
                 if isinstance(element, LTTextBoxHorizontal):
                     x0 = element.x0
@@ -195,6 +197,10 @@ def extract_pages(pdf_file, password='', page_numbers=None, maxpages=0,
                         m = element.y1
             n = len(elts)
             elts1 = []
+            """
+            tune strings coordinate to get them aligned in the same "line" if not too far apart 
+            (less than 1/2 the min line height of the page)
+            """
             for i in range(1,n):
                 for j in range(i+1,n):
                     if abs(elts[i-1]["y0"]-elts[j-1]["y0"])<(mindeltaheight/2):


### PR DESCRIPTION
**Description**

added 
```
lrtd_parse_page
Parse page and yield text token left to right and top down (lrtd)

:param document: open stream to the PDF file to be worked on
:param callback: a function to callback each tim a page is processed accept 3 parameters 
     p the page, starts at 0 
     selts the lrtb token list and context.
     selts is a list of objects {"x1":x1,"y1":y1,"x0":x0,"y0":y0,"txt":text}
     (x0,y0),(x1,y1) are the coordinates of the box surrounding the object
     if callback return False, lrtd_parse_page quits
:param context: a caller context object for storing some data and passed to callback
```

Fixes #290

**How Has This Been Tested?**

I have tested this code on 98 pages accounting reports and corrected most anomalies I have found with my document.
The code added is less than 100 lines and quite documented

**Checklist**

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the [README.md](../README.md) and other documentation, or I am sure that this is not necessary
- [ ] I have added a consice human-readable description of the change to [CHANGELOG.md](../CHANGELOG.md)
- [x] I have added docstrings to newly created methods and classes
- [x] I have optimized the code at least one time after creating the initial version
