### PR TITLE
Functionality is added to be able to separate words with more than one space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@ All notable changes in pdfminer.six will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [20200811]
+## [UNRELEASED]
 ### Added
-- functionality is added to be able to separate words with more than one space. This can be used to separate words, which already contain spaces as a part of them (e.g. to separate numbers, which have space as a decimal separator)
+- functionality is added to be able to separate words with more than one space. This can be used to separate words, which already contain spaces as a part of them (e.g. to separate numbers, which have space as a thousand separator)
 
 ## [20200726]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes in pdfminer.six will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [20200811]
+### Added
+- functionality is added to be able to separate words with more than one space. This can be used to separate words, which already contain spaces as a part of them (e.g. to separate numbers, which have space as a decimal separator)
+
 ## [20200726]
 
 ### Fixed

--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -40,8 +40,8 @@ class LAParams:
         specified relative to the width of the character.
     :param word_margin: If two characters on the same line are further apart
         than this margin then they are considered to be two separate words, and
-        an intermediate space will be added for readability. The margin is
-        specified relative to the width of the character.
+        an intermediate spaces (with amount equal to qnt_spaces_between_words) will be added for readability.
+        The margin is specified relative to the width of the character.
     :param line_margin: If two lines are are close together they are
         considered to be part of the same paragraph. The margin is
         specified relative to the height of a line.
@@ -55,6 +55,9 @@ class LAParams:
         layout analysis
     :param all_texts: If layout analysis should be performed on text in
         figures.
+    :param qnt_spaces_between_words: quantity of spaces, which will be added between words for readability.
+        More than one space can be used, to separate words, which already have spaces in them
+        (e.g. to separate numbers, which have space as a decimal separator)
     """
 
     def __init__(self,
@@ -63,9 +66,9 @@ class LAParams:
                  line_margin=0.5,
                  word_margin=0.1,
                  boxes_flow=0.5,
-                 qnt_spaces_between_words=1,
                  detect_vertical=False,
-                 all_texts=False):
+                 all_texts=False,
+                 qnt_spaces_between_words=1):
         self.line_overlap = line_overlap
         self.char_margin = char_margin
         self.line_margin = line_margin

--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -63,6 +63,7 @@ class LAParams:
                  line_margin=0.5,
                  word_margin=0.1,
                  boxes_flow=0.5,
+                 qnt_spaces_between_words=1,
                  detect_vertical=False,
                  all_texts=False):
         self.line_overlap = line_overlap
@@ -72,6 +73,7 @@ class LAParams:
         self.boxes_flow = boxes_flow
         self.detect_vertical = detect_vertical
         self.all_texts = all_texts
+        self.qnt_spaces_between_words = qnt_spaces_between_words
 
         self._validate()
         return
@@ -413,16 +415,17 @@ class LTTextLine(LTTextContainer):
 
 
 class LTTextLineHorizontal(LTTextLine):
-    def __init__(self, word_margin):
+    def __init__(self, word_margin, qnt_spaces_between_words):
         LTTextLine.__init__(self, word_margin)
         self._x1 = +INF
+        self.qnt_spaces_between_words = qnt_spaces_between_words
         return
-
+    #TODO: edit here
     def add(self, obj):
         if isinstance(obj, LTChar) and self.word_margin:
             margin = self.word_margin * max(obj.width, obj.height)
             if self._x1 < obj.x0 - margin:
-                LTContainer.add(self, LTAnno(' '))
+                LTContainer.add(self, LTAnno(' ' * self.qnt_spaces_between_words))
         self._x1 = obj.x1
         LTTextLine.add(self, obj)
         return
@@ -656,17 +659,17 @@ class LTLayoutContainer(LTContainer):
                         line.add(obj0)
                         line.add(obj1)
                     elif halign and not valign:
-                        line = LTTextLineHorizontal(laparams.word_margin)
+                        line = LTTextLineHorizontal(laparams.word_margin, laparams.qnt_spaces_between_words)
                         line.add(obj0)
                         line.add(obj1)
                     else:
-                        line = LTTextLineHorizontal(laparams.word_margin)
+                        line = LTTextLineHorizontal(laparams.word_margin, laparams.qnt_spaces_between_words)
                         line.add(obj0)
                         yield line
                         line = None
             obj0 = obj1
         if line is None:
-            line = LTTextLineHorizontal(laparams.word_margin)
+            line = LTTextLineHorizontal(laparams.word_margin, laparams.qnt_spaces_between_words)
             line.add(obj0)
         yield line
         return

--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -55,7 +55,7 @@ class LAParams:
         layout analysis
     :param all_texts: If layout analysis should be performed on text in
         figures.
-    :param qnt_spaces_between_words: quantity of spaces, which will be added between words for readability.
+    :param qnt_spaces_between_words: quantity of spaces, which will be inserted between words for readability.
         More than one space can be used, to separate words, which already have spaces in them
         (e.g. to separate numbers, which have space as a decimal separator)
     """
