### PR TITLE
Fix for when 'trailer' is indented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Rename PDFTextExtractionNotAllowedError to PDFTextExtractionNotAllowed to revert breaking change ([#461](https://github.com/pdfminer/pdfminer.six/pull/461))
 - Always try to get CMap, not only for identity encodings ([#438](https://github.com/pdfminer/pdfminer.six/pull/438))
+- Fix a bug where 'trailer' being indented caused issues ([#513](https://github.com/pdfminer/pdfminer.six/pull/513))
 
 ## [20200720]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Rename PDFTextExtractionNotAllowedError to PDFTextExtractionNotAllowed to revert breaking change ([#461](https://github.com/pdfminer/pdfminer.six/pull/461))
 - Always try to get CMap, not only for identity encodings ([#438](https://github.com/pdfminer/pdfminer.six/pull/438))
-- Fix a bug where 'trailer' being indented caused issues ([#513](https://github.com/pdfminer/pdfminer.six/pull/513))
+- Recognizing 'trailer' keyword with spaces as prefix or suffix ([#513](https://github.com/pdfminer/pdfminer.six/pull/513))
 
 ## [20200720]
 

--- a/pdfminer/pdfdocument.py
+++ b/pdfminer/pdfdocument.py
@@ -99,7 +99,7 @@ class PDFXRef(PDFBaseXRef):
                 raise PDFNoValidXRef('Unexpected EOF - file corrupted?')
             if not line:
                 raise PDFNoValidXRef('Premature eof: %r' % parser)
-            if line.startswith(b'trailer'):
+            if line.strip().startswith(b'trailer'):
                 parser.seek(pos)
                 break
             f = line.strip().split(b' ')

--- a/pdfminer/pdfdocument.py
+++ b/pdfminer/pdfdocument.py
@@ -93,16 +93,15 @@ class PDFXRef(PDFBaseXRef):
         while True:
             try:
                 (pos, line) = parser.nextline()
-                if not line.strip():
+                line = line.strip()
+                if not line:
                     continue
             except PSEOF:
                 raise PDFNoValidXRef('Unexpected EOF - file corrupted?')
-            if not line:
-                raise PDFNoValidXRef('Premature eof: %r' % parser)
-            if line.strip().startswith(b'trailer'):
+            if line.startswith(b'trailer'):
                 parser.seek(pos)
                 break
-            f = line.strip().split(b' ')
+            f = line.split(b' ')
             if len(f) != 2:
                 error_msg = 'Trailer not found: {!r}: line={!r}'\
                     .format(parser, line)
@@ -118,7 +117,7 @@ class PDFXRef(PDFBaseXRef):
                     (_, line) = parser.nextline()
                 except PSEOF:
                     raise PDFNoValidXRef('Unexpected EOF - file corrupted?')
-                f = line.strip().split(b' ')
+                f = line.split(b' ')
                 if len(f) != 3:
                     error_msg = 'Invalid XRef format: {!r}, line={!r}'\
                         .format(parser, line)


### PR DESCRIPTION
**Pull request**

Thanks for improving pdfminer.six! Please include the following information to
help us discuss and merge this PR:

Fix a bug where `trailer` being indented caused a bug. Thanks to @pietermarsman for suggesting the fix.

Closes #214

**How Has This Been Tested?**

There is an example script and PDF in #214.

**Checklist**

- [x] I have added tests that prove my fix is effective or that my feature 
  works  (N/A -> we don't really want to add this PDF to our test suite, correct?)
- [X] I have added docstrings to newly created methods and classes  (N/A)
- [X] I have optimized the code at least one time after creating the initial 
  version
- [X] I have updated the [README.md](../README.md) or I am verified that this
  is not necessary
- [X] I have updated the [readthedocs](../docs/source) documentation or I 
  verified that this is not necessary
- [X] I have added a consice human-readable description of the change to 
  [CHANGELOG.md](../CHANGELOG.md)
