### PR TITLE
Group text lines if they are centered (#382)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Grouping of text lines outside of parent container bounding box ([#386](https://github.com/pdfminer/pdfminer.six/pull/386))
 
+### Changed
+- Group text lines if they are centered ([#382](https://github.com/pdfminer/pdfminer.six/pull/382))
+
 ## [20200124] - 2020-01-24
 
 ### Security

--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -420,10 +420,22 @@ class LTTextLineHorizontal(LTTextLine):
         objs = plane.find((self.x0, self.y0-d, self.x1, self.y1+d))
         return [obj for obj in objs
                 if (isinstance(obj, LTTextLineHorizontal) and
-                    abs(obj.height-self.height) < d and
-                    (abs(obj.x0-self.x0) < d or
-                     abs(obj.x1-self.x1) < d or
-                     abs((obj.x0+obj.x1)/2-(self.x0+self.x1)/2) < d))]
+                    self.__is_same_height_as(obj, tolerance=d) and
+                    (self.__is_left_aligned_with(obj, tolerance=d) or
+                     self.__is_right_aligned_with(obj, tolerance=d) or
+                     self.__is_centrally_aligned_with(obj, tolerance=d)))]
+
+    def __is_left_aligned_with(self, other, tolerance=0):
+        return abs(other.x0 - self.x0) <= tolerance
+
+    def __is_right_aligned_with(self, other, tolerance=0):
+        return abs(other.x1 - self.x1) <= tolerance
+
+    def __is_centrally_aligned_with(self, other, tolerance=0):
+        return abs((other.x0+other.x1)/2 - (self.x0+self.x1)/2) <= tolerance
+
+    def __is_same_height_as(self, other, tolerance):
+        return abs(other.height - self.height) <= tolerance
 
 
 class LTTextLineVertical(LTTextLine):
@@ -446,10 +458,22 @@ class LTTextLineVertical(LTTextLine):
         objs = plane.find((self.x0-d, self.y0, self.x1+d, self.y1))
         return [obj for obj in objs
                 if (isinstance(obj, LTTextLineVertical) and
-                    abs(obj.width-self.width) < d and
-                    (abs(obj.y0-self.y0) < d or
-                     abs(obj.y1-self.y1) < d or
-                     abs((obj.y0+obj.y1)/2-(self.y0+self.y1)/2) < d))]
+                    self.__is_same_width_as(obj, tolerance=d) and
+                    (self.__is_lower_aligned_with(obj, tolerance=d) or
+                     self.__is_upper_aligned_with(obj, tolerance=d) or
+                     self.__is_centrally_aligned_with(obj, tolerance=d)))]
+
+    def __is_lower_aligned_with(self, other, tolerance=0):
+        return abs(other.y0 - self.y0) <= tolerance
+
+    def __is_upper_aligned_with(self, other, tolerance=0):
+        return abs(other.y1 - self.y1) <= tolerance
+
+    def __is_centrally_aligned_with(self, other, tolerance=0):
+        return abs((other.y0+other.y1)/2 - (self.y0+self.y1)/2) <= tolerance
+
+    def __is_same_width_as(self, other, tolerance):
+        return abs(other.width - self.width) <= tolerance
 
 
 class LTTextBox(LTTextContainer):

--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -409,7 +409,7 @@ class LTTextLineHorizontal(LTTextLine):
     def add(self, obj):
         if isinstance(obj, LTChar) and self.word_margin:
             margin = self.word_margin * max(obj.width, obj.height)
-            if self._x1 < obj.x0-margin:
+            if self._x1 < obj.x0 - margin:
                 LTContainer.add(self, LTAnno(' '))
         self._x1 = obj.x1
         LTTextLine.add(self, obj)