@@ -423,7 +423,7 @@ class LTTextLineHorizontal(LTTextLine):
         self._x1 = +INF
         self.qnt_spaces_between_words = qnt_spaces_between_words
         return
-    #TODO: edit here
+
     def add(self, obj):
         if isinstance(obj, LTChar) and self.word_margin:
             margin = self.word_margin * max(obj.width, obj.height)

--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -40,7 +40,8 @@ class LAParams:
         specified relative to the width of the character.
     :param word_margin: If two characters on the same line are further apart
         than this margin then they are considered to be two separate words, and
-        an intermediate spaces (with amount equal to qnt_spaces_between_words) will be added for readability.
+        an intermediate spaces (with amount equal to qnt_spaces)
+        will be added for readability.
         The margin is specified relative to the width of the character.
     :param line_margin: If two lines are are close together they are
         considered to be part of the same paragraph. The margin is
@@ -55,9 +56,10 @@ class LAParams:
         layout analysis
     :param all_texts: If layout analysis should be performed on text in
         figures.
-    :param qnt_spaces_between_words: quantity of spaces, which will be inserted between words for readability.
-        More than one space can be used, to separate words, which already have spaces in them
-        (e.g. to separate numbers, which have space as a decimal separator)
+    :param qnt_spaces: quantity of spaces, which will be inserted
+        between words for readability. More than one space can be used, to
+        separate words, which already have spaces in them. (e.g. to separate
+        numbers, which have space as a thousand separator)
     """
 
     def __init__(self,
@@ -68,7 +70,7 @@ class LAParams:
                  boxes_flow=0.5,
                  detect_vertical=False,
                  all_texts=False,
-                 qnt_spaces_between_words=1):
+                 qnt_spaces=1):
         self.line_overlap = line_overlap
         self.char_margin = char_margin
         self.line_margin = line_margin
@@ -76,7 +78,7 @@ class LAParams:
         self.boxes_flow = boxes_flow
         self.detect_vertical = detect_vertical
         self.all_texts = all_texts
-        self.qnt_spaces_between_words = qnt_spaces_between_words
+        self.qnt_spaces = qnt_spaces
 
         self._validate()
         return
@@ -418,17 +420,18 @@ class LTTextLine(LTTextContainer):
 
 
 class LTTextLineHorizontal(LTTextLine):
-    def __init__(self, word_margin, qnt_spaces_between_words):
+    def __init__(self, word_margin, qnt_spaces):
         LTTextLine.__init__(self, word_margin)
         self._x1 = +INF
-        self.qnt_spaces_between_words = qnt_spaces_between_words
+        self.qnt_spaces = qnt_spaces
         return
 
     def add(self, obj):
         if isinstance(obj, LTChar) and self.word_margin:
             margin = self.word_margin * max(obj.width, obj.height)
             if self._x1 < obj.x0 - margin:
-                LTContainer.add(self, LTAnno(' ' * self.qnt_spaces_between_words))
+                LTContainer.add(self,
+                                LTAnno(' ' * self.qnt_spaces))
         self._x1 = obj.x1
         LTTextLine.add(self, obj)
         return
@@ -662,17 +665,20 @@ class LTLayoutContainer(LTContainer):
                         line.add(obj0)
                         line.add(obj1)
                     elif halign and not valign:
-                        line = LTTextLineHorizontal(laparams.word_margin, laparams.qnt_spaces_between_words)
+                        line = LTTextLineHorizontal(laparams.word_margin,
+                                                    laparams.qnt_spaces)
                         line.add(obj0)
                         line.add(obj1)
                     else:
-                        line = LTTextLineHorizontal(laparams.word_margin, laparams.qnt_spaces_between_words)
+                        line = LTTextLineHorizontal(laparams.word_margin,
+                                                    laparams.qnt_spaces)
                         line.add(obj0)
                         yield line
                         line = None
             obj0 = obj1
         if line is None:
-            line = LTTextLineHorizontal(laparams.word_margin, laparams.qnt_spaces_between_words)
+            line = LTTextLineHorizontal(laparams.word_margin,
+                                        laparams.qnt_spaces)
             line.add(obj0)
         yield line
         return

--- a/tests/test_highlevel_extracttext.py
+++ b/tests/test_highlevel_extracttext.py
@@ -27,9 +27,9 @@ test_strings = {
     "simple1.pdf_no_boxes_flow": "Hello \n\nWorld\n\nHello \n\nWorld\n\n"
                                  "H e l l o  \n\nW o r l d\n\n"
                                  "H e l l o  \n\nW o r l d\n\n\f",
-    "simple1.pdf_2_spaces_as_word_separator": "Hello \n\nWorld\n\nHello \n\nWorld\n\n"
-                                              "H  e  l  l  o   \n\nW  o  r  l  d\n\n"
-                                              "H  e  l  l  o   \n\nW  o  r  l  d\n\n\f",
+    "simple1.pdf_2_spaces_as_sep": "Hello \n\nWorld\n\nHello \n\nWorld\n\n"
+                                   "H  e  l  l  o   \n\nW  o  r  l  d\n\n"
+                                   "H  e  l  l  o   \n\nW  o  r  l  d\n\n\f",
     "simple2.pdf": "\f",
     "simple3.pdf": "Hello\n\nHello\nあ\nい\nう\nえ\nお\nあ\nい\nう\nえ\nお\n"
                    "World\n\nWorld\n\n\f",
@@ -50,8 +50,9 @@ class TestExtractText(unittest.TestCase):
 
     def test_simple1_2_spaces_as_word_separator(self):
         test_file = "simple1.pdf"
-        s = run_with_string(test_file, laparams={"boxes_flow": None, "qnt_spaces_between_words": 2})
-        self.assertEqual(s, test_strings["simple1.pdf_2_spaces_as_word_separator"])
+        s = run_with_string(test_file, laparams={"boxes_flow": None,
+                                                 "qnt_spaces": 2})
+        self.assertEqual(s, test_strings["simple1.pdf_2_spaces_as_sep"])
 
     def test_simple2_with_string(self):
         test_file = "simple2.pdf"

--- a/tests/test_highlevel_extracttext.py
+++ b/tests/test_highlevel_extracttext.py
@@ -27,6 +27,9 @@ test_strings = {
     "simple1.pdf_no_boxes_flow": "Hello \n\nWorld\n\nHello \n\nWorld\n\n"
                                  "H e l l o  \n\nW o r l d\n\n"
                                  "H e l l o  \n\nW o r l d\n\n\f",
+    "simple1.pdf_2_spaces_as_word_separator": "Hello \n\nWorld\n\nHello \n\nWorld\n\n"
+                                              "H  e  l  l  o   \n\nW  o  r  l  d\n\n"
+                                              "H  e  l  l  o   \n\nW  o  r  l  d\n\n\f",
     "simple2.pdf": "\f",
     "simple3.pdf": "Hello\n\nHello\nあ\nい\nう\nえ\nお\nあ\nい\nう\nえ\nお\n"
                    "World\n\nWorld\n\n\f",
@@ -44,6 +47,11 @@ class TestExtractText(unittest.TestCase):
         test_file = "simple1.pdf"
         s = run_with_string(test_file, laparams={"boxes_flow": None})
         self.assertEqual(s, test_strings["simple1.pdf_no_boxes_flow"])
+
+    def test_simple1_2_spaces_as_word_separator(self):
+        test_file = "simple1.pdf"
+        s = run_with_string(test_file, laparams={"boxes_flow": None, "qnt_spaces_between_words": 2})
+        self.assertEqual(s, test_strings["simple1.pdf_2_spaces_as_word_separator"])
 
     def test_simple2_with_string(self):
         test_file = "simple2.pdf"

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -18,9 +18,9 @@ class TestGroupTextLines(unittest.TestCase):
         """
         laparams = LAParams()
         layout = LTLayoutContainer((0, 0, 50, 50))
