### PR TITLE
Restore PDFTextExtractionNotAllowed exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,17 @@ All notable changes in pdfminer.six will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [20200726]
+
+### Fixed
+- Rename PDFTextExtractionNotAllowedError to PDFTextExtractionNotAllowed to revert breaking change ([#461](https://github.com/pdfminer/pdfminer.six/pull/461))
+
 ## [20200720]
 
 ### Added
 - Support for painting multiple rectangles at once ([#371](https://github.com/pdfminer/pdfminer.six/pull/371))
 
-## Fixed
+### Fixed
 - Always try to get CMap, not only for identity encodings ([#438](https://github.com/pdfminer/pdfminer.six/pull/438))
 - Validate image object in do_EI is a PDFStream ([#451](https://github.com/pdfminer/pdfminer.six/pull/451))
 

--- a/pdfminer/pdfdocument.py
+++ b/pdfminer/pdfdocument.py
@@ -46,10 +46,16 @@ class PDFTextExtractionNotAllowedWarning(UserWarning):
     pass
 
 
-class PDFTextExtractionNotAllowedError(PDFEncryptionError):
+class PDFTextExtractionNotAllowed(PDFEncryptionError):
     pass
 
-PDFTextExtractionNotAllowed = PDFTextExtractionNotAllowedError
+
+class PDFTextExtractionNotAllowedError(PDFTextExtractionNotAllowed):
+    def __init__(self, *args):
+        from warnings import warn
+        warn('PDFTextExtractionNotAllowedError will be removed in the future. '
+             'Use PDFTextExtractionNotAllowed instead.', DeprecationWarning)
+        super().__init__(*args)
 
 
 # some predefined literals and keywords.

--- a/pdfminer/pdfdocument.py
+++ b/pdfminer/pdfdocument.py
@@ -49,6 +49,8 @@ class PDFTextExtractionNotAllowedWarning(UserWarning):
 class PDFTextExtractionNotAllowedError(PDFEncryptionError):
     pass
 
+PDFTextExtractionNotAllowed = PDFTextExtractionNotAllowedError
+
 
 # some predefined literals and keywords.
 LITERAL_OBJSTM = LIT('ObjStm')


### PR DESCRIPTION
Restore PDFTextExtractionNotAllowed  exception class as an alias of the
new PDFTextExtractionNotAllowedError exception that was introduced in
https://github.com/pdfminer/pdfminer.six/commit/6a9269b432b861fdd8de6f532759833faf9a9159

Removing PDFTextExtractionNotAllowed is an API breakage that made
several tools fail break.

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>