### PR TITLE
add font id and encoding in font and add cid in LTChar

### DIFF
--- a/pdfminer/converter.py
+++ b/pdfminer/converter.py
@@ -169,7 +169,7 @@ class PDFLayoutAnalyzer(PDFTextDevice):
         textwidth = font.char_width(cid)
         textdisp = font.char_disp(cid)
         item = LTChar(matrix, font, fontsize, scaling, rise, text, textwidth,
-                      textdisp, ncs, graphicstate)
+                      textdisp, ncs, graphicstate, cid)
         self.cur_item.add(item)
         return item.adv
 

--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -329,12 +329,16 @@ class LTChar(LTComponent, LTText):
         textwidth: float,
         textdisp: Union[float, Tuple[Optional[float], float]],
         ncs: PDFColorSpace,
-        graphicstate: PDFGraphicState
+        graphicstate: PDFGraphicState,
+        cid: int
     ) -> None:
         LTText.__init__(self)
         self._text = text
         self.matrix = matrix
         self.fontname = font.fontname
+        self.cid = cid
+        # Because the font name can be the same on a page, so add fontid attribute
+        if hasattr(font, "id"): self.fontid = font.id
         self.ncs = ncs
         self.graphicstate = graphicstate
         self.adv = textwidth * fontsize * scaling

--- a/pdfminer/pdffont.py
+++ b/pdfminer/pdffont.py
@@ -630,6 +630,7 @@ class PDFSimpleFont(PDFFont):
             encoding = resolve1(spec['Encoding'])
         else:
             encoding = LITERAL_STANDARD_ENCODING
+        self.encoding = encoding
         if isinstance(encoding, dict):
             name = literal_name(encoding.get('BaseEncoding',
                                              LITERAL_STANDARD_ENCODING))

--- a/pdfminer/pdfinterp.py
+++ b/pdfminer/pdfinterp.py
@@ -221,9 +221,8 @@ class PDFResourceManager:
                     raise PDFFontError('Invalid Font spec: %r' % spec)
                 font = PDFType1Font(self, spec)  # this is so wrong!
             if objid and self.caching:
+                font.id = objid                
                 self._cached_fonts[objid] = font
-                # font object add id attribute
-                font.id = objid
         return font
 
 

--- a/pdfminer/pdfinterp.py
+++ b/pdfminer/pdfinterp.py
@@ -222,6 +222,8 @@ class PDFResourceManager:
                 font = PDFType1Font(self, spec)  # this is so wrong!
             if objid and self.caching:
                 self._cached_fonts[objid] = font
+                # font object add id attribute
+                font.id = objid
         return font
 
 


### PR DESCRIPTION
**Pull request**

Thanks for improving pdfminer.six! Please include the following information to
help us discuss and merge this PR:

- A description of why this PR is needed. What does it fix? What does it 
  improve?
 add font id in Font: Because the font name can be the same on a page, so add fontid attribute.
 add cid in LTChar: Because some PDFTrueTypeFont are not correct，so can get cid from LTChar to fix.
 add encoding in Font: Same thing as above.   

- A summary of the things that this PR changes.
add font id at pdfinterp.py when get fonts.
add cid at converter.py when create LTChar object and add cid in LTChar class init.
add encoding at pdffont.py when PDFSimpleFont class init. 

- Reference the issues that this PR fixes (use the fixes #(issue nr) syntax). 
  If this PR does not fix any issue, create the issue first and mention that 
  you are willing to work on it.
not need.

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide 
instructions so we can reproduce. Include an example pdf if you have one. 

**Checklist**

- [ ] I have added tests that prove my fix is effective or that my feature 
  works
- [ ] I have added docstrings to newly created methods and classes
- [ ] I have optimized the code at least one time after creating the initial 
  version
- [ ] I have updated the [README.md](../README.md) or I am verified that this
  is not necessary
- [ ] I have updated the [readthedocs](../docs/source) documentation or I 
  verified that this is not necessary
- [ ] I have added a consice human-readable description of the change to 
  [CHANGELOG.md](../CHANGELOG.md)
