### PR TITLE
Fix cryptography build in travis cicd by upgrading distribution from Trusty Tahr to Focal Fossa

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
-  - "3.9-dev"
+  - "3.9"
 install:
   - pip install tox==3.14.0 tox-travis flake8
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: focal
 language: python
 python:
   - "3.6"


### PR DESCRIPTION
**Pull request**

Fix #584 

Change the travis cicd pipeline to use ubuntu focal fossa (20.04) instead of trusty tahr (14.04). This should fix the failure to build cryptography. 

**How Has This Been Tested?**

With travis :) 

**Checklist**

- [ ] I have added tests that prove my fix is effective or that my feature 
  works
- [x] I have added docstrings to newly created methods and classes
- [ x I have optimized the code at least one time after creating the initial 
  version
- [x] I have updated the [README.md](../README.md) or I am verified that this
  is not necessary
- [x] I have updated the [readthedocs](../docs/source) documentation or I 
  verified that this is not necessary
- [ ] I have added a consice human-readable description of the change to 
  [CHANGELOG.md](../CHANGELOG.md)
