### PR TITLE
Fix TypeError: cannot unpack non-iterable PDFObjRef object, when unpacking the value of 'DW2'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes in pdfminer.six will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [20201018]
+## [Unreleased]
 
 ### Fixed
 - Fix issue of TypeError: cannot unpack non-iterable PDFObjRef object, when unpacking the value of 'DW2' ([#529](https://github.com/pdfminer/pdfminer.six/pull/529))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [20201018]
 
+### Fixed
+- Fix issue of TypeError: cannot unpack non-iterable PDFObjRef object, when unpacking the value of 'DW2' ([#529](https://github.com/pdfminer/pdfminer.six/pull/529))
+
+## [20201018]
+
 ### Deprecated
 - Support for Python 3.4 and 3.5 ([#503](https://github.com/pdfminer/pdfminer.six/pull/503))
 

--- a/pdfminer/pdffont.py
+++ b/pdfminer/pdffont.py
@@ -706,7 +706,7 @@ class PDFCIDFont(PDFFont):
             widths = get_widths2(list_value(spec.get('W2', [])))
             self.disps = {cid: (vx, vy)
                           for (cid, (_, (vx, vy))) in widths.items()}
-            (vy, w) = spec.get('DW2', [880, -1000])
+            (vy, w) = resolve1(spec.get('DW2', [880, -1000]))
             self.default_disp = (None, vy)
             widths = {cid: w for (cid, (w, _)) in widths.items()}
             default_width = w


### PR DESCRIPTION
An error is occured when the 'DW2' key contains a PDFObjRef object instead of a list of int values, e.g: 'DW2': <PDFObjRef:152>.
To solve this issue, we utilise the resolve1() function

See: https://github.com/pdfminer/pdfminer.six/issues/518

**Pull request**

Thanks for improving pdfminer.six! Please include the following information to
help us discuss and merge this PR:

- A description of why this PR is needed. What does it fix? What does it 
  improve?
- A summary of the things that this PR changes.
- Reference the issues that this PR fixes (use the fixes #(issue nr) syntax). 
  If this PR does not fix any issue, create the issue first and mention that 
  you are willing to work on it.

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide 
instructions so we can reproduce. Include an example pdf if you have one. 

**Checklist**

- [ ] I have added tests that prove my fix is effective or that my feature 
  works
- [ ] I have added docstrings to newly created methods and classes
- [ ] I have optimized the code at least one time after creating the initial 
  version
- [x] I have updated the [README.md](../README.md) or I am verified that this
  is not necessary
- [x] I have updated the [readthedocs](../docs/source) documentation or I 
  verified that this is not necessary
- [x] I have added a consice human-readable description of the change to 
  [CHANGELOG.md](../CHANGELOG.md)
