### PR TITLE
Catch ValueError when converting font encoding differences to characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-Nothing
+- Also ignore ValueError's when converting font encoding differences ([#389](https://github.com/pdfminer/pdfminer.six/pull/389))
 
 ## [20200124] - 2020-01-24
 

--- a/pdfminer/encodingdb.py
+++ b/pdfminer/encodingdb.py
@@ -106,7 +106,7 @@ class EncodingDB:
                 elif isinstance(x, PSLiteral):
                     try:
                         cid2unicode[cid] = name2unicode(x.name)
-                    except KeyError as e:
+                    except (KeyError, ValueError) as e:
                         log.debug(str(e))
                     cid += 1
         return cid2unicode

--- a/tests/test_encodingdb.py
+++ b/tests/test_encodingdb.py
@@ -6,7 +6,8 @@ Therefore lowercase unittest variants are added.
 """
 from nose.tools import assert_raises
 
-from pdfminer.encodingdb import name2unicode
+from pdfminer.encodingdb import name2unicode, EncodingDB
+from pdfminer.psparser import PSLiteral
 
 
 def test_name2unicode_name_in_agl():
@@ -145,3 +146,12 @@ def test_name2unicode_pua_ogoneksmall():
 
 def test_name2unicode_overflow_error():
     assert_raises(KeyError, name2unicode, '226215240241240240240240')
+
+
+def test_get_encoding_with_invalid_differences():
+    """Invalid differences should be silently ignored
+
+    Regression test for https://github.com/pdfminer/pdfminer.six/issues/385
+    """
+    invalid_differences = [PSLiteral('ubuntu'), PSLiteral('1234')]
+    EncodingDB.get_encoding('StandardEncoding', invalid_differences)


### PR DESCRIPTION
**Pull request**

Fixes #385. 

When converting font encoding differences to characters `KeyError`'s are ignored. But other errors (like `ValueError` shown in #385) are not ignored. This PR adds the `ValueError` to the except clause. 

**How Has This Been Tested?**

With PDF from #385. Added extra tests. 

**Checklist**

- [x] I have added tests that prove my fix is effective or that my feature 
  works
- [x] I have added docstrings to newly created methods and classes
- [x] I have optimized the code at least one time after creating the initial 
  version
- [x] I have updated the [README.md](../README.md) or I am verified that this
  is not necessary
- [x] I have updated the [readthedocs](../docs/source) documentation or I 
  verified that this is not necessary
- [x] I have added a consice human-readable description of the change to 
  [CHANGELOG.md](../CHANGELOG.md)
