### PR TITLE
Added support for Paeth PNG filter compression (predictor value = 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- Support for Paeth PNG filter compression (predictor value = 4) ([#](https://github.com/pdfminer/pdfminer.six/pull/))
+
 ### Removed
 - Unused dependency on `sortedcontainers` package ([#525](https://github.com/pdfminer/pdfminer.six/pull/525))
 


### PR DESCRIPTION
**Pull request**

Fixes #339 Added support for Paeth PNG compression filter (predictor value = 4). Fixed bugs in other filters.

**How Has This Been Tested?**

I have tested this with a private PDF file that I am not allowed to share.

**Checklist**

- [ ] I have added tests that prove my fix is effective or that my feature 
  works
- [ ] I have added docstrings to newly created methods and classes
- [ ] I have optimized the code at least one time after creating the initial 
  version
- [ ] I have updated the [README.md](../README.md) or I am verified that this
  is not necessary
- [ ] I have updated the [readthedocs](../docs/source) documentation or I 
  verified that this is not necessary
- [ ] I have added a consice human-readable description of the change to 
  [CHANGELOG.md](../CHANGELOG.md)