-        line1 = LTTextLineHorizontal(laparams.word_margin, laparams.qnt_spaces_between_words)
+        line1 = LTTextLineHorizontal(laparams.word_margin, laparams.qnt_spaces)
         line1.set_bbox((0, 0, 50, 5))
-        line2 = LTTextLineHorizontal(laparams.word_margin, laparams.qnt_spaces_between_words)
+        line2 = LTTextLineHorizontal(laparams.word_margin, laparams.qnt_spaces)
         line2.set_bbox((0, 50, 50, 55))
         lines = [line1, line2]
 
@@ -34,28 +34,32 @@ class TestFindNeigbors(unittest.TestCase):
         laparams = LAParams()
         plane = Plane((0, 0, 50, 50))
 
-        line = LTTextLineHorizontal(laparams.word_margin, laparams.qnt_spaces_between_words)
+        line = LTTextLineHorizontal(laparams.word_margin, laparams.qnt_spaces)
         line.set_bbox((10, 4, 20, 6))
         plane.add(line)
 
-        left_aligned_above = LTTextLineHorizontal(laparams.word_margin, laparams.qnt_spaces_between_words)
+        left_aligned_above = LTTextLineHorizontal(laparams.word_margin,
+                                                  laparams.qnt_spaces)
         left_aligned_above.set_bbox((10, 6, 15, 8))
         plane.add(left_aligned_above)
 
