### PR TITLE
Split out IO logic from high level functions (#392)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Ignore ValueError when converting font encoding differences ([#389](https://github.com/pdfminer/pdfminer.six/pull/389))
 - Grouping of text lines outside of parent container bounding box ([#386](https://github.com/pdfminer/pdfminer.six/pull/386))
 
+### Added
+- Also accept file-like objects in high level functions `extract_text` and `extract_pages` ([#392](https://github.com/pdfminer/pdfminer.six/pull/392))
+
 ### Changed
 - Group text lines if they are centered ([#382](https://github.com/pdfminer/pdfminer.six/pull/382))
 

--- a/pdfminer/high_level.py
+++ b/pdfminer/high_level.py
@@ -11,28 +11,7 @@ from .layout import LAParams
 from .pdfdevice import TagExtractor
 from .pdfinterp import PDFResourceManager, PDFPageInterpreter
 from .pdfpage import PDFPage
-
-
-class open_filename(object):
-    """
-    Context manager that allows opening a filename and closes it on exit,
-    (just like `open`), but does nothing for file-like objects.
-    """
-    def __init__(self, filename, *args, **kwargs):
-        if isinstance(filename, str):
-            self.file_handler = open(filename, *args, **kwargs)
-            self.closing = True
-        else:
-            self.file_handler = filename
-            self.closing = False
-
-    def __enter__(self):
-        return self.file_handler
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        if self.closing:
-            self.file_handler.close()
-        return False
+from .utils import open_filename
 
 
 def extract_text_to_fp(inf, outfp, output_type='text', codec='utf-8',

--- a/pdfminer/utils.py
+++ b/pdfminer/utils.py
@@ -11,6 +11,28 @@ import chardet  # For str encoding detection
 INF = (1 << 31) - 1
 
 
+class open_filename(object):
+    """
+    Context manager that allows opening a filename and closes it on exit,
+    (just like `open`), but does nothing for file-like objects.
+    """
+    def __init__(self, filename, *args, **kwargs):
+        if isinstance(filename, str):
+            self.file_handler = open(filename, *args, **kwargs)
+            self.closing = True
+        else:
+            self.file_handler = filename
+            self.closing = False
+
+    def __enter__(self):
+        return self.file_handler
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.closing:
+            self.file_handler.close()
+        return False
+
+
 def make_compat_bytes(in_str):
     "Converts to bytes, encoding to unicode."
     assert isinstance(in_str, str), str(type(in_str))

--- a/tests/test_highlevel_extracttext.py
+++ b/tests/test_highlevel_extracttext.py
@@ -4,9 +4,16 @@ from helpers import absolute_sample_path
 from pdfminer.high_level import extract_text
 
 
-def run(sample_path):
+def run_with_string(sample_path):
     absolute_path = absolute_sample_path(sample_path)
     s = extract_text(absolute_path)
+    return s
+
+
+def run_with_file(sample_path):
+    absolute_path = absolute_sample_path(sample_path)
+    with open(absolute_path, "rb") as in_file:
+        s = extract_text(in_file)
     return s
 
 
@@ -20,19 +27,34 @@ test_strings = {
 
 
 class TestExtractText(unittest.TestCase):
-    def test_simple1(self):
+    def test_simple1_with_string(self):
         test_file = "simple1.pdf"
-        s = run(test_file)
+        s = run_with_string(test_file)
         self.assertEqual(s, test_strings[test_file])
 
-    def test_simple2(self):
+    def test_simple2_with_string(self):
         test_file = "simple2.pdf"
-        s = run(test_file)
+        s = run_with_string(test_file)
         self.assertEqual(s, test_strings[test_file])
 
-    def test_simple3(self):
+    def test_simple3_with_string(self):
         test_file = "simple3.pdf"
-        s = run(test_file)
+        s = run_with_string(test_file)
+        self.assertEqual(s, test_strings[test_file])
+
+    def test_simple1_with_file(self):
+        test_file = "simple1.pdf"
+        s = run_with_file(test_file)
+        self.assertEqual(s, test_strings[test_file])
+
+    def test_simple2_with_file(self):
+        test_file = "simple2.pdf"
+        s = run_with_file(test_file)
+        self.assertEqual(s, test_strings[test_file])
+
+    def test_simple3_with_file(self):
+        test_file = "simple3.pdf"
+        s = run_with_file(test_file)
         self.assertEqual(s, test_strings[test_file])
 
 


### PR DESCRIPTION
**Pull request**

Adds two new functions (`extract_text_from_io` and `extract_pages_from_io`) to `high_level.py`, allowing you to call `extract_text` and `extract_pages` without having the file locally.

Closes #392 

**Notes**
- I've created the new functions, `*_from_io` to avoid breaking changes to the original functions. This is not very consistent with the `extract_text_to_fp` at the top of the file, perhaps. Happy to implement alternatives.
- I've used `inf` as the new IO parameter, even though I don't really like the name. This is to be consistent with `extract_text_to_fp`. Other places in the code use `fp`. Happy to change.
- I added the test in a new file, as the existing code has `test_highlevel_extracttext.py`. Is this correct, or should this all be in one `test_high_level.py`?


**How Has This Been Tested?**

I've added tests for `extract_text_from_io`, but couldn't find any existing tests for `extract_pages`?

**Checklist**

- [X] I have added tests that prove my fix is effective or that my feature 
  works
- [X] I have added docstrings to newly created methods and classes
- [X] I have optimized the code at least one time after creating the initial 
  version
- [X] I have updated the [README.md](../README.md) or I am verified that this
  is not necessary (not necessary)
- [X] I have updated the [readthedocs](../docs/source) documentation or I 
  verified that this is not necessary (not necessary as the read the docs page on this is auto generated from docstrings)
- [X] I have added a consice human-readable description of the change to 
  [CHANGELOG.md](../CHANGELOG.md)
