### PR TITLE
Integrates with the python-bidi to apply Bi-directional (BiDi) layout…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
         'chardet ; python_version > "3.0"',
         'cryptography',
         'sortedcontainers',
+        'python-bidi',
     ],
     extras_require={
         "dev": ["nose", "tox"],


### PR DESCRIPTION
**Pull request**

Fixes #515 

**Description**
This PR adds support RTL languages. This has been acheived by importing python-bidi library which applies X1 to X9 rules of the unicode algorithm.

See [unicode levels and directions](http://unicode.org/reports/tr9/#Explicit_Levels_and_Directions) and the [wiki about bi-directional text](https://en.wikipedia.org/wiki/Bidirectional_text).

**Summary of changes**
This algorithm was applied by adding an analyzing function under LTTextLine class to reorder its objs (LTChar). The rules will not affect the output of non RTL languages.

I tried multiple approaches to add supports of bidi text. Here are the approaches and why the current one was selected:

- Applying BiDi rules on page level after all anlyizes are completed:
The downside of this one that it will not return the charecters in the fixed order if rendering was itirating on charecters levels such as the pdf2text method. Also, it requires changing the get_text method on LTChar to reverse RTL ligature characters.

- Applying BiDi rules on the text output of LTTextLine level:
This method will apply the rules on the text output of the items. The problem with this one that it will not rearrange the items itself, the transformation only will be done during getting the text. 

- Applying BiDi rules on LTTextLine level (This PR):
This method will apply the rules on LTChar during the analyzing of LTText. The LTChar will be resorted based on the rules. This method insures that what ever was the method to get text, the rules will be applied only once.

**How Has This Been Tested?**
This can be tested on any RTL PDF file. Here is an example of one: [3.pdf](https://github.com/pdfminer/pdfminer.six/files/5321321/3.pdf)
This is my first contribution to a public repository. Your help is appreciated to adhere to the contribution guides.

**Checklist**

- [No new tests was added] I have added tests that prove my fix is effective or that my feature 
  works
- [X] I have added docstrings to newly created methods and classes
- [X] I have optimized the code at least one time after creating the initial 
  version
- [X] I have updated the [README.md](../README.md) or I am verified that this
  is not necessary
- [x] I have updated the [readthedocs](../docs/source) documentation or I 
  verified that this is not necessary
- [ ] I have added a consice human-readable description of the change to 
  [CHANGELOG.md](../CHANGELOG.md)
