### PR TITLE
Fix Memory Leak (Issue 580)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+- Fix for memory leak ([#580](https://github.com/pdfminer/pdfminer.six/issues/580))
 - Support for identity cmap's ([#626](https://github.com/pdfminer/pdfminer.six/pull/626))
 
 ## [20211012]


### PR DESCRIPTION
PDF parsing leaked memory. If you bracketed a parsing operation with
gc.set_debug(gc.DEBUG_SAVEALL) and gc.garbage you would see a large number
of PdfMiner objects that are unable to be garbage collected.

The PSBaseParser kept track of its parse state by having a _parse1 instance
variable to which it assigned member functions of the same instance. This lead
to circular references which caused the memory leaks.

This fix replaces _parse1 with a _parse_type variable that takes on a value
of the ParseType enumerable. A parse_token member function dispatches the parse
operations with an if statement. With this change, memory no longer leaks.

**Pull request**

- Fix for memory leaks when doing PDF parsing.
- This changes the way in which the PDF parser maintains its internal state. The parsing functionality is not changed.
- #580 

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide 
instructions so we can reproduce. Include an example pdf if you have one. 

**Checklist**

- [ ] I have added tests that prove my fix is effective or that my feature 
  works
- [ ] I have added docstrings to newly created methods and classes
- [ ] I have optimized the code at least one time after creating the initial 
  version
- [ x] I have updated the [README.md](../README.md) or I am verified that this
  is not necessary
- [x] I have updated the [readthedocs](../docs/source) documentation or I 
  verified that this is not necessary
- [x] I have added a consice human-readable description of the change to 
  [CHANGELOG.md](../CHANGELOG.md)
