### PR TITLE
pdfdevice.TagExtractor: fix TypeError in render_string

### DIFF
--- a/pdfminer/pdfdevice.py
+++ b/pdfminer/pdfdevice.py
@@ -156,7 +156,7 @@ class TagExtractor(PDFDevice):
                 except PDFUnicodeNotDefined:
                     print(chars)
                     pass
-        self.outfp.write(utils.enc(text))
+        self.outfp.write(utils.make_compat_bytes(utils.enc(text)))
         return
 
     def begin_page(self, page, ctm):


### PR DESCRIPTION
Fixes:
```
$ tools/pdf2txt.py --output_type tag samples/simple1.pdf
<page id="0" bbox="0.000,0.000,612.000,792.000" rotate="0">Traceback (most recent call last):
  File "tools/pdf2txt.py", line 204, in <module>
    sys.exit(main())
  File "tools/pdf2txt.py", line 198, in main
    outfp = extract_text(**vars(A))
  File "tools/pdf2txt.py", line 66, in extract_text
    pdfminer.high_level.extract_text_to_fp(fp, **locals())
  File "/mnt/c/src/pdfminer.six/pdfminer/high_level.py", line 85, in extract_text_to_fp
    interpreter.process_page(page)
  File "/mnt/c/src/pdfminer.six/pdfminer/pdfinterp.py", line 925, in process_page
    self.render_contents(page.resources, page.contents, ctm=ctm)
  File "/mnt/c/src/pdfminer.six/pdfminer/pdfinterp.py", line 939, in render_contents
    self.execute(list_value(streams))
  File "/mnt/c/src/pdfminer.six/pdfminer/pdfinterp.py", line 964, in execute
    func(*args)
  File "/mnt/c/src/pdfminer.six/pdfminer/pdfinterp.py", line 832, in do_TJ
    self.device.render_string(self.textstate, seq, self.ncs,
  File "/mnt/c/src/pdfminer.six/pdfminer/pdfdevice.py", line 191, in render_string
    self.outfp.write(utils.enc(text))
TypeError: a bytes-like object is required, not 'str'
```

Found via mypy (PR #661)