### PR TITLE
Handle XREFs with missing startxref after trailer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes in pdfminer.six will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [20200909]
+
+### Fixed
+- Handle XREF trailer not terminated with a startxref ([#493](https://github.com/pdfminer/pdfminer.six/issues/493))
+
 ## [20200726]
 
 ### Fixed

--- a/pdfminer/pdfdocument.py
+++ b/pdfminer/pdfdocument.py
@@ -135,7 +135,7 @@ class PDFXRef(PDFBaseXRef):
         try:
             (_, kwd) = parser.nexttoken()
             assert kwd is KWD(b'trailer'), str(kwd)
-            (_, dic) = parser.nextobject()
+            (_, dic) = parser.nextobject(True)
         except PSEOF:
             x = parser.pop(1)
             if not x:

--- a/pdfminer/psparser.py
+++ b/pdfminer/psparser.py
@@ -555,7 +555,7 @@ class PSStackParser(PSBaseParser):
     def do_keyword(self, pos, token):
         return
 
-    def nextobject(self):
+    def nextobject(self, dict_end_produces_result = False):
         """Yields a list of objects.
 
         Arrays and dictionaries are represented as Python lists and
@@ -590,7 +590,11 @@ class PSStackParser(PSBaseParser):
                         raise PSSyntaxError(error_msg)
                     d = {literal_name(k): v
                          for (k, v) in choplist(2, objs) if v is not None}
-                    self.push((pos, d))
+                    if dict_end_produces_result and not self.context:
+                      self.add_results((pos, d))
+                    else:
+                      self.push((pos, d))
+
                 except PSTypeError:
                     if settings.STRICT:
                         raise

--- a/samples/missing_xref_trailer.pdf
+++ b/samples/missing_xref_trailer.pdf
@@ -1,0 +1,117 @@
+%PDF-1.3
+1 0 obj
+<</Type /Catalog /Pages 2 0 R>>
+endobj
+2 0 obj
+<</Type /Pages /Parent 6 0 R /Kids [3 0 R] /Count 1>>
+endobj
+3 0 obj
+<</Type /Page /MediaBox [0 0 612.00 792.00] /Parent 2 0 R /Resources <</Font <</F1 <</Type /Font /Subtype /Type1 /BaseFont /Helvetica>>>>>> /Contents 4 0 R>>
+endobj
+4 0 obj
+<</Length 37>>
+stream
+BT
+/F1 10 Tf
+10 400 Td
+(Page1) Tj
+ET
+endstream
+endobj
+xref
+0 5
+0000000000 65535 f
+0000000009 00000 n
+0000000056 00000 n
+0000000125 00000 n
+0000000298 00000 n
+trailer
+<</Root 1 0 R /Size 5>>
+%LOL
+5 0 obj
+<</Type /Catalog /Pages 6 0 R>>
+endobj
+6 0 obj
+<</Type /Pages /Parent 10 0 R /Kids [2 0 R 7 0 R] /Count 2>>
+endobj
+7 0 obj
+<</Type /Page /MediaBox [0 0 612.00 792.00] /Parent 6 0 R /Resources <</Font <</F1 <</Type /Font /Subtype /Type1 /BaseFont /Helvetica>>>>>> /Contents 8 0 R>>
+endobj
+8 0 obj
+<</Length 37>>
+stream
+BT
+/F1 10 Tf
+10 400 Td
+(Page2) Tj
+ET
+endstream
+endobj
+xref
+5 4
+0000000523 00000 n
+0000000570 00000 n
+0000000646 00000 n
+0000000819 00000 n
+trailer
+<</Root 5 0 R /Size 9 /Prev 382>>
+%LOL
+9 0 obj
+<</Type /Catalog /Pages 10 0 R>>
+endobj
+10 0 obj
+<</Type /Pages /Parent 14 0 R /Kids [6 0 R 11 0 R] /Count 3>>
+endobj
+11 0 obj
+<</Type /Page /MediaBox [0 0 612.00 792.00] /Parent 10 0 R /Resources <</Font <</F1 <</Type /Font /Subtype /Type1 /BaseFont /Helvetica>>>>>> /Contents 12 0 R>>
+endobj
+12 0 obj
+<</Length 37>>
+stream
+BT
+/F1 10 Tf
+10 400 Td
+(Page3) Tj
+ET
+endstream
+endobj
+xref
+9 4
+0000001035 00000 n
+0000001083 00000 n
+0000001161 00000 n
+0000001337 00000 n
+trailer
+<</Root 9 0 R /Size 13 /Prev 903>>
+%LOL
+13 0 obj
+<</Type /Catalog /Pages 14 0 R>>
+endobj
+14 0 obj
+<</Type /Pages /Parent 13 0 R /Kids [10 0 R 15 0 R] /Count 4>>
+endobj
+15 0 obj
+<</Type /Page /MediaBox [0 0 612.00 792.00] /Parent 14 0 R /Resources <</Font <</F1 <</Type /Font /Subtype /Type1 /BaseFont /Helvetica>>>>>> /Contents 16 0 R>>
+endobj
+16 0 obj
+<</Length 37>>
+stream
+BT
+/F1 10 Tf
+10 400 Td
+(Page4) Tj
+ET
+endstream
+endobj
+xref
+13 4
+0000001555 00000 n
+0000001604 00000 n
+0000001683 00000 n
+0000001859 00000 n
+trailer
+<</Root 13 0 R /Size 17 /Prev 1422>>
+%LOL
+startxref
+1944
+%%EOF

--- a/tests/test_tools_pdf2txt.py
+++ b/tests/test_tools_pdf2txt.py
@@ -15,9 +15,18 @@ def run(sample_path, options=None):
         else:
             s = 'pdf2txt -o{} {}'.format(output_file.name, absolute_path)
         pdf2txt.main(s.split(' ')[1:])
+        with open(output_file.name) as f:
+          return f.read()
 
 
 class TestPdf2Txt():
+    def test_missing_xref_trailer(self):
+        contents = run('missing_xref_trailer.pdf')
+        assert "Page1" in contents
+        assert "Page2" in contents
+        assert "Page3" in contents
+        assert "Page4" in contents
+
     def test_jo(self):
         run('jo.pdf')
 


### PR DESCRIPTION
This is a fix for: https://github.com/pdfminer/pdfminer.six/issues/493

====

**How Has This Been Tested?**

I have included a sample PDF that is similar in structure to the PDF that was creating the problem.

**Checklist**

- [x] I have added tests that prove my fix is effective or that my feature 
  works
- [ ] I have added docstrings to newly created methods and classes
- [ ] I have optimized the code at least one time after creating the initial 
  version
- [ ] I have updated the [README.md](../README.md) or I am verified that this
  is not necessary
- [ ] I have updated the [readthedocs](../docs/source) documentation or I 
  verified that this is not necessary
- [x] I have added a consice human-readable description of the change to 
  [CHANGELOG.md](../CHANGELOG.md)