-        right_aligned_below = LTTextLineHorizontal(laparams.word_margin, laparams.qnt_spaces_between_words)
+        right_aligned_below = LTTextLineHorizontal(laparams.word_margin,
+                                                   laparams.qnt_spaces)
         right_aligned_below.set_bbox((15, 2, 20, 4))
         plane.add(right_aligned_below)
 
         centrally_aligned_overlapping = LTTextLineHorizontal(
-            laparams.word_margin, laparams.qnt_spaces_between_words)
+            laparams.word_margin, laparams.qnt_spaces)
         centrally_aligned_overlapping.set_bbox((13, 5, 17, 7))
         plane.add(centrally_aligned_overlapping)
 
-        not_aligned = LTTextLineHorizontal(laparams.word_margin, laparams.qnt_spaces_between_words)
+        not_aligned = LTTextLineHorizontal(laparams.word_margin,
+                                           laparams.qnt_spaces)
         not_aligned.set_bbox((0, 6, 5, 8))
         plane.add(not_aligned)
 
-        wrong_height = LTTextLineHorizontal(laparams.word_margin, laparams.qnt_spaces_between_words)
+        wrong_height = LTTextLineHorizontal(laparams.word_margin,
+                                            laparams.qnt_spaces)
         wrong_height.set_bbox((10, 6, 15, 10))
         plane.add(wrong_height)
 

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -18,9 +18,9 @@ class TestGroupTextLines(unittest.TestCase):
         """
         laparams = LAParams()
         layout = LTLayoutContainer((0, 0, 50, 50))
-        line1 = LTTextLineHorizontal(laparams.word_margin)
+        line1 = LTTextLineHorizontal(laparams.word_margin, laparams.qnt_spaces_between_words)
         line1.set_bbox((0, 0, 50, 5))
-        line2 = LTTextLineHorizontal(laparams.word_margin)
+        line2 = LTTextLineHorizontal(laparams.word_margin, laparams.qnt_spaces_between_words)
         line2.set_bbox((0, 50, 50, 55))
         lines = [line1, line2]
 
@@ -34,28 +34,28 @@ class TestFindNeigbors(unittest.TestCase):
         laparams = LAParams()
         plane = Plane((0, 0, 50, 50))
 
-        line = LTTextLineHorizontal(laparams.word_margin)
+        line = LTTextLineHorizontal(laparams.word_margin, laparams.qnt_spaces_between_words)
         line.set_bbox((10, 4, 20, 6))
         plane.add(line)
 
-        left_aligned_above = LTTextLineHorizontal(laparams.word_margin)
+        left_aligned_above = LTTextLineHorizontal(laparams.word_margin, laparams.qnt_spaces_between_words)
         left_aligned_above.set_bbox((10, 6, 15, 8))
         plane.add(left_aligned_above)
 
-        right_aligned_below = LTTextLineHorizontal(laparams.word_margin)
+        right_aligned_below = LTTextLineHorizontal(laparams.word_margin, laparams.qnt_spaces_between_words)
         right_aligned_below.set_bbox((15, 2, 20, 4))
         plane.add(right_aligned_below)
 
         centrally_aligned_overlapping = LTTextLineHorizontal(
-            laparams.word_margin)
+            laparams.word_margin, laparams.qnt_spaces_between_words)
         centrally_aligned_overlapping.set_bbox((13, 5, 17, 7))
         plane.add(centrally_aligned_overlapping)
 
-        not_aligned = LTTextLineHorizontal(laparams.word_margin)
+        not_aligned = LTTextLineHorizontal(laparams.word_margin, laparams.qnt_spaces_between_words)
         not_aligned.set_bbox((0, 6, 5, 8))
         plane.add(not_aligned)
 
-        wrong_height = LTTextLineHorizontal(laparams.word_margin)
+        wrong_height = LTTextLineHorizontal(laparams.word_margin, laparams.qnt_spaces_between_words)
         wrong_height.set_bbox((10, 6, 15, 10))
         plane.add(wrong_height)
 


### PR DESCRIPTION
**Pull request**

Functionality is added to be able to separate words with more than one space. 

For this a new parameter is added to LAParams
**qnt_spaces** - quantity of spaces, which will be inserted between words for readability. More than one space can be used, to separate words, which already have spaces in them. (e.g. to separate numbers, which have space as a thousand separator)

Default value for qnt_spaces = 1, so change is backwards compatible and  all existing tests pass


Example in case space is used as thousand separator:

Original PDF:
```
30 123.17               60 456.87
```

text, converted with pdfminer.six without this fix (one space is used as a word separator, and it is not changeable):
```
30 123.17 60 456.87
```


text, converted with pdfminer.six with this fix (possible to optionally add more than one space between words):
```
30 123.17        60 456.87
```


This resolves this issue: https://github.com/pdfminer/pdfminer.six/issues/366

**How Has This Been Tested?**

Test is added to test this new functionality

test_highlevel_extracttext.py ==> test_simple1_2_spaces_as_word_separator

**Checklist**

- [x] I have added tests that prove my fix is effective or that my feature 
  works
- [x] I have added docstrings to newly created methods and classes
- [x] I have optimized the code at least one time after creating the initial 
  version
- [x] I have updated the [README.md](../README.md) or I am verified that this
  is not necessary
- [x] I have updated the [readthedocs](../docs/source) documentation or I 
  verified that this is not necessary
- [x] I have added a consice human-readable description of the change to 
  [CHANGELOG.md](../CHANGELOG.md)
