### PR TITLE
Check the obj type before calling the in operation

### DIFF
--- a/pdfminer/pdfinterp.py
+++ b/pdfminer/pdfinterp.py
@@ -837,7 +837,7 @@ class PDFPageInterpreter:
 
     def do_EI(self, obj):
         """End inline image object"""
-        if 'W' in obj and 'H' in obj:
+        if isinstance(obj, PDFStream) and 'W' in obj and 'H' in obj:
             iobjid = str(id(obj))
             self.device.begin_figure(iobjid, (0, 0, 1, 1), MATRIX_IDENTITY)
             self.device.render_image(iobjid, obj)


### PR DESCRIPTION
The object can be of type byte instead of PDFStream.
Without this type check, a python `TypeError` can be raised.

In the case that raised the error, the obj turns out to be:
```
b"\xd1\....."
```
of class `bytes`.