@@ -424,34 +424,35 @@ class LTTextLineHorizontal(LTTextLine):
         will be the same height as self, and also either left-, right-, or
         centrally-aligned.
         """
-        d = ratio*self.height
-        objs = plane.find((self.x0, self.y0-d, self.x1, self.y1+d))
+        d = ratio * self.height
+        objs = plane.find((self.x0, self.y0 - d, self.x1, self.y1 + d))
         return [obj for obj in objs
                 if (isinstance(obj, LTTextLineHorizontal) and
-                    self.__is_same_height_as(obj, tolerance=d) and
-                    (self.__is_left_aligned_with(obj, tolerance=d) or
-                     self.__is_right_aligned_with(obj, tolerance=d) or
-                     self.__is_centrally_aligned_with(obj, tolerance=d)))]
+                    self._is_same_height_as(obj, tolerance=d) and
+                    (self._is_left_aligned_with(obj, tolerance=d) or
+                     self._is_right_aligned_with(obj, tolerance=d) or
+                     self._is_centrally_aligned_with(obj, tolerance=d)))]
 
-    def __is_left_aligned_with(self, other, tolerance=0):
+    def _is_left_aligned_with(self, other, tolerance=0):
         """
         Whether the left-hand edge of `other` is within `tolerance`.
         """
         return abs(other.x0 - self.x0) <= tolerance
 
-    def __is_right_aligned_with(self, other, tolerance=0):
+    def _is_right_aligned_with(self, other, tolerance=0):
         """
         Whether the right-hand edge of `other` is within `tolerance`.
         """
         return abs(other.x1 - self.x1) <= tolerance
 
-    def __is_centrally_aligned_with(self, other, tolerance=0):
+    def _is_centrally_aligned_with(self, other, tolerance=0):
         """
         Whether the horizontal center of `other` is within `tolerance`.
         """
-        return abs((other.x0+other.x1)/2 - (self.x0+self.x1)/2) <= tolerance
+        return abs(
+            (other.x0 + other.x1) / 2 - (self.x0 + self.x1) / 2) <= tolerance
 
-    def __is_same_height_as(self, other, tolerance):
+    def _is_same_height_as(self, other, tolerance):
         return abs(other.height - self.height) <= tolerance
 
 
@@ -464,7 +465,7 @@ class LTTextLineVertical(LTTextLine):
     def add(self, obj):
         if isinstance(obj, LTChar) and self.word_margin:
             margin = self.word_margin * max(obj.width, obj.height)
-            if obj.y1+margin < self._y0:
+            if obj.y1 + margin < self._y0:
                 LTContainer.add(self, LTAnno(' '))
         self._y0 = obj.y0
         LTTextLine.add(self, obj)
@@ -479,34 +480,35 @@ class LTTextLineVertical(LTTextLine):
         will be the same width as self, and also either upper-, lower-, or
         centrally-aligned.
         """
-        d = ratio*self.width
-        objs = plane.find((self.x0-d, self.y0, self.x1+d, self.y1))
+        d = ratio * self.width
+        objs = plane.find((self.x0 - d, self.y0, self.x1 + d, self.y1))
         return [obj for obj in objs
                 if (isinstance(obj, LTTextLineVertical) and
-                    self.__is_same_width_as(obj, tolerance=d) and
-                    (self.__is_lower_aligned_with(obj, tolerance=d) or
-                     self.__is_upper_aligned_with(obj, tolerance=d) or
-                     self.__is_centrally_aligned_with(obj, tolerance=d)))]
+                    self._is_same_width_as(obj, tolerance=d) and
+                    (self._is_lower_aligned_with(obj, tolerance=d) or
+                     self._is_upper_aligned_with(obj, tolerance=d) or
+                     self._is_centrally_aligned_with(obj, tolerance=d)))]
 
-    def __is_lower_aligned_with(self, other, tolerance=0):
+    def _is_lower_aligned_with(self, other, tolerance=0):
         """
         Whether the lower edge of `other` is within `tolerance`.
         """
         return abs(other.y0 - self.y0) <= tolerance
 
-    def __is_upper_aligned_with(self, other, tolerance=0):
+    def _is_upper_aligned_with(self, other, tolerance=0):
         """
         Whether the upper edge of `other` is within `tolerance`.
         """
         return abs(other.y1 - self.y1) <= tolerance
 
-    def __is_centrally_aligned_with(self, other, tolerance=0):
+    def _is_centrally_aligned_with(self, other, tolerance=0):
         """
         Whether the vertical center of `other` is within `tolerance`.
         """
-        return abs((other.y0+other.y1)/2 - (self.y0+self.y1)/2) <= tolerance
+        return abs(
+            (other.y0 + other.y1) / 2 - (self.y0 + self.y1) / 2) <= tolerance
 
-    def __is_same_width_as(self, other, tolerance):
+    def _is_same_width_as(self, other, tolerance):
         return abs(other.width - self.width) <= tolerance
 
 

--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -422,7 +422,8 @@ class LTTextLineHorizontal(LTTextLine):
                 if (isinstance(obj, LTTextLineHorizontal) and
                     abs(obj.height-self.height) < d and
                     (abs(obj.x0-self.x0) < d or
-                     abs(obj.x1-self.x1) < d))]
+                     abs(obj.x1-self.x1) < d or
+                     abs((obj.x0+obj.x1)/2-(self.x0+self.x1)/2) < d))]
 
 
 class LTTextLineVertical(LTTextLine):
@@ -447,7 +448,8 @@ class LTTextLineVertical(LTTextLine):
                 if (isinstance(obj, LTTextLineVertical) and
                     abs(obj.width-self.width) < d and
                     (abs(obj.y0-self.y0) < d or
-                     abs(obj.y1-self.y1) < d))]
+                     abs(obj.y1-self.y1) < d or
+                     abs((obj.y0+obj.y1)/2-(self.y0+self.y1)/2) < d))]
 
 
 class LTTextBox(LTTextContainer):

