### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: python
+dist: bionic
+arch:
+  - AMD64
+  - ppc64le
 python:
   - "3.6"
   - "3.7"


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.

Changes made: 
Openssl version 1.1.x is not available for  xenial on ppc64le, So moved to distro Bionic.

For more Info Tag @gerrith3 Thanks!