### PR TITLE
Fix issue #136

### DIFF
--- a/pdfminer/pdfinterp.py
+++ b/pdfminer/pdfinterp.py
@@ -333,6 +333,8 @@ class PDFPageInterpreter:
         def get_colorspace(spec):
             if isinstance(spec, list):
                 name = literal_name(spec[0])
+            elif isinstance(spec, dict):
+                name = literal_name(list(spec.values())[0])                
             else:
                 name = literal_name(spec)
             if name == 'ICCBased' and isinstance(spec, list) \


### PR DESCRIPTION
The function get_colorspace(spec) might be called with a Dict causing an unhandled TypeError: unhashable type: 'dict'.
This change tries to handles a Dict in a similar way then Lists are handled.

See https://github.com/pdfminer/pdfminer.six/issues/136

**Pull request**

Thanks for improving pdfminer.six! Please include the following information to
help us discuss and merge this PR:

- A description of why this PR is needed. What does it fix? What does it 
  improve?
- A summary of the things that this PR changes.
- Reference the issues that this PR fixes (use the fixes #(issue nr) syntax). 
  If this PR does not fix any issue, create the issue first and mention that 
  you are willing to work on it.

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide 
instructions so we can reproduce. Include an example pdf if you have one. 

**Checklist**

- [ ] I have added tests that prove my fix is effective or that my feature 
  works
- [ ] I have added docstrings to newly created methods and classes
- [ ] I have optimized the code at least one time after creating the initial 
  version
- [ ] I have updated the [README.md](../README.md) or I am verified that this
  is not necessary
- [ ] I have updated the [readthedocs](../docs/source) documentation or I 
  verified that this is not necessary
- [ ] I have added a consice human-readable description of the change to 
  [CHANGELOG.md](../CHANGELOG.md)