--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -416,6 +416,14 @@ class LTTextLineHorizontal(LTTextLine):
         return
 
     def find_neighbors(self, plane, ratio):
+        """
+        Finds neighboring LTTextLineHorizontals in the plane.
+
+        Returns a list of other LTTestLineHorizontals in the plane which are
+        close to self. "Close" can be controlled by ratio. The returned objects
+        will be the same height as self, and also either left-, right-, or
+        centrally-aligned.
+        """
         d = ratio*self.height
         objs = plane.find((self.x0, self.y0-d, self.x1, self.y1+d))
         return [obj for obj in objs
@@ -426,12 +434,21 @@ class LTTextLineHorizontal(LTTextLine):
                      self.__is_centrally_aligned_with(obj, tolerance=d)))]
 
     def __is_left_aligned_with(self, other, tolerance=0):
+        """
+        Whether the left-hand edge of `other` is within `tolerance`.
+        """
         return abs(other.x0 - self.x0) <= tolerance
 
     def __is_right_aligned_with(self, other, tolerance=0):
+        """
+        Whether the right-hand edge of `other` is within `tolerance`.
+        """
         return abs(other.x1 - self.x1) <= tolerance
 
     def __is_centrally_aligned_with(self, other, tolerance=0):
+        """
+        Whether the horizontal center of `other` is within `tolerance`.
+        """
         return abs((other.x0+other.x1)/2 - (self.x0+self.x1)/2) <= tolerance
 
     def __is_same_height_as(self, other, tolerance):
@@ -454,6 +471,14 @@ class LTTextLineVertical(LTTextLine):
         return
 
     def find_neighbors(self, plane, ratio):
+        """
+        Finds neighboring LTTextLineVerticals in the plane.
+
+        Returns a list of other LTTextLineVerticals in the plane which are
+        close to self. "Close" can be controlled by ratio. The returned objects
+        will be the same width as self, and also either upper-, lower-, or
+        centrally-aligned.
+        """
         d = ratio*self.width
         objs = plane.find((self.x0-d, self.y0, self.x1+d, self.y1))
         return [obj for obj in objs
@@ -464,12 +489,21 @@ class LTTextLineVertical(LTTextLine):
                      self.__is_centrally_aligned_with(obj, tolerance=d)))]
 
     def __is_lower_aligned_with(self, other, tolerance=0):
+        """
+        Whether the lower edge of `other` is within `tolerance`.
+        """
         return abs(other.y0 - self.y0) <= tolerance
 
     def __is_upper_aligned_with(self, other, tolerance=0):
+        """
+        Whether the upper edge of `other` is within `tolerance`.
+        """
         return abs(other.y1 - self.y1) <= tolerance
 
     def __is_centrally_aligned_with(self, other, tolerance=0):
+        """
+        Whether the vertical center of `other` is within `tolerance`.
+        """
         return abs((other.y0+other.y1)/2 - (self.y0+self.y1)/2) <= tolerance
 
     def __is_same_width_as(self, other, tolerance):

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1,6 +1,12 @@
 import unittest
 
-from pdfminer.layout import LTLayoutContainer, LAParams, LTTextLineHorizontal
+from pdfminer.layout import (
+    LTLayoutContainer,
+    LAParams,
+    LTTextLineHorizontal,
+    LTTextLineVertical,
+)
+from pdfminer.utils import Plane
 
 
 class TestGroupTextLines(unittest.TestCase):
@@ -21,3 +27,85 @@ class TestGroupTextLines(unittest.TestCase):
         textboxes = list(layout.group_textlines(laparams, lines))
 
         self.assertEqual(len(textboxes), 2)
