### PR TITLE
Fix value error and key error

### DIFF
--- a/pdfminer/pdfdocument.py
+++ b/pdfminer/pdfdocument.py
@@ -230,7 +230,7 @@ class PDFXRefStream(PDFBaseXRef):
         (_, kwd) = parser.nexttoken()
         (_, stream) = parser.nextobject()
         if not isinstance(stream, PDFStream) \
-                or stream['Type'] is not LITERAL_XREF:
+                or stream.get('Type') is not LITERAL_XREF:
             raise PDFNoValidXRef('Invalid PDF stream spec.')
         size = stream['Size']
         index_array = stream.get('Index', (0, size))

--- a/pdfminer/pdfparser.py
+++ b/pdfminer/pdfparser.py
@@ -68,14 +68,14 @@ class PDFParser(PSStackParser):
 
         elif token is self.KEYWORD_R:
             # reference to indirect object
-            try:
-                ((_, objid), (_, genno)) = self.pop(2)
-                (objid, genno) = (int(objid), int(genno))
-                obj = PDFObjRef(self.doc, objid, genno)
-                self.push((pos, obj))
-            except PSSyntaxError:
-                pass
-
+            if len(self.curstack) > 2:
+                try:
+                    ((_, objid), (_, genno)) = self.pop(2)
+                    (objid, genno) = (int(objid), int(genno))
+                    obj = PDFObjRef(self.doc, objid, genno)
+                    self.push((pos, obj))
+                except PSSyntaxError:
+                    pass
         elif token is self.KEYWORD_STREAM:
             # stream object
             ((_, dic),) = self.pop(1)


### PR DESCRIPTION
- Fixes issue #573 
- Two things: check the stack length before popping, and also use `.get` to protect getting a key that doesn't exist.
The code change is pretty simple and in general good practice in python so I think they should be adopted.
Sorry that I couldn't share the original PDF document as explained in the issue.
- Issue number #573 

**How Has This Been Tested?**
Can confirm that with these fixes the document can be processed.

**Checklist**

- [ NA] I have added tests that prove my fix is effective or that my feature 
  works
- [ NA] I have added docstrings to newly created methods and classes
- [ NA] I have optimized the code at least one time after creating the initial 
  version
- [ NA] I have updated the [README.md](../README.md) or I am verified that this
  is not necessary
- [NA ] I have updated the [readthedocs](../docs/source) documentation or I 
  verified that this is not necessary
- [ pending] I have added a consice human-readable description of the change to 
  [CHANGELOG.md](../CHANGELOG.md)
