### PR TITLE
Fix out-of-bound access on some PDFs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Pass caching parameter to PDFResourceManager in `high_level` functions ([#475](https://github.com/pdfminer/pdfminer.six/pull/475))
+- Fix out-of-bound access on some PDFs ([#483](https://github.com/pdfminer/pdfminer.six/pull/483))
 
 ### Removed
 - Remove unused rijndael encryption implementation ([#465](https://github.com/pdfminer/pdfminer.six/pull/465))

--- a/pdfminer/pdfdocument.py
+++ b/pdfminer/pdfdocument.py
@@ -669,7 +669,7 @@ class PDFDocument:
             while kwd is not self.KEYWORD_OBJ:
                 (_, kwd) = self._parser.nexttoken()
                 x.append(kwd)
-            if x:
+            if len(x) >= 2:
                 objid1 = x[-2]
         # #### end hack around malformed pdf files
         if objid1 != objid:


### PR DESCRIPTION
Replace the non-emptiness check with a minimum length check — you can't get the second to last item in a list of less than two items.