+
+
+class TestFindNeigbors(unittest.TestCase):
+    def test_find_neighbors_horizontal(self):
+        laparams = LAParams()
+        plane = Plane((0, 0, 50, 50))
+
+        line = LTTextLineHorizontal(laparams.word_margin)
+        line.set_bbox((10, 4, 20, 6))
+        plane.add(line)
+
+        left_aligned_above = LTTextLineHorizontal(laparams.word_margin)
+        left_aligned_above.set_bbox((10, 6, 15, 8))
+        plane.add(left_aligned_above)
+
+        right_aligned_below = LTTextLineHorizontal(laparams.word_margin)
+        right_aligned_below.set_bbox((15, 2, 20, 4))
+        plane.add(right_aligned_below)
+
+        centrally_aligned_overlapping = LTTextLineHorizontal(
+            laparams.word_margin)
+        centrally_aligned_overlapping.set_bbox((13, 5, 17, 7))
+        plane.add(centrally_aligned_overlapping)
+
+        not_aligned = LTTextLineHorizontal(laparams.word_margin)
+        not_aligned.set_bbox((0, 6, 5, 8))
+        plane.add(not_aligned)
+
+        wrong_height = LTTextLineHorizontal(laparams.word_margin)
+        wrong_height.set_bbox((10, 6, 15, 10))
+        plane.add(wrong_height)
+
+        neighbors = line.find_neighbors(plane, laparams.line_margin)
+        self.assertCountEqual(
+            neighbors,
+            [
+                line,
+                left_aligned_above,
+                right_aligned_below,
+                centrally_aligned_overlapping,
+            ],
+        )
+
+    def test_find_neighbors_vertical(self):
+        laparams = LAParams()
+        plane = Plane((0, 0, 50, 50))
+
+        line = LTTextLineVertical(laparams.word_margin)
+        line.set_bbox((4, 10, 6, 20))
+        plane.add(line)
+
+        bottom_aligned_right = LTTextLineVertical(laparams.word_margin)
+        bottom_aligned_right.set_bbox((6, 10, 8, 15))
+        plane.add(bottom_aligned_right)
+
+        top_aligned_left = LTTextLineVertical(laparams.word_margin)
+        top_aligned_left.set_bbox((2, 15, 4, 20))
+        plane.add(top_aligned_left)
+
+        centrally_aligned_overlapping = LTTextLineVertical(
+            laparams.word_margin)
+        centrally_aligned_overlapping.set_bbox((5, 13, 7, 17))
+        plane.add(centrally_aligned_overlapping)
+
+        not_aligned = LTTextLineVertical(laparams.word_margin)
+        not_aligned.set_bbox((6, 0, 8, 5))
+        plane.add(not_aligned)
+
+        wrong_width = LTTextLineVertical(laparams.word_margin)
+        wrong_width.set_bbox((6, 10, 10, 15))
+        plane.add(wrong_width)
+
+        neighbors = line.find_neighbors(plane, laparams.line_margin)
+        self.assertCountEqual(
+            neighbors,
+            [
+                line,
+                bottom_aligned_right,
+                top_aligned_left,
+                centrally_aligned_overlapping,
+            ],
+        )


### PR DESCRIPTION
**Description**

Add a check when checking if lines should be merged to see if they are centered above each other.

Fixes #382

Note: it might also be worth having a read of #383, as there is perhaps a discussion there about how to deal with these checks for a negative line margin...

**How Has This Been Tested?**

[Example PDF](https://www.dropbox.com/s/iesuryj5ter1bax/centered_text_example.pdf?dl=0)

Here is my test code (which simply loads the pdfs and prints the elements):
```
from pdfminer import converter, pdfdocument, pdfinterp, pdfpage, pdfparser
from pdfminer.layout import LTTextContainer, LAParams
path_to_file = "centered_text_example.pdf"

with open(path_to_file, "rb") as pdf_file:
    parser = pdfparser.PDFParser(pdf_file)
    document = pdfdocument.PDFDocument(parser)
    resource_manager = pdfinterp.PDFResourceManager()
    device = converter.PDFPageAggregator(resource_manager, laparams=LAParams())
    interpreter = pdfinterp.PDFPageInterpreter(resource_manager, device)
    for page in pdfpage.PDFPage.create_pages(document):
        interpreter.process_page(page)
        results = device.get_result()
        elements = [
            element for element in results if isinstance(element, LTTextContainer)
        ]
device.close()

print(elements)
```

Before this change, you get:
```
[
    <LTTextBoxHorizontal(0) 123.800,344.802,216.392,367.878 'Long Text 1\n'>, 
    <LTTextBoxHorizontal(1) 146.100,366.002,194.070,411.778 'Text 1\nText 2\n'>, 
    <LTTextBoxHorizontal(2) 146.100,302.502,194.070,348.278 'Text 3\nText 4\n'>, 
    <LTTextBoxHorizontal(3) 39.700,24.176,43.200,42.152 ' \n'>, 
    <LTTextBoxHorizontal(4) 395.500,24.176,399.000,42.152 ' \n'>
]
```
After this change you get:
```
[
    <LTTextBoxHorizontal(0) 123.800,302.502,216.392,411.778 'Text 1\nText 2\nLong Text 1\nText 3\nText 4\n'>,
    <LTTextBoxHorizontal(1) 39.700,24.176,43.200,42.152 ' \n'>
    <LTTextBoxHorizontal(2) 395.500,24.176,399.000,42.152 ' \n'>
]
```

(The last two elements in each are just artefacts in the example pdf, ignore them).

**Checklist**

_I will do these things once I get a bit of guidance on whether this is an acceptable change. I'll also need a pointer on how to add a relevant test._

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the [README.md](../README.md) and other documentation, or I am sure that this is not necessary
- [x] I have added a consice human-readable description of the change to [CHANGELOG.md](../CHANGELOG.md)
- [x] I have added docstrings to newly created methods and classes
- [x] I have optimized the code at least one time after creating the initial version
