### PR TITLE
Deprecate Python 3.4 and 3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Deprecated
+- Support for Python 3.4 and 3.5 ([#503](https://github.com/pdfminer/pdfminer.six/pull/503))
+
 ### Added
 - Support for `pathlib.PurePath` in `open_filename` ([#491](https://github.com/pdfminer/pdfminer.six/issues/491))
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Features
 How to use
 ----------
 
- * Install Python 3.4 or newer
+ * Install Python 3.6 or newer (3.4 and 3.5 are deprecated)
  * Install
 
     `pip install pdfminer.six`

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -57,7 +57,7 @@ Features
 Installation instructions
 =========================
 
-Before using it, you must install it using Python 3.4 or newer.
+Before using it, you must install it using Python 3.6 or newer (3.4 and 3.5 are deprecated).
 
 ::
 

--- a/pdfminer/__init__.py
+++ b/pdfminer/__init__.py
@@ -1,4 +1,12 @@
+import sys
+import warnings
+
+
 __version__ = '20200726'
+
+if sys.version_info < (3, 6):
+    warnings.warn('Python 3.4 and 3.5 are deprecated. '
+                  'Please upgrade to Python 3.6 or newer.')
 
 if __name__ == '__main__':
     print(__version__)


### PR DESCRIPTION
**Pull request**

For issue #503
This code is based on 3fbaa574938e1588da9167ddc913b17f3ff80a40.

**How Has This Been Tested?**

I tested in my environment.

**Checklist**

- [ ] I have added tests that prove my fix is effective or that my feature 
  works
- [ ] I have added docstrings to newly created methods and classes
- [x] I have optimized the code at least one time after creating the initial 
  version
- [x] I have updated the [README.md](../README.md) or I am verified that this
  is not necessary
- [x] I have updated the [readthedocs](../docs/source) documentation or I 
  verified that this is not necessary
- [x] I have added a consice human-readable description of the change to 
  [CHANGELOG.md](../CHANGELOG.md)
