### PR TITLE
Added feature for fine-grained control of merging to LAParams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,16 @@
 # Changelog
-All notable changes in pdfminer.six will be documented in this file. 
+All notable changes in pdfminer.six will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## [Unreleased]
 
+### Added
+- `lines_merge` and `boxes_merge` attributes to `LAParams` to allow for more fine-grained user control of merge behavior of lines and boxes
+
 ### Fixed
-- Fix issue of TypeError: cannot unpack non-iterable PDFObjRef object, when unpacking the value of 'DW2' ([#529](https://github.com/pdfminer/pdfminer.six/pull/529))
+- Fix issue of "TypeError: cannot unpack non-iterable PDFObjRef object", when unpacking the value of 'DW2' ([#529](https://github.com/pdfminer/pdfminer.six/pull/529))
 - `PermissionError` when creating temporary filepaths on windows when running tests ([#469](https://github.com/pdfminer/pdfminer.six/issues/469))
 
 ## Removed
@@ -51,7 +54,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Hiding fallback xref by default from dumppdf.py output ([#431](https://github.com/pdfminer/pdfminer.six/pull/431))
 - Raise a warning instead of an error when extracting text from a non-extractable PDF ([#453](https://github.com/pdfminer/pdfminer.six/pull/453))
 - Switched from pycryptodome to cryptography package for AES decryption ([#456](https://github.com/pdfminer/pdfminer.six/pull/456))
-  
+
 ## [20200517]
 
 ### Added
@@ -108,18 +111,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Deprecated
 - The argument `_py2_no_more_posargs` because Python2 is removed on January
-, 2020 ([#328](https://github.com/pdfminer/pdfminer.six/pull/328) and 
+, 2020 ([#328](https://github.com/pdfminer/pdfminer.six/pull/328) and
 [#307](https://github.com/pdfminer/pdfminer.six/pull/307))
 
 ### Added
 - Simple wrapper to easily extract text from a PDF file [#330](https://github.com/pdfminer/pdfminer.six/pull/330)
 - Support for extracting JBIG2 encoded images ([#311](https://github.com/pdfminer/pdfminer.six/pull/311) and [#46](https://github.com/pdfminer/pdfminer.six/pull/46))
-- Sphinx documentation that is published on 
+- Sphinx documentation that is published on
   [Read the Docs](https://pdfminersix.readthedocs.io/)
   ([#329](https://github.com/pdfminer/pdfminer.six/pull/329))
 
 ### Fixed
-- Unhandled AssertionError when dumping pdf containing reference to object id 0 
+- Unhandled AssertionError when dumping pdf containing reference to object id 0
  ([#318](https://github.com/pdfminer/pdfminer.six/pull/318))
 - Debug flag actually changes logging level to debug for pdf2txt.py and
  dumppdf.py ([#325](https://github.com/pdfminer/pdfminer.six/pull/325))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,10 +11,10 @@ Any contribution is appreciated! You might want to:
 ## How can I contribute?
 
 * Use [issues](https://github.com/pdfminer/pdfminer.six/issues) to report bugs and features
-    - If you report a bug in the results for a particular pdf, include that pdf. This allows others to replicate the
-     issue. 
+    - If you report a bug in the results for a particular PDF, include that PDF. This allows others to replicate the
+     issue.
 * Fix issues by [creating pull requests](https://help.github.com/en/articles/creating-a-pull-request).
-* Help others by sharing your thoughs in comments on issues and pull requests.
+* Help others by sharing your thoughts in comments on issues and pull requests.
 * Join the chat on [gitter](https://gitter.im/pdfminer-six/Lobby)
 
 ## Guidelines for creating issues
@@ -22,19 +22,19 @@ Any contribution is appreciated! You might want to:
 * Search previous issues, as yours might be a duplicate.
 * When creating a new issue for a bug, include a minimal reproducible example.
 * When creating a new issue for a feature, be sure to describe the context of the problem you are trying to solve. This
-  will help others to see the importance of your feature request. 
+  will help others to see the importance of your feature request.
 
 ## Guideline for creating pull request
 
 * A pull request should close an existing issue.
-* Pull requests should be merged to develop, not master. This ensures that master always equals the released version.  
-* Include unit tests when possible. In case of bugs, this will help to prevent the same mistake in the future. In case 
+* Pull requests should be merged to develop, not master. This ensures that master always equals the released version.
+* Include unit tests when possible. In case of bugs, this will help to prevent the same mistake in the future. In case
   of features, this will show that your code works correctly.
 * Code should work for Python 3.6+.
 * Code should conform to PEP8 coding style.
 * New features should be well documented using docstrings.
 * Check spelling and grammar.
-* Don't forget to update the [CHANGELOG.md](CHANGELOG.md#[Unreleased])
+* Don't forget to update the [CHANGELOG.md](CHANGELOG.md#[Unreleased]).
 
 ## Guidelines for posting comments
 
@@ -62,9 +62,9 @@ Any contribution is appreciated! You might want to:
     ```sh
     tox
    ```
-   
+
    Or on a single Python version:
-   
+
    ```sh
     tox -e py36
     ```

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ pdfminer.six
 Pdfminer.six is a community maintained fork of the original PDFMiner. It is a
 tool for extracting information from PDF documents. It focuses on getting
 and analyzing text data. Pdfminer.six extracts the text from a page directly
-from the sourcecode of the PDF. It can also be used to get the exact location, 
-font or color of the text. 
+from the sourcecode of the PDF. It can also be used to get the exact location,
+font or color of the text.
 
 It is built in a modular way such that each component of pdfminer.six can be
 replaced easily. You can implement your own interpreter or rendering device
-that uses the power of pdfminer.six for other purposes than text analysis. 
+that uses the power of pdfminer.six for other purposes than text analysis.
 
 Check out the full documentation on
 [Read the Docs](https://pdfminersix.readthedocs.io).
@@ -26,7 +26,7 @@ Features
 
  * Written entirely in Python.
  * Parse, analyze, and convert PDF documents.
- * PDF-1.7 specification support. (well, almost).
+ * PDF 1.7 specification support (well, almost).
  * CJK languages and vertical writing scripts support.
  * Various font types (Type1, TrueType, Type3, and CID) support.
  * Support for extracting images (JPG, JBIG2 and Bitmaps).
@@ -53,4 +53,4 @@ How to use
 Contributing
 ------------
 
-Be sure to read the [contribution guidelines](https://github.com/pdfminer/pdfminer.six/blob/master/CONTRIBUTING.md). 
+Be sure to read the [contribution guidelines](https://github.com/pdfminer/pdfminer.six/blob/master/CONTRIBUTING.md).

--- a/pdfminer/converter.py
+++ b/pdfminer/converter.py
@@ -74,7 +74,7 @@ class PDFLayoutAnalyzer(PDFTextDevice):
         return
 
     def paint_path(self, gstate, stroke, fill, evenodd, path):
-        """Paint paths described in section 4.4 of the PDF reference manual"""
+        """Paint paths described in section 4.4 of the PDF reference manual."""
         shape = ''.join(x[0] for x in path)
 
         if shape.count('m') > 1:

--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -30,7 +30,7 @@ class IndexAssigner:
 
 
 class LAParams:
-    """Parameters for layout analysis
+    """Parameters for layout analysis.
 
     :param line_overlap: If two characters have more overlap than this they
         are considered to be on the same line. The overlap is specified
@@ -102,7 +102,7 @@ class LAParams:
 
 
 class LTItem:
-    """Interface for things that can be analyzed"""
+    """Interface for things that can be analyzed."""
 
     def analyze(self, laparams):
         """Perform the layout analysis."""
@@ -110,7 +110,7 @@ class LTItem:
 
 
 class LTText:
-    """Interface for things that have text"""
+    """Interface for things that have text."""
 
     def __repr__(self):
         return ('<%s %r>' %
@@ -122,7 +122,7 @@ class LTText:
 
 
 class LTComponent(LTItem):
-    """Object with a bounding box"""
+    """Object with a bounding box."""
 
     def __init__(self, bbox):
         LTItem.__init__(self)
@@ -198,7 +198,7 @@ class LTComponent(LTItem):
 
 
 class LTCurve(LTComponent):
-    """A generic Bezier curve"""
+    """A generic Bezier curve."""
 
     def __init__(self, linewidth, pts, stroke=False, fill=False, evenodd=False,
                  stroking_color=None, non_stroking_color=None):
@@ -236,7 +236,7 @@ class LTRect(LTCurve):
     """
 
     def __init__(self, linewidth, bbox, stroke=False, fill=False,
-                 evenodd=False, stroking_color=None,  non_stroking_color=None):
+                 evenodd=False, stroking_color=None, non_stroking_color=None):
         (x0, y0, x1, y1) = bbox
         LTCurve.__init__(self, linewidth,
                          [(x0, y0), (x1, y0), (x1, y1), (x0, y1)], stroke,
@@ -270,7 +270,7 @@ class LTImage(LTComponent):
 
 
 class LTAnno(LTItem, LTText):
-    """Actual letter in the text as a Unicode string.
+    """An annotational letter in the text, as a Unicode string.
 
     Note that, while a LTChar object has actual boundaries, LTAnno objects does
     not, as these are "virtual" characters, inserted by a layout analyzer
@@ -286,7 +286,7 @@ class LTAnno(LTItem, LTText):
 
 
 class LTChar(LTComponent, LTText):
-    """Actual letter in the text as a Unicode string."""
+    """An actual letter in the text, as a Unicode string."""
 
     def __init__(self, matrix, font, fontsize, scaling, rise,
                  text, textwidth, textdisp, ncs, graphicstate):
@@ -343,7 +343,7 @@ class LTChar(LTComponent, LTText):
 
 
 class LTContainer(LTComponent):
-    """Object that can be extended and analyzed"""
+    """An object that can be extended and analyzed."""
 
     def __init__(self, bbox):
         LTComponent.__init__(self, bbox)
@@ -438,12 +438,12 @@ class LTTextLineHorizontal(LTTextLine):
         LTTextLine.add(self, obj)
         return
 
-    def get_bbox_with_tolerance(self, d):
+    def get_bbox_plus_tolerance(self, d):
         return (self.x0, self.y0 - d, self.x1, self.y1 + d)
 
     def find_neighbors(self, plane, ratio):
         """
-        Finds neighboring LTTextLineHorizontals in the plane.
+        Find neighboring LTTextLineHorizontals in the plane.
 
         Returns a list of other LTTestLineHorizontals in the plane which are
         close to self. "Close" can be controlled by ratio. The returned objects
@@ -461,19 +461,19 @@ class LTTextLineHorizontal(LTTextLine):
 
     def _is_left_aligned_with(self, other, tolerance=0):
         """
-        Whether the left-hand edge of `other` is within `tolerance`.
+        Check whether the left-hand edge of `other` is within `tolerance`.
         """
         return abs(other.x0 - self.x0) <= tolerance
 
     def _is_right_aligned_with(self, other, tolerance=0):
         """
-        Whether the right-hand edge of `other` is within `tolerance`.
+        Check whether the right-hand edge of `other` is within `tolerance`.
         """
         return abs(other.x1 - self.x1) <= tolerance
 
     def _is_centrally_aligned_with(self, other, tolerance=0):
         """
-        Whether the horizontal center of `other` is within `tolerance`.
+        Check whether the horizontal center of `other` is within `tolerance`.
         """
         return abs(
             (other.x0 + other.x1) / 2 - (self.x0 + self.x1) / 2) <= tolerance
@@ -497,12 +497,12 @@ class LTTextLineVertical(LTTextLine):
         LTTextLine.add(self, obj)
         return
 
-    def get_bbox_with_tolerance(self, d):
+    def get_bbox_plus_tolerance(self, d):
         return (self.x0 - d, self.y0, self.x1 + d, self.y1)
 
     def find_neighbors(self, plane, ratio):
         """
-        Finds neighboring LTTextLineVerticals in the plane.
+        Find neighboring LTTextLineVerticals in the plane.
 
         Returns a list of other LTTextLineVerticals in the plane which are
         close to self. "Close" can be controlled by ratio. The returned objects
@@ -520,19 +520,19 @@ class LTTextLineVertical(LTTextLine):
 
     def _is_lower_aligned_with(self, other, tolerance=0):
         """
-        Whether the lower edge of `other` is within `tolerance`.
+        Check whether the lower edge of `other` is within `tolerance`.
         """
         return abs(other.y0 - self.y0) <= tolerance
 
     def _is_upper_aligned_with(self, other, tolerance=0):
         """
-        Whether the upper edge of `other` is within `tolerance`.
+        Check whether the upper edge of `other` is within `tolerance`.
         """
         return abs(other.y1 - self.y1) <= tolerance
 
     def _is_centrally_aligned_with(self, other, tolerance=0):
         """
-        Whether the vertical center of `other` is within `tolerance`.
+        Check whether the vertical center of `other` is within `tolerance`.
         """
         return abs(
             (other.y0 + other.y1) / 2 - (self.y0 + self.y1) / 2) <= tolerance

--- a/pdfminer/pdfinterp.py
+++ b/pdfminer/pdfinterp.py
@@ -308,7 +308,7 @@ class PDFContentParser(PSStackParser):
 
 
 class PDFPageInterpreter:
-    """Processor for the content of a PDF page
+    """Processor for the content of a PDF page.
 
     Reference: PDF Reference, Appendix A, Operator Summary
     """
@@ -398,94 +398,94 @@ class PDFPageInterpreter:
         return
 
     def do_q(self):
-        """Save graphics state"""
+        """Save graphics state."""
         self.gstack.append(self.get_current_state())
         return
 
     def do_Q(self):
-        """Restore graphics state"""
+        """Restore graphics state."""
         if self.gstack:
             self.set_current_state(self.gstack.pop())
         return
 
     def do_cm(self, a1, b1, c1, d1, e1, f1):
-        """Concatenate matrix to current transformation matrix"""
+        """Concatenate matrix to current transformation matrix."""
         self.ctm = mult_matrix((a1, b1, c1, d1, e1, f1), self.ctm)
         self.device.set_ctm(self.ctm)
         return
 
     def do_w(self, linewidth):
-        """Set line width"""
+        """Set line width."""
         self.graphicstate.linewidth = linewidth
         return
 
     def do_J(self, linecap):
-        """Set line cap style"""
+        """Set line cap style."""
         self.graphicstate.linecap = linecap
         return
 
     def do_j(self, linejoin):
-        """Set line join style"""
+        """Set line join style."""
         self.graphicstate.linejoin = linejoin
         return
 
     def do_M(self, miterlimit):
-        """Set miter limit"""
+        """Set miter limit."""
         self.graphicstate.miterlimit = miterlimit
         return
 
     def do_d(self, dash, phase):
-        """Set line dash pattern"""
+        """Set line dash pattern."""
         self.graphicstate.dash = (dash, phase)
         return
 
     def do_ri(self, intent):
-        """Set color rendering intent"""
+        """Set color rendering intent."""
         self.graphicstate.intent = intent
         return
 
     def do_i(self, flatness):
-        """Set flatness tolerance"""
+        """Set flatness tolerance."""
         self.graphicstate.flatness = flatness
         return
 
     def do_gs(self, name):
-        """Set parameters from graphics state parameter dictionary"""
+        """Set parameters from graphics state parameter dictionary."""
         # todo
         return
 
     def do_m(self, x, y):
-        """Begin new subpath"""
+        """Begin new subpath."""
         self.curpath.append(('m', x, y))
         return
 
     def do_l(self, x, y):
-        """Append straight line segment to path"""
+        """Append straight line segment to path."""
         self.curpath.append(('l', x, y))
         return
 
     def do_c(self, x1, y1, x2, y2, x3, y3):
-        """Append curved segment to path (three control points)"""
+        """Append curved segment to path (three control points)."""
         self.curpath.append(('c', x1, y1, x2, y2, x3, y3))
         return
 
     def do_v(self, x2, y2, x3, y3):
-        """Append curved segment to path (initial point replicated)"""
+        """Append curved segment to path (initial point replicated)."""
         self.curpath.append(('v', x2, y2, x3, y3))
         return
 
     def do_y(self, x1, y1, x3, y3):
-        """Append curved segment to path (final point replicated)"""
+        """Append curved segment to path (final point replicated)."""
         self.curpath.append(('y', x1, y1, x3, y3))
         return
 
     def do_h(self):
-        """Close subpath"""
+        """Close subpath."""
         self.curpath.append(('h',))
         return
 
     def do_re(self, x, y, w, h):
-        """Append rectangle to path"""
+        """Append rectangle to path."""
         self.curpath.append(('m', x, y))
         self.curpath.append(('l', x+w, y))
         self.curpath.append(('l', x+w, y+h))
@@ -494,77 +494,77 @@ class PDFPageInterpreter:
         return
 
     def do_S(self):
-        """Stroke path"""
+        """Stroke path."""
         self.device.paint_path(self.graphicstate, True, False, False,
                                self.curpath)
         self.curpath = []
         return
 
     def do_s(self):
-        """Close and stroke path"""
+        """Close and stroke path."""
         self.do_h()
         self.do_S()
         return
 
     def do_f(self):
-        """Fill path using nonzero winding number rule"""
+        """Fill path using nonzero winding number rule."""
         self.device.paint_path(self.graphicstate, False, True, False,
                                self.curpath)
         self.curpath = []
         return
 
     def do_F(self):
-        """Fill path using nonzero winding number rule (obsolete)"""
+        """Fill path using nonzero winding number rule (obsolete)."""
         return self.do_f()
 
     def do_f_a(self):
-        """Fill path using even-odd rule"""
+        """Fill path using even-odd rule."""
         self.device.paint_path(self.graphicstate, False, True, True,
                                self.curpath)
         self.curpath = []
         return
 
     def do_B(self):
-        """Fill and stroke path using nonzero winding number rule"""
+        """Fill and stroke path using nonzero winding number rule."""
         self.device.paint_path(self.graphicstate, True, True, False,
                                self.curpath)
         self.curpath = []
         return
 
     def do_B_a(self):
-        """Fill and stroke path using even-odd rule"""
+        """Fill and stroke path using even-odd rule."""
         self.device.paint_path(self.graphicstate, True, True, True,
                                self.curpath)
         self.curpath = []
         return
 
     def do_b(self):
-        """Close, fill, and stroke path using nonzero winding number rule"""
+        """Close, fill, and stroke path using nonzero winding number rule."""
         self.do_h()
         self.do_B()
         return
 
     def do_b_a(self):
-        """Close, fill, and stroke path using even-odd rule"""
+        """Close, fill, and stroke path using even-odd rule."""
         self.do_h()
         self.do_B_a()
         return
 
     def do_n(self):
-        """End path without filling or stroking"""
+        """End path without filling or stroking."""
         self.curpath = []
         return
 
     def do_W(self):
-        """Set clipping path using nonzero winding number rule"""
+        """Set clipping path using nonzero winding number rule."""
         return
 
     def do_W_a(self):
-        """Set clipping path using even-odd rule"""
+        """Set clipping path using even-odd rule."""
         return
 
     def do_CS(self, name):
-        """Set color space for stroking operations
+        """Set color space for stroking operations.
 
         Introduced in PDF 1.1
         """
@@ -576,7 +576,7 @@ class PDFPageInterpreter:
         return
 
     def do_cs(self, name):
-        """Set color space for nonstroking operations"""
+        """Set color space for nonstroking operations."""
         try:
             self.ncs = self.csmap[literal_name(name)]
         except KeyError:
@@ -585,32 +585,32 @@ class PDFPageInterpreter:
         return
 
     def do_G(self, gray):
-        """Set gray level for stroking operations"""
+        """Set gray level for stroking operations."""
         self.graphicstate.scolor = gray
         return
 
     def do_g(self, gray):
-        """Set gray level for nonstroking operations"""
+        """Set gray level for nonstroking operations."""
         self.graphicstate.ncolor = gray
         return
 
     def do_RG(self, r, g, b):
-        """Set RGB color for stroking operations"""
+        """Set RGB color for stroking operations."""
         self.graphicstate.scolor = (r, g, b)
         return
 
     def do_rg(self, r, g, b):
-        """Set RGB color for nonstroking operations"""
+        """Set RGB color for nonstroking operations."""
         self.graphicstate.ncolor = (r, g, b)
         return
 
     def do_K(self, c, m, y, k):
-        """Set CMYK color for stroking operations"""
+        """Set CMYK color for stroking operations."""
         self.graphicstate.scolor = (c, m, y, k)
         return
 
     def do_k(self, c, m, y, k):
-        """Set CMYK color for nonstroking operations"""
+        """Set CMYK color for nonstroking operations."""
         self.graphicstate.ncolor = (c, m, y, k)
         return
 
@@ -626,7 +626,7 @@ class PDFPageInterpreter:
         return
 
     def do_scn(self):
-        """Set color for nonstroking operations"""
+        """Set color for nonstroking operations."""
         if self.ncs:
             n = self.ncs.ncomponents
         else:
@@ -637,21 +637,21 @@ class PDFPageInterpreter:
         return
 
     def do_SC(self):
-        """Set color for stroking operations"""
+        """Set color for stroking operations."""
         self.do_SCN()
         return
 
     def do_sc(self):
-        """Set color for nonstroking operations"""
+        """Set color for nonstroking operations."""
         self.do_scn()
         return
 
     def do_sh(self, name):
-        """Paint area defined by shading pattern"""
+        """Paint area defined by shading pattern."""
         return
 
     def do_BT(self):
-        """Begin text object
+        """Begin text object.
 
         Initializing the text matrix, Tm, and the text line matrix, Tlm, to
         the identity matrix. Text objects cannot be nested; a second BT cannot
@@ -661,39 +661,39 @@ class PDFPageInterpreter:
         return
 
     def do_ET(self):
-        """End a text object"""
+        """End a text object."""
         return
 
     def do_BX(self):
-        """Begin compatibility section"""
+        """Begin compatibility section."""
         return
 
     def do_EX(self):
-        """End compatibility section"""
+        """End compatibility section."""
         return
 
     def do_MP(self, tag):
-        """Define marked-content point"""
+        """Define marked-content point."""
         self.device.do_tag(tag)
         return
 
     def do_DP(self, tag, props):
-        """Define marked-content point with property list"""
+        """Define marked-content point with property list."""
         self.device.do_tag(tag, props)
         return
 
     def do_BMC(self, tag):
-        """Begin marked-content sequence"""
+        """Begin marked-content sequence."""
         self.device.begin_tag(tag)
         return
 
     def do_BDC(self, tag, props):
-        """Begin marked-content sequence with property list"""
+        """Begin marked-content sequence with property list."""
         self.device.begin_tag(tag, props)
         return
 
     def do_EMC(self):
-        """End marked-content sequence"""
+        """End marked-content sequence."""
         self.device.end_tag()
         return
 
@@ -736,7 +736,7 @@ class PDFPageInterpreter:
         return
 
     def do_Tf(self, fontid, fontsize):
-        """Set the text font
+        """Set the text font.
 
         :param fontid: the name of a font resource in the Font subdictionary
             of the current resource dictionary
@@ -752,12 +752,12 @@ class PDFPageInterpreter:
         return
 
     def do_Tr(self, render):
-        """Set the text rendering mode"""
+        """Set the text rendering mode."""
         self.textstate.render = render
         return
 
     def do_Ts(self, rise):
-        """Set the text rise
+        """Set the text rise.
 
         :param rise: a number expressed in unscaled text space units
         """
@@ -765,14 +765,14 @@ class PDFPageInterpreter:
         return
 
     def do_Td(self, tx, ty):
-        """Move text position"""
+        """Move text position."""
         (a, b, c, d, e, f) = self.textstate.matrix
         self.textstate.matrix = (a, b, c, d, tx*a+ty*c+e, tx*b+ty*d+f)
         self.textstate.linematrix = (0, 0)
         return
 
     def do_TD(self, tx, ty):
-        """Move text position and set leading"""
+        """Move text position and set leading."""
         (a, b, c, d, e, f) = self.textstate.matrix
         self.textstate.matrix = (a, b, c, d, tx*a+ty*c+e, tx*b+ty*d+f)
         self.textstate.leading = ty
@@ -780,13 +780,13 @@ class PDFPageInterpreter:
         return
 
     def do_Tm(self, a, b, c, d, e, f):
-        """Set text matrix and text line matrix"""
+        """Set text matrix and text line matrix."""
         self.textstate.matrix = (a, b, c, d, e, f)
         self.textstate.linematrix = (0, 0)
         return
 
     def do_T_a(self):
-        """Move to start of next text line"""
+        """Move to start of next text line."""
         (a, b, c, d, e, f) = self.textstate.matrix
         self.textstate.matrix = (a, b, c, d, self.textstate.leading*c+e,
                                  self.textstate.leading*d+f)
@@ -794,7 +794,7 @@ class PDFPageInterpreter:
         return
 
     def do_TJ(self, seq):
-        """Show text, allowing individual glyph positioning"""
+        """Show text, allowing individual glyph positioning."""
         if self.textstate.font is None:
             if settings.STRICT:
                 raise PDFInterpreterError('No font specified!')
@@ -804,12 +804,12 @@ class PDFPageInterpreter:
         return
 
     def do_Tj(self, s):
-        """Show text"""
+        """Show text."""
         self.do_TJ([s])
         return
 
     def do__q(self, s):
-        """Move to next line and show text
+        """Move to next line and show text.
 
         The ' (single quote) operator.
         """
@@ -818,7 +818,7 @@ class PDFPageInterpreter:
         return
 
     def do__w(self, aw, ac, s):
-        """Set word and character spacing, move to next line, and show text
+        """Set word and character spacing, move to next line, and show text.
 
         The " (double quote) operator.
         """
@@ -828,15 +828,15 @@ class PDFPageInterpreter:
         return
 
     def do_BI(self):
-        """Begin inline image object"""
+        """Begin inline image object."""
         return
 
     def do_ID(self):
-        """Begin inline image data"""
+        """Begin inline image data."""
         return
 
     def do_EI(self, obj):
-        """End inline image object"""
+        """End inline image object."""
         if isinstance(obj, PDFStream) and 'W' in obj and 'H' in obj:
             iobjid = str(id(obj))
             self.device.begin_figure(iobjid, (0, 0, 1, 1), MATRIX_IDENTITY)
@@ -845,7 +845,7 @@ class PDFPageInterpreter:
         return
 
     def do_Do(self, xobjid):
-        """Invoke named XObject"""
+        """Invoke named XObject."""
         xobjid = literal_name(xobjid)
         try:
             xobj = stream_value(self.xobjmap[xobjid])

--- a/pdfminer/utils.py
+++ b/pdfminer/utils.py
@@ -369,7 +369,7 @@ class Plane:
             self.add(obj)
 
     def add(self, obj):
-        """place an object."""
+        """Add an object."""
         for k in self._getrange((obj.x0, obj.y0, obj.x1, obj.y1)):
             if k not in self._grid:
                 r = []
@@ -381,7 +381,7 @@ class Plane:
         self._objs.add(obj)
 
     def remove(self, obj):
-        """displace an object."""
+        """Remove an object."""
         for k in self._getrange((obj.x0, obj.y0, obj.x1, obj.y1)):
             try:
                 self._grid[k].remove(obj)
@@ -390,7 +390,7 @@ class Plane:
         self._objs.remove(obj)
 
     def find(self, bbox):
-        """finds objects that are in a certain area."""
+        """Find objects that intersect a specified bounding box."""
         (x0, y0, x1, y1) = bbox
         done = set()
         for k in self._getrange(bbox):

--- a/pdfminer/utils.py
+++ b/pdfminer/utils.py
@@ -1,5 +1,5 @@
 """
-Miscellaneous Routines.
+Miscellaneous Routines
 """
 import io
 import pathlib

--- a/tests/test_encodingdb.py
+++ b/tests/test_encodingdb.py
@@ -4,6 +4,7 @@ See: https://github.com/adobe-type-tools/agl-specification#2-the-mapping
 While not in the specification, lowercase unicode often occurs in pdf's.
 Therefore lowercase unittest variants are added.
 """
+
 from nose.tools import assert_raises
 
 from pdfminer.encodingdb import name2unicode, EncodingDB

--- a/tests/test_font_size.py
+++ b/tests/test_font_size.py
@@ -1,6 +1,7 @@
-from helpers import absolute_sample_path
 from pdfminer.high_level import extract_pages
 from pdfminer.layout import LTChar, LTTextBox
+
+from .helpers import absolute_sample_path
 
 
 def test_font_size():

--- a/tests/test_highlevel_extracttext.py
+++ b/tests/test_highlevel_extracttext.py
@@ -1,8 +1,9 @@
 import unittest
 
-from helpers import absolute_sample_path
 from pdfminer.high_level import extract_text, extract_pages
 from pdfminer.layout import LAParams, LTTextContainer
+
+from .helpers import absolute_sample_path
 
 
 def run_with_string(sample_path, laparams=None):

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -16,6 +16,7 @@ class TestGroupTextLines(unittest.TestCase):
         separate LTTextBoxes if they do not overlap. Even when the bounding box
         of the parent container does not contain all the lines.
         """
+
         laparams = LAParams()
         layout = LTLayoutContainer((0, 0, 50, 50))
         line1 = LTTextLineHorizontal(laparams.word_margin)

--- a/tests/test_pdfdocument.py
+++ b/tests/test_pdfdocument.py
@@ -1,9 +1,10 @@
 from nose.tools import raises
 
-from helpers import absolute_sample_path
 from pdfminer.pdfdocument import PDFDocument
 from pdfminer.pdfparser import PDFParser
 from pdfminer.pdftypes import PDFObjectNotFound
+
+from .helpers import absolute_sample_path
 
 
 class TestPdfDocument(object):

--- a/tests/test_tools_dumppdf.py
+++ b/tests/test_tools_dumppdf.py
@@ -1,9 +1,10 @@
 import warnings
 
-from helpers import absolute_sample_path
-from tempfilepath import TemporaryFilePath
 from pdfminer.pdfdocument import PDFNoValidXRefWarning
 from tools import dumppdf
+
+from .helpers import absolute_sample_path
+from .tempfilepath import TemporaryFilePath
 
 
 def run(filename, options=None):

--- a/tests/test_tools_pdf2txt.py
+++ b/tests/test_tools_pdf2txt.py
@@ -3,8 +3,9 @@ from shutil import rmtree
 from tempfile import mkdtemp
 
 import tools.pdf2txt as pdf2txt
-from helpers import absolute_sample_path
-from tempfilepath import TemporaryFilePath
+
+from .helpers import absolute_sample_path
+from .tempfilepath import TemporaryFilePath
 
 
 def run(sample_path, options=None):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,10 @@
 from nose.tools import assert_equal, assert_raises
 import pathlib
 
-from helpers import absolute_sample_path
 from pdfminer.layout import LTComponent
 from pdfminer.utils import open_filename, Plane, shorten_str
+
+from .helpers import absolute_sample_path
 
 
 class TestOpenFilename:


### PR DESCRIPTION
This is useful for scenarios like preventing merging when an LTCurve separates LTTextLines or LTTextBoxes and thus one doesn't want the usual merge behaviour. In theory, also in many other scenarios.

I trust you don't mind I took the opportunity to do a bit of tidying up in a few areas I saw too (really, just bringing things into convention or fixing small obvious errors in comments).

## Changelog

### Added
- `lines_merge` and `boxes_merge` attributes to `LAParams` to allow for more fine-grained user control of merge behavior of lines and boxes


**Pull request**

Thanks for improving pdfminer.six! Please include the following information to
help us discuss and merge this PR:

- A description of why this PR is needed. What does it fix? What does it 
  improve?
- A summary of the things that this PR changes.
- Reference the issues that this PR fixes (use the fixes #(issue nr) syntax). 
  If this PR does not fix any issue, create the issue first and mention that 
  you are willing to work on it.

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide 
instructions so we can reproduce. Include an example pdf if you have one. 

**Checklist**

- [x] I have added tests that prove my fix is effective or that my feature 
  works
- [x] I have added docstrings to newly created methods and classes
- [x] I have optimized the code at least one time after creating the initial 
  version
- [x] I have updated the [README.md](../README.md) or I am verified that this
  is not necessary
- [x] I have updated the [readthedocs](../docs/source) documentation or I 
  verified that this is not necessary
- [x] I have added a consice human-readable description of the change to 
  [CHANGELOG.md](../CHANGELOG.md)