### PR TITLE
BugFix: Replace PDFPasswordIncorrect with PDFEncryptionWarning

### DIFF
--- a/pdfminer/pdfdocument.py
+++ b/pdfminer/pdfdocument.py
@@ -348,7 +348,7 @@ class PDFStandardSecurityHandler:
     def init_key(self) -> None:
         self.key = self.authenticate(self.password)
         if self.key is None:
-            raise PDFPasswordIncorrect
+            raise PDFEncryptionWarning
         return
 
     def is_printable(self) -> bool:


### PR DESCRIPTION
**Pull request**

Thanks for improving pdfminer.six! Please include the following information to
help us discuss and merge this PR:

- A description of why this PR is needed. What does it fix? What does it 
  improve?
  - From this PR https://github.com/htInEdin/pdfminer.six/commit/10f6fb40c258c86fd04d86bade20f69fb07faabd#diff-19c70cd6ee74a06a40b8124e99c5da47009d4b7d3d08f588290052c7538f4d26L43, `PDFPasswordIncorrect` should be replaced by `PDFEncryptionWarning`.
  - This PR replaces the remaining `PDFPasswordIncorrect` with `PDFEncryptionWarning`

- A summary of the things that this PR changes.
  - PDFPasswordIncorrect no longer has any reference, when raised, resulting in
 ```
handle_action exception occurred. Error string: 'module 'pdfminer.pdfdocument' has no attribute 'PDFPasswordIncorrect''
```


- Reference the issues that this PR fixes (use the fixes #(issue nr) syntax). 
  If this PR does not fix any issue, create the issue first and mention that 
  you are willing to work on it.
  - PR https://github.com/htInEdin/pdfminer.six/commit/10f6fb40c258c86fd04d86bade20f69fb07faabd#diff-19c70cd6ee74a06a40b8124e99c5da47009d4b7d3d08f588290052c7538f4d26L43

**How Has This Been Tested?**

Please describe the tests that you ran to verify your changes. Provide 
instructions so we can reproduce. Include an example pdf if you have one. 

**Checklist**

- [x] I have added tests that prove my fix is effective or that my feature 
  works
- [x] I have added docstrings to newly created methods and classes
- [x] I have optimized the code at least one time after creating the initial 
  version
- [x] I have updated the [README.md](../README.md) or verified that this
  is not necessary
- [ ] I have updated the [readthedocs](../docs/source) documentation or
  verified that this is not necessary
- [ ] I have added a concise human-readable description of the change to
  [CHANGELOG.md](../CHANGELOG.md)
