### PR TITLE
Update documentation for boxes_flow, allow None

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ python:
   - "3.7"
   - "3.8"
 install:
-  - pip install tox-travis flake8
+  - pip install tox==3.14.0 tox-travis flake8
 script:
   - tox -r

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Grouping of text lines outside of parent container bounding box ([#386](https://github.com/pdfminer/pdfminer.six/pull/386))
 
 ### Changed
+- Allow boxes_flow LAParam to be passed as None, validate the input, and update documentation ([#395](https://github.com/pdfminer/pdfminer.six/pull/395))
 - Group text lines if they are centered ([#382](https://github.com/pdfminer/pdfminer.six/pull/382))
 
 ## [20200124] - 2020-01-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- Allow boxes_flow LAParam to be passed as None, validate the input, and update documentation ([#395](https://github.com/pdfminer/pdfminer.six/pull/395))
+
 ### Fixed
 
 - Ignore ValueError when converting font encoding differences ([#389](https://github.com/pdfminer/pdfminer.six/pull/389))
 - Grouping of text lines outside of parent container bounding box ([#386](https://github.com/pdfminer/pdfminer.six/pull/386))
 
 ### Changed
-- Allow boxes_flow LAParam to be passed as None, validate the input, and update documentation ([#395](https://github.com/pdfminer/pdfminer.six/pull/395))
 - Group text lines if they are centered ([#382](https://github.com/pdfminer/pdfminer.six/pull/382))
 
 ## [20200124] - 2020-01-24

--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -29,10 +29,6 @@ class IndexAssigner:
         return
 
 
-class InvalidLaParamsException(Exception):
-    pass
-
-
 class LAParams:
     """Parameters for layout analysis
 
@@ -55,7 +51,7 @@ class LAParams:
         of a text matters when determining the order of text boxes. The value
         should be within the range of -1.0 (only horizontal position
         matters) to +1.0 (only vertical position matters). You can also pass
-        None to disable advanced layout analysis, and instead return text
+        `None` to disable advanced layout analysis, and instead return text
         based on the (x, y) coordinates of the bottom left corner.
     :param detect_vertical: If vertical text should be considered during
         layout analysis
@@ -79,19 +75,19 @@ class LAParams:
         self.detect_vertical = detect_vertical
         self.all_texts = all_texts
 
-        self.__validate()
+        self._validate()
         return
 
-    def __validate(self):
+    def _validate(self):
         # Validate boxes_flow
         if self.boxes_flow is not None:
             boxes_flow_err_msg = ("LAParam boxes_flow should be None, or a "
                                   "number between -1 and +1")
             if not (isinstance(self.boxes_flow, int) or
                     isinstance(self.boxes_flow, float)):
-                raise InvalidLaParamsException(boxes_flow_err_msg)
+                raise TypeError(boxes_flow_err_msg)
             if not -1 <= self.boxes_flow <= 1:
-                raise InvalidLaParamsException(boxes_flow_err_msg)
+                raise ValueError(boxes_flow_err_msg)
 
     def __repr__(self):
         return '<LAParams: char_margin=%.1f, line_margin=%.1f, ' \
@@ -804,21 +800,20 @@ class LTLayoutContainer(LTContainer):
         for obj in empties:
             obj.analyze(laparams)
         textboxes = list(self.group_textlines(laparams, textlines))
-        if laparams.boxes_flow is not None and \
-                -1 <= laparams.boxes_flow <= +1 and textboxes:
-            self.groups = self.group_textboxes(laparams, textboxes)
-            assigner = IndexAssigner()
-            for group in self.groups:
-                group.analyze(laparams)
-                assigner.run(group)
-            textboxes.sort(key=lambda box: box.index)
-        else:
+        if laparams.boxes_flow is None:
             def getkey(box):
                 if isinstance(box, LTTextBoxVertical):
                     return (0, -box.x1, box.y0)
                 else:
                     return (1, box.y0, box.x0)
             textboxes.sort(key=getkey)
+        else:
+            self.groups = self.group_textboxes(laparams, textboxes)
+            assigner = IndexAssigner()
+            for group in self.groups:
+                group.analyze(laparams)
+                assigner.run(group)
+            textboxes.sort(key=lambda box: box.index)
         self._objs = textboxes + otherobjs + empties
         return
 

--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -52,7 +52,7 @@ class LAParams:
         should be within the range of -1.0 (only horizontal position
         matters) to +1.0 (only vertical position matters). You can also pass
         `None` to disable advanced layout analysis, and instead return text
-        based on the (x, y) coordinates of the bottom left corner.
+        based on the position of the bottom left corner of the text box.
     :param detect_vertical: If vertical text should be considered during
         layout analysis
     :param all_texts: If layout analysis should be performed on text in
@@ -79,7 +79,6 @@ class LAParams:
         return
 
     def _validate(self):
-        # Validate boxes_flow
         if self.boxes_flow is not None:
             boxes_flow_err_msg = ("LAParam boxes_flow should be None, or a "
                                   "number between -1 and +1")

--- a/tools/pdf2txt.py
+++ b/tools/pdf2txt.py
@@ -120,7 +120,10 @@ def maketheparser():
         help="Specifies how much a horizontal and vertical position of a "
              "text matters when determining the order of lines. The value "
              "should be within the range of -1.0 (only horizontal position "
-             "matters) to +1.0 (only vertical position matters).")
+             "matters) to +1.0 (only vertical position matters). You can also "
+             "pass `None` to disable advanced layout analysis, and instead "
+             "return text based on the position of the bottom left corner of "
+             "the text box.")
     la_params.add_argument(
         "--all-texts", "-A", default=False, action="store_true",
         help="If layout analysis should be performed on text in figures.")


### PR DESCRIPTION
**Pull request**

Closes #395 

- Allows passing `boxes_flow` as `None` to disable the advanced layout analysis
- Updates the documentation to this effect (if you want me to call it something other than "advanced layout analysis - let me know!)
- I've added a private `__validate` method to `LAParams` to check that boxes flow is either `None`, or between `-1` and `+1`. Happy to remove this if you think it's excessive..

- I've NOT added any other checks about any other params to `__validate`. I'm happy to do this, but there don't seem to be any other specified ranges in the [docs](https://pdfminersix.readthedocs.io/en/latest/api/composable.html#laparams), so I'd just be checking the types, really.

**How Has This Been Tested?**

I checked before the change that passing `None` breaks, and after that it works (using `extract_pages`). The speed changes a lot without the extra layout analysis, so I could tell it was working. `tox` passes.

**Checklist**

- [X] I have added tests that prove my fix is effective or that my feature 
  works
- [X] I have added docstrings to newly created methods and classes
- [X] I have optimized the code at least one time after creating the initial 
  version
- [X] I have updated the [README.md](../README.md) or I am verified that this
  is not necessary
- [X] I have updated the [readthedocs](../docs/source) documentation or I 
  verified that this is not necessary
- [X] I have added a consice human-readable description of the change to 
  [CHANGELOG.md](../CHANGELOG.md)
