### PR TITLE
bugfix PDFObjRef is not iterable

### DIFF
--- a/pdfminer/pdftypes.py
+++ b/pdfminer/pdftypes.py
@@ -294,7 +294,7 @@ class PDFStream(PDFObject):
             else:
                 raise PDFNotImplementedError('Unsupported filter: %r' % f)
             # apply predictors
-            if params and 'Predictor' in params:
+            if isinstance(params, dict) and 'Predictor' in params:
                 pred = int_value(params['Predictor'])
                 if pred == 1:
                     # no predictor


### PR DESCRIPTION
Sadly, I cannot upload the problematic PDFs due a non-disclosure agreement. I can however point out the issue and share my fix.

When trying to instantiate a PDFCIDFont object at:
https://github.com/pdfminer/pdfminer.six/blob/0b44f7771462363528c109f263276eb254c4fcd0/pdfminer/pdfinterp.py#L193

Where
```
self
<pdfminer.pdfinterp.PDFResourceManager at 0x7f0c80493048>

spec
{'Type': /'Font',
 'Subtype': /'CIDFontType2',
 'BaseFont': /'ISOCPEUR',
 'FontDescriptor': <PDFObjRef:5>,
 'CIDSystemInfo': <PDFObjRef:41>,
 'W': <PDFObjRef:13>,
 'Encoding': /'Identity-H'}
```

The execution ends up at PDFStream.decode with:
```
self
<PDFStream(7): raw=8963, {'Length1': 28048, 'Length': 8961, 'Filter': /'FlateDecode', 'DecodeParms': <PDFObjRef:39>}>
```

The origin of the bug is that in this case, `get_filters(self)`
https://github.com/pdfminer/pdfminer.six/blob/0b44f7771462363528c109f263276eb254c4fcd0/pdfminer/pdftypes.py#L258

returns:
```
 In[8]: filters
Out[8]: [(/'FlateDecode', <PDFObjRef:39>)]
```

As you can see, the second element of the first and only Tuple is a `PDFObjRef`, which is then saved to `params`  and fails a little later down the line when trying to evaluate `'Predictor' in params:`
https://github.com/pdfminer/pdfminer.six/blob/0b44f7771462363528c109f263276eb254c4fcd0/pdfminer/pdftypes.py#L297

I noticed that the default value of `params` is an empty dictionary, which effectively skips that check. So I extended the check to only continue if `params` was a dictionary:
https://github.com/imochoa/pdfminer.six/blob/2d996c9ae26c8a336711178a8afe3091e1140970/pdfminer/pdftypes.py#L297


I think the underlying error is the fact that `get_filters(self)` is returning a PDFObjRef instead of a dictionary. I've tried to find the exact origin, but I'm not too familiar with the project and couldn't pinpoint the exact issue. The furthest I got was that `PDFParser` was that the problematic `<PDFObjRef:39>`  value was being set at the dictionary in:
https://github.com/pdfminer/pdfminer.six/blob/0b44f7771462363528c109f263276eb254c4fcd0/pdfminer/pdfparser.py#L122

as:
```
dic['DecodeParms']
<PDFObjRef:39>
```


Since I couldn't prevent it from coming up, refining the check seemed like the next best option and it works well on the 2 problematic PDFs I have.