### PR TITLE
Use Python3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 PACKAGE=pdfminer
 
-PYTHON=python
+PYTHON=python3
 GIT=git
 RM=rm -f
 CP=cp -f
@@ -55,4 +55,4 @@ $(CMAPDST)/to-unicode-Adobe-Korea1.pickle.gz: $(CMAPDST)
 		$(CMAPDST) Adobe-Korea1 $(CMAPSRC)/cid2code_Adobe_Korea1.txt
 
 test: cmap
-	nosetests
+	nosetests3


### PR DESCRIPTION
Hi everyone,

Python2 is now EOL and the most of distribution (Debian i.e) will be start
use python3  as default and python2 package will no be suported.

In this PR I send this patch that we are using on Debian
https://salsa.debian.org/python-team/modules/pdfminer/-/blob/debian/master/debian/patches/0001-Update-patch-use-Python3.patch

Please consider apply it.

Cheers
<!-- 
**Pull request**

Thanks for improving pdfminer.six! Please include the following information to
help us discuss and merge this PR:

- A description of why this PR is needed. What does it fix? What does it 
  improve?
- A summary of the things that this PR changes.
- Reference the issues that this PR fixes (use the fixes #(issue nr) syntax). 
  If this PR does not fix any issue, create the issue first and mention that 
  you are willing to work on it.

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide 
instructions so we can reproduce. Include an example pdf if you have one. 

**Checklist**

- [ ] I have added tests that prove my fix is effective or that my feature 
  works
- [ ] I have added docstrings to newly created methods and classes
- [ ] I have optimized the code at least one time after creating the initial 
  version
- [ ] I have updated the [README.md](../README.md) or I am verified that this
  is not necessary
- [ ] I have updated the [readthedocs](../docs/source) documentation or I 
  verified that this is not necessary
- [ ] I have added a consice human-readable description of the change to 
  [CHANGELOG.md](../CHANGELOG.md)
-->