### PR TITLE
add shebang line to script in tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Group text lines if they are centered ([#382](https://github.com/pdfminer/pdfminer.six/pull/382))
+- Add shebang line to script in tools (pull request to come)
 
 ## [20200124] - 2020-01-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes in pdfminer.six will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Added
+
+- Python3 shebang line to script in tools ([408](https://github.com/pdfminer/pdfminer.six/pull/408)
+
 ## [20200402]
 
 ### Added
@@ -19,7 +25,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Group text lines if they are centered ([#382](https://github.com/pdfminer/pdfminer.six/pull/382))
-- Add shebang line to script in tools (pull request to come)
 
 ## [20200124] - 2020-01-24
 

--- a/pdfminer/psparser.py
+++ b/pdfminer/psparser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # -*- coding: utf-8 -*-
 

--- a/tests/test_pdfencoding.py
+++ b/tests/test_pdfencoding.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # -*- coding: utf-8 -*-
 

--- a/tools/conv_afm.py
+++ b/tools/conv_afm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import fileinput

--- a/tools/conv_cmap.py
+++ b/tools/conv_cmap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import pickle as pickle

--- a/tools/conv_glyphlist.py
+++ b/tools/conv_glyphlist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import fileinput

--- a/tools/dumppdf.py
+++ b/tools/dumppdf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Extract pdf structure in XML format"""
 import logging
 import os.path

--- a/tools/dumppdf.py
+++ b/tools/dumppdf.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """Extract pdf structure in XML format"""
 import logging
 import os.path

--- a/tools/pdf2txt.py
+++ b/tools/pdf2txt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """A command line tool for extracting text and images from PDF and
 output it to plain text, html, xml or tags."""
 import argparse

--- a/tools/pdf2txt.py
+++ b/tools/pdf2txt.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """A command line tool for extracting text and images from PDF and
 output it to plain text, html, xml or tags."""
 import argparse

--- a/tools/pdfdiff.py
+++ b/tools/pdfdiff.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 compares rwo pdf files.

--- a/tools/pdfstats.py
+++ b/tools/pdfstats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Exercise pdfminer, looking deeply into a PDF document,
 # print some stats to stdout

--- a/tools/pdfstats.py
+++ b/tools/pdfstats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 # Exercise pdfminer, looking deeply into a PDF document,
 # print some stats to stdout

--- a/tools/prof.py
+++ b/tools/prof.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 
 


### PR DESCRIPTION
This update fix https://github.com/pdfminer/pdfminer.six/issues/405. 

It enables to run the scripts in tools (especially pdf2txt.py and dumppdf.py) directly from terminal. 
