### PR TITLE
Fix spelling error

### DIFF
--- a/tools/pdfdiff.py
+++ b/tools/pdfdiff.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 """
-compares rwo pdf files.
+compares two pdf files.
 """
 import io
 import logging


### PR DESCRIPTION
* Change rwo to two in pdfdiff.py

**Pull request**

Thanks for improving pdfminer.six! Please include the following information to
help us discuss and merge this PR:

- A description of why this PR is needed. What does it fix? What does it 
  improve?
- A summary of the things that this PR changes.
- Reference the issues that this PR fixes (use the fixes #(issue nr) syntax). 
  If this PR does not fix any issue, create the issue first and mention that 
  you are willing to work on it.

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide 
instructions so we can reproduce. Include an example pdf if you have one. 

**Checklist**

- [ ] I have added tests that prove my fix is effective or that my feature 
  works
- [ ] I have added docstrings to newly created methods and classes
- [ ] I have optimized the code at least one time after creating the initial 
  version
- [ ] I have updated the [README.md](../README.md) or I am verified that this
  is not necessary
- [ ] I have updated the [readthedocs](../docs/source) documentation or I 
  verified that this is not necessary
- [ ] I have added a consice human-readable description of the change to 
  [CHANGELOG.md](../CHANGELOG.md)
