### PR TITLE
Remove obsolete returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Replace warnings.warn with logging.Logger.warning in line with [recommended use](https://docs.python.org/3/howto/logging.html#when-to-use-logging) ([#673](https://github.com/pdfminer/pdfminer.six/pull/673))
 
+### Removed
+- Unnecessary return statements without argument at the end of functions ([#707](https://github.com/pdfminer/pdfminer.six/pull/707))
+
 ## [20211012]
 
 ### Added

--- a/pdfminer/arcfour.py
+++ b/pdfminer/arcfour.py
@@ -21,7 +21,6 @@ class Arcfour:
         self.s = s
         (self.i, self.j) = (0, 0)
 
-
     def process(self, data: bytes) -> bytes:
         (i, j) = (self.i, self.j)
         s = self.s

--- a/pdfminer/arcfour.py
+++ b/pdfminer/arcfour.py
@@ -20,7 +20,7 @@ class Arcfour:
             (s[i], s[j]) = (s[j], s[i])
         self.s = s
         (self.i, self.j) = (0, 0)
-        return
+
 
     def process(self, data: bytes) -> bytes:
         (i, j) = (self.i, self.j)

--- a/pdfminer/ccitt.py
+++ b/pdfminer/ccitt.py
@@ -36,7 +36,6 @@ class BitParser:
     def __init__(self) -> None:
         self._pos = 0
 
-
     @classmethod
     def add(cls, root: BitParserState, v: Union[int, str], bits: str) -> None:
         p: BitParserState = root
@@ -54,12 +53,10 @@ class BitParser:
         assert b is not None
         p[b] = v
 
-
     def feedbytes(self, data: bytes) -> None:
         for byte in get_bytes(data):
             for m in (128, 64, 32, 16, 8, 4, 2, 1):
                 self._parse_bit(byte & m)
-
 
     def _parse_bit(self, x: object) -> None:
         if x:
@@ -72,7 +69,6 @@ class BitParser:
         else:
             assert self._accept is not None
             self._state = self._accept(v)
-
 
 
 class CCITTG4Parser(BitParser):

--- a/pdfminer/ccitt.py
+++ b/pdfminer/ccitt.py
@@ -35,7 +35,7 @@ class BitParser:
 
     def __init__(self) -> None:
         self._pos = 0
-        return
+
 
     @classmethod
     def add(cls, root: BitParserState, v: Union[int, str], bits: str) -> None:
@@ -53,13 +53,13 @@ class BitParser:
                 b = 0
         assert b is not None
         p[b] = v
-        return
+
 
     def feedbytes(self, data: bytes) -> None:
         for byte in get_bytes(data):
             for m in (128, 64, 32, 16, 8, 4, 2, 1):
                 self._parse_bit(byte & m)
-        return
+
 
     def _parse_bit(self, x: object) -> None:
         if x:
@@ -72,7 +72,7 @@ class BitParser:
         else:
             assert self._accept is not None
             self._state = self._accept(v)
-        return
+
 
 
 class CCITTG4Parser(BitParser):

--- a/pdfminer/cmapdb.py
+++ b/pdfminer/cmapdb.py
@@ -9,26 +9,26 @@ More information is available on the Adobe website:
 
 """
 
-import sys
+import gzip
+import logging
 import os
 import os.path
-import gzip
 import pickle as pickle
 import struct
-import logging
+import sys
 from typing import (Any, BinaryIO, Dict, Iterable, Iterator, List,
                     MutableMapping, Optional, TextIO, Tuple, Union, cast)
-from .psparser import PSStackParser
-from .psparser import PSSyntaxError
+
+from .encodingdb import name2unicode
+from .psparser import KWD
 from .psparser import PSEOF
 from .psparser import PSKeyword
 from .psparser import PSLiteral
+from .psparser import PSStackParser
+from .psparser import PSSyntaxError
 from .psparser import literal_name
-from .psparser import KWD
-from .encodingdb import name2unicode
 from .utils import choplist
 from .utils import nunpack
-
 
 log = logging.getLogger(__name__)
 
@@ -72,7 +72,6 @@ class CMap(CMapBase):
         CMapBase.__init__(self, **kwargs)
         self.code2cid: Dict[int, object] = {}
 
-
     def __repr__(self) -> str:
         return '<CMap: %s>' % self.attrs.get('CMapName')
 
@@ -89,7 +88,6 @@ class CMap(CMapBase):
                     dst[k] = v
         copy(self.code2cid, cmap.code2cid)
 
-
     def decode(self, code: bytes) -> Iterator[int]:
         log.debug('decode: %r, %r', self, code)
         d = self.code2cid
@@ -104,7 +102,6 @@ class CMap(CMapBase):
             else:
                 d = self.code2cid
 
-
     def dump(self, out: TextIO = sys.stdout,
              code2cid: Optional[Dict[int, object]] = None,
              code: Tuple[int, ...] = ()) -> None:
@@ -117,7 +114,6 @@ class CMap(CMapBase):
                 out.write('code %r = cid %d\n' % (c, v))
             else:
                 self.dump(out=out, code2cid=cast(Dict[int, object], v), code=c)
-
 
 
 class IdentityCMap(CMapBase):
@@ -146,7 +142,6 @@ class UnicodeMap(CMapBase):
         CMapBase.__init__(self, **kwargs)
         self.cid2unichr: Dict[int, str] = {}
 
-
     def __repr__(self) -> str:
         return '<UnicodeMap: %s>' % self.attrs.get('CMapName')
 
@@ -157,7 +152,6 @@ class UnicodeMap(CMapBase):
     def dump(self, out: TextIO = sys.stdout) -> None:
         for (k, v) in sorted(self.cid2unichr.items()):
             out.write('cid %d = unicode %r\n' % (k, v))
-
 
 
 class IdentityUnicodeMap(UnicodeMap):
@@ -185,7 +179,6 @@ class FileCMap(CMap):
         d[ci] = cid
 
 
-
 class FileUnicodeMap(UnicodeMap):
 
     def add_cid2unichr(self, cid: int, code: Union[PSLiteral, bytes, int]
@@ -204,7 +197,6 @@ class FileUnicodeMap(UnicodeMap):
             raise TypeError(code)
 
 
-
 class PyCMap(CMap):
 
     def __init__(self, name: str, module: Any) -> None:
@@ -212,7 +204,6 @@ class PyCMap(CMap):
         self.code2cid = module.CODE2CID
         if module.IS_VERTICAL:
             self.attrs['WMode'] = 1
-
 
 
 class PyUnicodeMap(UnicodeMap):
@@ -224,7 +215,6 @@ class PyUnicodeMap(UnicodeMap):
             self.attrs['WMode'] = 1
         else:
             self.cid2unichr = module.CID2UNICHR_H
-
 
 
 class CMapDB:

--- a/pdfminer/cmapdb.py
+++ b/pdfminer/cmapdb.py
@@ -43,24 +43,24 @@ class CMapBase:
 
     def __init__(self, **kwargs: object) -> None:
         self.attrs: MutableMapping[str, object] = kwargs.copy()
-        return
+
 
     def is_vertical(self) -> bool:
         return self.attrs.get('WMode', 0) != 0
 
     def set_attr(self, k: str, v: object) -> None:
         self.attrs[k] = v
-        return
+
 
     def add_code2cid(self, code: str, cid: int) -> None:
-        return
+        pass
 
     def add_cid2unichr(self, cid: int, code: Union[PSLiteral, bytes, int]
                        ) -> None:
-        return
+        pass
 
     def use_cmap(self, cmap: "CMapBase") -> None:
-        return
+        pass
 
     def decode(self, code: bytes) -> Iterable[int]:
         raise NotImplementedError
@@ -71,7 +71,7 @@ class CMap(CMapBase):
     def __init__(self, **kwargs: Union[str, int]) -> None:
         CMapBase.__init__(self, **kwargs)
         self.code2cid: Dict[int, object] = {}
-        return
+
 
     def __repr__(self) -> str:
         return '<CMap: %s>' % self.attrs.get('CMapName')
@@ -88,7 +88,7 @@ class CMap(CMapBase):
                 else:
                     dst[k] = v
         copy(self.code2cid, cmap.code2cid)
-        return
+
 
     def decode(self, code: bytes) -> Iterator[int]:
         log.debug('decode: %r, %r', self, code)
@@ -103,7 +103,7 @@ class CMap(CMapBase):
                     d = cast(Dict[int, object], x)
             else:
                 d = self.code2cid
-        return
+
 
     def dump(self, out: TextIO = sys.stdout,
              code2cid: Optional[Dict[int, object]] = None,
@@ -117,7 +117,7 @@ class CMap(CMapBase):
                 out.write('code %r = cid %d\n' % (c, v))
             else:
                 self.dump(out=out, code2cid=cast(Dict[int, object], v), code=c)
-        return
+
 
 
 class IdentityCMap(CMapBase):
@@ -145,7 +145,7 @@ class UnicodeMap(CMapBase):
     def __init__(self, **kwargs: Union[str, int]) -> None:
         CMapBase.__init__(self, **kwargs)
         self.cid2unichr: Dict[int, str] = {}
-        return
+
 
     def __repr__(self) -> str:
         return '<UnicodeMap: %s>' % self.attrs.get('CMapName')
@@ -157,7 +157,7 @@ class UnicodeMap(CMapBase):
     def dump(self, out: TextIO = sys.stdout) -> None:
         for (k, v) in sorted(self.cid2unichr.items()):
             out.write('cid %d = unicode %r\n' % (k, v))
-        return
+
 
 
 class IdentityUnicodeMap(UnicodeMap):
@@ -183,7 +183,7 @@ class FileCMap(CMap):
                 d = t
         ci = ord(code[-1])
         d[ci] = cid
-        return
+
 
 
 class FileUnicodeMap(UnicodeMap):
@@ -202,7 +202,7 @@ class FileUnicodeMap(UnicodeMap):
             self.cid2unichr[cid] = chr(code)
         else:
             raise TypeError(code)
-        return
+
 
 
 class PyCMap(CMap):
@@ -212,7 +212,7 @@ class PyCMap(CMap):
         self.code2cid = module.CODE2CID
         if module.IS_VERTICAL:
             self.attrs['WMode'] = 1
-        return
+
 
 
 class PyUnicodeMap(UnicodeMap):
@@ -224,7 +224,7 @@ class PyUnicodeMap(UnicodeMap):
             self.attrs['WMode'] = 1
         else:
             self.cid2unichr = module.CID2UNICHR_H
-        return
+
 
 
 class CMapDB:

--- a/pdfminer/cmapdb.py
+++ b/pdfminer/cmapdb.py
@@ -44,13 +44,11 @@ class CMapBase:
     def __init__(self, **kwargs: object) -> None:
         self.attrs: MutableMapping[str, object] = kwargs.copy()
 
-
     def is_vertical(self) -> bool:
         return self.attrs.get('WMode', 0) != 0
 
     def set_attr(self, k: str, v: object) -> None:
         self.attrs[k] = v
-
 
     def add_code2cid(self, code: str, cid: int) -> None:
         pass

--- a/pdfminer/converter.py
+++ b/pdfminer/converter.py
@@ -52,7 +52,7 @@ class PDFLayoutAnalyzer(PDFTextDevice):
         self.pageno = pageno
         self.laparams = laparams
         self._stack: List[LTLayoutContainer] = []
-        return
+
 
     def begin_page(self, page: PDFPage, ctm: Matrix) -> None:
         (x0, y0, x1, y1) = page.mediabox
@@ -60,7 +60,7 @@ class PDFLayoutAnalyzer(PDFTextDevice):
         (x1, y1) = apply_matrix_pt(ctm, (x1, y1))
         mediabox = (0, 0, abs(x0-x1), abs(y0-y1))
         self.cur_item = LTPage(self.pageno, mediabox)
-        return
+
 
     def end_page(self, page: PDFPage) -> None:
         assert not self._stack, str(len(self._stack))
@@ -69,19 +69,19 @@ class PDFLayoutAnalyzer(PDFTextDevice):
             self.cur_item.analyze(self.laparams)
         self.pageno += 1
         self.receive_layout(self.cur_item)
-        return
+
 
     def begin_figure(self, name: str, bbox: Rect, matrix: Matrix) -> None:
         self._stack.append(self.cur_item)
         self.cur_item = LTFigure(name, bbox, mult_matrix(matrix, self.ctm))
-        return
+
 
     def end_figure(self, _: str) -> None:
         fig = self.cur_item
         assert isinstance(self.cur_item, LTFigure), str(type(self.cur_item))
         self.cur_item = self._stack.pop()
         self.cur_item.add(fig)
-        return
+
 
     def render_image(self, name: str, stream: PDFStream) -> None:
         assert isinstance(self.cur_item, LTFigure), str(type(self.cur_item))
@@ -89,7 +89,7 @@ class PDFLayoutAnalyzer(PDFTextDevice):
                        (self.cur_item.x0, self.cur_item.y0,
                         self.cur_item.x1, self.cur_item.y1))
         self.cur_item.add(item)
-        return
+
 
     def paint_path(
         self,
@@ -178,7 +178,7 @@ class PDFLayoutAnalyzer(PDFTextDevice):
         return '(cid:%d)' % cid
 
     def receive_layout(self, ltpage: LTPage) -> None:
-        return
+        pass
 
 
 class PDFPageAggregator(PDFLayoutAnalyzer):
@@ -191,11 +191,11 @@ class PDFPageAggregator(PDFLayoutAnalyzer):
         PDFLayoutAnalyzer.__init__(self, rsrcmgr, pageno=pageno,
                                    laparams=laparams)
         self.result: Optional[LTPage] = None
-        return
+
 
     def receive_layout(self, ltpage: LTPage) -> None:
         self.result = ltpage
-        return
+
 
     def get_result(self) -> LTPage:
         assert self.result is not None
@@ -254,7 +254,7 @@ class TextConverter(PDFConverter[AnyIO]):
                          laparams=laparams)
         self.showpageno = showpageno
         self.imagewriter = imagewriter
-        return
+
 
     def write_text(self, text: str) -> None:
         text = utils.compatible_encode_method(text, self.codec, 'ignore')
@@ -262,7 +262,7 @@ class TextConverter(PDFConverter[AnyIO]):
             cast(BinaryIO, self.outfp).write(text.encode())
         else:
             cast(TextIO, self.outfp).write(text)
-        return
+
 
     def receive_layout(self, ltpage: LTPage) -> None:
         def render(item: LTItem) -> None:
@@ -280,7 +280,7 @@ class TextConverter(PDFConverter[AnyIO]):
             self.write_text('Page %s\n' % ltpage.pageid)
         render(ltpage)
         self.write_text('\f')
-        return
+
 
     # Some dummy functions to save memory/CPU when all that is wanted
     # is text.  This stops all the image and drawing output from being

--- a/pdfminer/converter.py
+++ b/pdfminer/converter.py
@@ -1,11 +1,12 @@
 import io
 import logging
-from pdfminer.pdfcolor import PDFColorSpace
+import re
 from typing import (BinaryIO, Dict, Generic, List, Optional, Sequence, TextIO,
                     Tuple, TypeVar, Union, cast)
-import re
 
+from pdfminer.pdfcolor import PDFColorSpace
 from . import utils
+from .image import ImageWriter
 from .layout import LAParams, LTComponent, TextGroupElement
 from .layout import LTChar
 from .layout import LTContainer
@@ -33,7 +34,6 @@ from .utils import apply_matrix_pt
 from .utils import bbox2str
 from .utils import enc
 from .utils import mult_matrix
-from .image import ImageWriter
 
 log = logging.getLogger(__name__)
 
@@ -61,7 +61,6 @@ class PDFLayoutAnalyzer(PDFTextDevice):
         mediabox = (0, 0, abs(x0-x1), abs(y0-y1))
         self.cur_item = LTPage(self.pageno, mediabox)
 
-
     def end_page(self, page: PDFPage) -> None:
         assert not self._stack, str(len(self._stack))
         assert isinstance(self.cur_item, LTPage), str(type(self.cur_item))
@@ -70,11 +69,9 @@ class PDFLayoutAnalyzer(PDFTextDevice):
         self.pageno += 1
         self.receive_layout(self.cur_item)
 
-
     def begin_figure(self, name: str, bbox: Rect, matrix: Matrix) -> None:
         self._stack.append(self.cur_item)
         self.cur_item = LTFigure(name, bbox, mult_matrix(matrix, self.ctm))
-
 
     def end_figure(self, _: str) -> None:
         fig = self.cur_item
@@ -82,14 +79,12 @@ class PDFLayoutAnalyzer(PDFTextDevice):
         self.cur_item = self._stack.pop()
         self.cur_item.add(fig)
 
-
     def render_image(self, name: str, stream: PDFStream) -> None:
         assert isinstance(self.cur_item, LTFigure), str(type(self.cur_item))
         item = LTImage(name, stream,
                        (self.cur_item.x0, self.cur_item.y0,
                         self.cur_item.x1, self.cur_item.y1))
         self.cur_item.add(item)
-
 
     def paint_path(
         self,
@@ -192,10 +187,8 @@ class PDFPageAggregator(PDFLayoutAnalyzer):
                                    laparams=laparams)
         self.result: Optional[LTPage] = None
 
-
     def receive_layout(self, ltpage: LTPage) -> None:
         self.result = ltpage
-
 
     def get_result(self) -> LTPage:
         assert self.result is not None
@@ -255,14 +248,12 @@ class TextConverter(PDFConverter[AnyIO]):
         self.showpageno = showpageno
         self.imagewriter = imagewriter
 
-
     def write_text(self, text: str) -> None:
         text = utils.compatible_encode_method(text, self.codec, 'ignore')
         if self.outfp_binary:
             cast(BinaryIO, self.outfp).write(text.encode())
         else:
             cast(TextIO, self.outfp).write(text)
-
 
     def receive_layout(self, ltpage: LTPage) -> None:
         def render(item: LTItem) -> None:
@@ -280,7 +271,6 @@ class TextConverter(PDFConverter[AnyIO]):
             self.write_text('Page %s\n' % ltpage.pageid)
         render(ltpage)
         self.write_text('\f')
-
 
     # Some dummy functions to save memory/CPU when all that is wanted
     # is text.  This stops all the image and drawing output from being

--- a/pdfminer/converter.py
+++ b/pdfminer/converter.py
@@ -53,7 +53,6 @@ class PDFLayoutAnalyzer(PDFTextDevice):
         self.laparams = laparams
         self._stack: List[LTLayoutContainer] = []
 
-
     def begin_page(self, page: PDFPage, ctm: Matrix) -> None:
         (x0, y0, x1, y1) = page.mediabox
         (x0, y0) = apply_matrix_pt(ctm, (x0, y0))

--- a/pdfminer/image.py
+++ b/pdfminer/image.py
@@ -59,11 +59,9 @@ class BMPWriter:
         self.pos0 = self.fp.tell()
         self.pos1 = self.pos0 + self.datasize
 
-
     def write_line(self, y: int, data: bytes) -> None:
         self.fp.seek(self.pos1 - (y+1)*self.linesize)
         self.fp.write(data)
-
 
 
 class ImageWriter:
@@ -76,7 +74,6 @@ class ImageWriter:
         self.outdir = outdir
         if not os.path.exists(self.outdir):
             os.makedirs(self.outdir)
-
 
     def export_image(self, image: LTImage) -> str:
         (width, height) = image.srcsize

--- a/pdfminer/image.py
+++ b/pdfminer/image.py
@@ -58,12 +58,12 @@ class BMPWriter:
                 self.fp.write(struct.pack('BBBx', i, i, i))
         self.pos0 = self.fp.tell()
         self.pos1 = self.pos0 + self.datasize
-        return
+
 
     def write_line(self, y: int, data: bytes) -> None:
         self.fp.seek(self.pos1 - (y+1)*self.linesize)
         self.fp.write(data)
-        return
+
 
 
 class ImageWriter:
@@ -76,7 +76,7 @@ class ImageWriter:
         self.outdir = outdir
         if not os.path.exists(self.outdir):
             os.makedirs(self.outdir)
-        return
+
 
     def export_image(self, image: LTImage) -> str:
         (width, height) = image.srcsize

--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -28,7 +28,7 @@ class IndexAssigner:
 
     def __init__(self, index: int = 0) -> None:
         self.index = index
-        return
+
 
     def run(self, obj: "LTItem") -> None:
         if isinstance(obj, LTTextBox):
@@ -37,7 +37,7 @@ class IndexAssigner:
         elif isinstance(obj, LTTextGroup):
             for x in obj:
                 self.run(x)
-        return
+
 
 
 class LAParams:
@@ -87,7 +87,7 @@ class LAParams:
         self.all_texts = all_texts
 
         self._validate()
-        return
+
 
     def _validate(self) -> None:
         if self.boxes_flow is not None:
@@ -111,7 +111,7 @@ class LTItem:
 
     def analyze(self, laparams: LAParams) -> None:
         """Perform the layout analysis."""
-        return
+        pass
 
 
 class LTText:
@@ -132,7 +132,7 @@ class LTComponent(LTItem):
     def __init__(self, bbox: Rect) -> None:
         LTItem.__init__(self)
         self.set_bbox(bbox)
-        return
+
 
     def __repr__(self) -> str:
         return ('<%s %s>' %
@@ -160,7 +160,7 @@ class LTComponent(LTItem):
         self.width = x1-x0
         self.height = y1-y0
         self.bbox = bbox
-        return
+
 
     def is_empty(self) -> bool:
         return self.width <= 0 or self.height <= 0
@@ -223,7 +223,7 @@ class LTCurve(LTComponent):
         self.evenodd = evenodd
         self.stroking_color = stroking_color
         self.non_stroking_color = non_stroking_color
-        return
+
 
     def get_pts(self) -> str:
         return ','.join('%.3f,%.3f' % p for p in self.pts)
@@ -248,7 +248,7 @@ class LTLine(LTCurve):
     ) -> None:
         LTCurve.__init__(self, linewidth, [p0, p1], stroke, fill, evenodd,
                          stroking_color, non_stroking_color)
-        return
+
 
 
 class LTRect(LTCurve):
@@ -271,7 +271,7 @@ class LTRect(LTCurve):
         LTCurve.__init__(self, linewidth,
                          [(x0, y0), (x1, y0), (x1, y1), (x0, y1)], stroke,
                          fill, evenodd, stroking_color, non_stroking_color)
-        return
+
 
 
 class LTImage(LTComponent):
@@ -291,7 +291,7 @@ class LTImage(LTComponent):
         self.colorspace = stream.get_any(('CS', 'ColorSpace'))
         if not isinstance(self.colorspace, list):
             self.colorspace = [self.colorspace]
-        return
+
 
     def __repr__(self) -> str:
         return ('<%s(%s) %s %r>' %

--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -3,6 +3,11 @@ import logging
 from typing import (Dict, Generic, Iterable, Iterator, List, Optional,
                     Sequence, Set, Tuple, TypeVar, Union, cast)
 
+from .pdfcolor import PDFColorSpace
+from .pdffont import PDFFont
+from .pdfinterp import Color
+from .pdfinterp import PDFGraphicState
+from .pdftypes import PDFStream
 from .utils import INF
 from .utils import LTComponentT
 from .utils import Matrix
@@ -15,11 +20,6 @@ from .utils import fsplit
 from .utils import get_bound
 from .utils import matrix2str
 from .utils import uniq
-from .pdfcolor import PDFColorSpace
-from .pdftypes import PDFStream
-from .pdfinterp import Color
-from .pdfinterp import PDFGraphicState
-from .pdffont import PDFFont
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +37,6 @@ class IndexAssigner:
         elif isinstance(obj, LTTextGroup):
             for x in obj:
                 self.run(x)
-
 
 
 class LAParams:
@@ -88,7 +87,6 @@ class LAParams:
 
         self._validate()
 
-
     def _validate(self) -> None:
         if self.boxes_flow is not None:
             boxes_flow_err_msg = ("LAParam boxes_flow should be None, or a "
@@ -133,7 +131,6 @@ class LTComponent(LTItem):
         LTItem.__init__(self)
         self.set_bbox(bbox)
 
-
     def __repr__(self) -> str:
         return ('<%s %s>' %
                 (self.__class__.__name__, bbox2str(self.bbox)))
@@ -160,7 +157,6 @@ class LTComponent(LTItem):
         self.width = x1-x0
         self.height = y1-y0
         self.bbox = bbox
-
 
     def is_empty(self) -> bool:
         return self.width <= 0 or self.height <= 0
@@ -224,7 +220,6 @@ class LTCurve(LTComponent):
         self.stroking_color = stroking_color
         self.non_stroking_color = non_stroking_color
 
-
     def get_pts(self) -> str:
         return ','.join('%.3f,%.3f' % p for p in self.pts)
 
@@ -250,7 +245,6 @@ class LTLine(LTCurve):
                          stroking_color, non_stroking_color)
 
 
-
 class LTRect(LTCurve):
     """A rectangle.
 
@@ -273,7 +267,6 @@ class LTRect(LTCurve):
                          fill, evenodd, stroking_color, non_stroking_color)
 
 
-
 class LTImage(LTComponent):
     """An image object.
 
@@ -291,7 +284,6 @@ class LTImage(LTComponent):
         self.colorspace = stream.get_any(('CS', 'ColorSpace'))
         if not isinstance(self.colorspace, list):
             self.colorspace = [self.colorspace]
-
 
     def __repr__(self) -> str:
         return ('<%s(%s) %s %r>' %

--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -29,7 +29,6 @@ class IndexAssigner:
     def __init__(self, index: int = 0) -> None:
         self.index = index
 
-
     def run(self, obj: "LTItem") -> None:
         if isinstance(obj, LTTextBox):
             obj.index = self.index

--- a/pdfminer/lzw.py
+++ b/pdfminer/lzw.py
@@ -1,7 +1,6 @@
-from io import BytesIO
 import logging
+from io import BytesIO
 from typing import BinaryIO, Iterator, List, Optional, cast
-
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +19,6 @@ class LZWDecoder:
         # NB: self.table stores None only in indices 256 and 257
         self.table: Optional[List[Optional[bytes]]] = None
         self.prevbuf: Optional[bytes] = None
-
 
     def readbits(self, bits: int) -> int:
         v = 0
@@ -95,7 +93,6 @@ class LZWDecoder:
             assert self.table is not None
             logger.debug('nbits=%d, code=%d, output=%r, table=%r'
                          % (self.nbits, code, x, self.table[258:]))
-
 
 
 def lzwdecode(data: bytes) -> bytes:

--- a/pdfminer/lzw.py
+++ b/pdfminer/lzw.py
@@ -20,7 +20,7 @@ class LZWDecoder:
         # NB: self.table stores None only in indices 256 and 257
         self.table: Optional[List[Optional[bytes]]] = None
         self.prevbuf: Optional[bytes] = None
-        return
+
 
     def readbits(self, bits: int) -> int:
         v = 0
@@ -95,7 +95,7 @@ class LZWDecoder:
             assert self.table is not None
             logger.debug('nbits=%d, code=%d, output=%r, table=%r'
                          % (self.nbits, code, x, self.table[258:]))
-        return
+
 
 
 def lzwdecode(data: bytes) -> bytes:

--- a/pdfminer/pdfcolor.py
+++ b/pdfminer/pdfcolor.py
@@ -1,7 +1,7 @@
 import collections
 from typing import Dict
-from .psparser import LIT
 
+from .psparser import LIT
 
 LITERAL_DEVICE_GRAY = LIT('DeviceGray')
 LITERAL_DEVICE_RGB = LIT('DeviceRGB')
@@ -13,7 +13,6 @@ class PDFColorSpace:
     def __init__(self, name: str, ncomponents: int) -> None:
         self.name = name
         self.ncomponents = ncomponents
-
 
     def __repr__(self) -> str:
         return '<PDFColorSpace: %s, ncomponents=%d>' % \

--- a/pdfminer/pdfcolor.py
+++ b/pdfminer/pdfcolor.py
@@ -13,7 +13,7 @@ class PDFColorSpace:
     def __init__(self, name: str, ncomponents: int) -> None:
         self.name = name
         self.ncomponents = ncomponents
-        return
+
 
     def __repr__(self) -> str:
         return '<PDFColorSpace: %s, ncomponents=%d>' % \

--- a/pdfminer/pdfdevice.py
+++ b/pdfminer/pdfdevice.py
@@ -28,7 +28,6 @@ class PDFDevice:
         self.rsrcmgr = rsrcmgr
         self.ctm: Optional[Matrix] = None
 
-
     def __repr__(self) -> str:
         return '<PDFDevice>'
 
@@ -48,7 +47,6 @@ class PDFDevice:
 
     def set_ctm(self, ctm: Matrix) -> None:
         self.ctm = ctm
-
 
     def begin_tag(
         self,

--- a/pdfminer/pdfdevice.py
+++ b/pdfminer/pdfdevice.py
@@ -26,7 +26,7 @@ class PDFDevice:
     def __init__(self, rsrcmgr: "PDFResourceManager") -> None:
         self.rsrcmgr = rsrcmgr
         self.ctm: Optional[Matrix] = None
-        return
+
 
     def __repr__(self) -> str:
         return '<PDFDevice>'
@@ -43,40 +43,40 @@ class PDFDevice:
         self.close()
 
     def close(self) -> None:
-        return
+        pass
 
     def set_ctm(self, ctm: Matrix) -> None:
         self.ctm = ctm
-        return
+
 
     def begin_tag(
         self,
         tag: PSLiteral,
         props: Optional["PDFStackT"] = None
     ) -> None:
-        return
+        pass
 
     def end_tag(self) -> None:
-        return
+        pass
 
     def do_tag(
         self,
         tag: PSLiteral,
         props: Optional["PDFStackT"] = None
     ) -> None:
-        return
+        pass
 
     def begin_page(self, page: PDFPage, ctm: Matrix) -> None:
-        return
+        pass
 
     def end_page(self, page: PDFPage) -> None:
-        return
+        pass
 
     def begin_figure(self, name: str, bbox: Rect, matrix: Matrix) -> None:
-        return
+        pass
 
     def end_figure(self, name: str) -> None:
-        return
+        pass
 
     def paint_path(
         self,
@@ -86,10 +86,10 @@ class PDFDevice:
         evenodd: bool,
         path: Sequence[PathSegment]
     ) -> None:
-        return
+        pass
 
     def render_image(self, name: str, stream: PDFStream) -> None:
-        return
+        pass
 
     def render_string(
         self,
@@ -98,7 +98,7 @@ class PDFDevice:
         ncs: PDFColorSpace,
         graphicstate: "PDFGraphicState"
     ) -> None:
-        return
+        pass
 
 
 class PDFTextDevice(PDFDevice):
@@ -132,7 +132,7 @@ class PDFTextDevice(PDFDevice):
                 seq, matrix, textstate.linematrix, font, fontsize,
                 scaling, charspace, wordspace, rise, dxscale, ncs,
                 graphicstate)
-        return
+
 
     def render_string_horizontal(
         self,
@@ -227,7 +227,7 @@ class TagExtractor(PDFDevice):
         self.codec = codec
         self.pageno = 0
         self._stack: List[PSLiteral] = []
-        return
+
 
     def render_string(
         self,
@@ -252,7 +252,7 @@ class TagExtractor(PDFDevice):
                 except PDFUnicodeNotDefined:
                     pass
         self._write(utils.enc(text))
-        return
+
 
     def begin_page(self, page: PDFPage, ctm: Matrix) -> None:
         output = '<page id="%s" bbox="%s" rotate="%d">' %\

--- a/pdfminer/pdfdevice.py
+++ b/pdfminer/pdfdevice.py
@@ -1,13 +1,14 @@
-from pdfminer.psparser import PSLiteral
 from typing import (BinaryIO, Iterable, List, Optional, Sequence,
                     TYPE_CHECKING, Union, cast)
+
+from pdfminer.psparser import PSLiteral
 from . import utils
-from .utils import Matrix, Point, Rect, PathSegment
 from .pdfcolor import PDFColorSpace
 from .pdffont import PDFFont
 from .pdffont import PDFUnicodeNotDefined
 from .pdfpage import PDFPage
 from .pdftypes import PDFStream
+from .utils import Matrix, Point, Rect, PathSegment
 
 if TYPE_CHECKING:
     from .pdfinterp import PDFGraphicState
@@ -133,7 +134,6 @@ class PDFTextDevice(PDFDevice):
                 scaling, charspace, wordspace, rise, dxscale, ncs,
                 graphicstate)
 
-
     def render_string_horizontal(
         self,
         seq: PDFTextSeq,
@@ -228,7 +228,6 @@ class TagExtractor(PDFDevice):
         self.pageno = 0
         self._stack: List[PSLiteral] = []
 
-
     def render_string(
         self,
         textstate: "PDFTextState",
@@ -252,7 +251,6 @@ class TagExtractor(PDFDevice):
                 except PDFUnicodeNotDefined:
                     pass
         self._write(utils.enc(text))
-
 
     def begin_page(self, page: PDFPage, ctm: Matrix) -> None:
         output = '<page id="%s" bbox="%s" rotate="%d">' %\

--- a/pdfminer/pdfdocument.py
+++ b/pdfminer/pdfdocument.py
@@ -100,7 +100,7 @@ class PDFXRef(PDFBaseXRef):
     def __init__(self) -> None:
         self.offsets: Dict[int, Tuple[Optional[int], int, int]] = {}
         self.trailer: Dict[str, Any] = {}
-        return
+
 
     def __repr__(self) -> str:
         return '<PDFXRef: offsets=%r>' % (self.offsets.keys())
@@ -145,7 +145,7 @@ class PDFXRef(PDFBaseXRef):
                 self.offsets[objid] = (None, int(pos_b), int(genno_b))
         log.info('xref objects: %r', self.offsets)
         self.load_trailer(parser)
-        return
+
 
     def load_trailer(self, parser: PDFParser) -> None:
         try:
@@ -159,7 +159,7 @@ class PDFXRef(PDFBaseXRef):
             (_, dic) = x[0]
         self.trailer.update(dict_value(dic))
         log.debug('trailer=%r', self.trailer)
-        return
+
 
     def get_trailer(self) -> Dict[str, Any]:
         return self.trailer
@@ -225,7 +225,7 @@ class PDFXRefFallback(PDFXRef):
                 for index in range(n):
                     objid1 = objs[index*2]
                     self.offsets[objid1] = (objid, index, 0)
-        return
+
 
 
 class PDFXRefStream(PDFBaseXRef):
@@ -237,7 +237,7 @@ class PDFXRefStream(PDFBaseXRef):
         self.fl2: Optional[int] = None
         self.fl3: Optional[int] = None
         self.ranges: List[Tuple[int, int]] = []
-        return
+
 
     def __repr__(self) -> str:
         return '<PDFXRefStream: ranges=%r>' % (self.ranges)

--- a/pdfminer/pdfdocument.py
+++ b/pdfminer/pdfdocument.py
@@ -101,7 +101,6 @@ class PDFXRef(PDFBaseXRef):
         self.offsets: Dict[int, Tuple[Optional[int], int, int]] = {}
         self.trailer: Dict[str, Any] = {}
 
-
     def __repr__(self) -> str:
         return '<PDFXRef: offsets=%r>' % (self.offsets.keys())
 
@@ -146,7 +145,6 @@ class PDFXRef(PDFBaseXRef):
         log.info('xref objects: %r', self.offsets)
         self.load_trailer(parser)
 
-
     def load_trailer(self, parser: PDFParser) -> None:
         try:
             (_, kwd) = parser.nexttoken()
@@ -159,7 +157,6 @@ class PDFXRef(PDFBaseXRef):
             (_, dic) = x[0]
         self.trailer.update(dict_value(dic))
         log.debug('trailer=%r', self.trailer)
-
 
     def get_trailer(self) -> Dict[str, Any]:
         return self.trailer
@@ -227,7 +224,6 @@ class PDFXRefFallback(PDFXRef):
                     self.offsets[objid1] = (objid, index, 0)
 
 
-
 class PDFXRefStream(PDFBaseXRef):
 
     def __init__(self) -> None:
@@ -237,7 +233,6 @@ class PDFXRefStream(PDFBaseXRef):
         self.fl2: Optional[int] = None
         self.fl3: Optional[int] = None
         self.ranges: List[Tuple[int, int]] = []
-
 
     def __repr__(self) -> str:
         return '<PDFXRefStream: ranges=%r>' % (self.ranges)

--- a/pdfminer/pdfinterp.py
+++ b/pdfminer/pdfinterp.py
@@ -73,7 +73,7 @@ class PDFTextState:
         self.reset()
         # self.matrix is set
         # self.linematrix is set
-        return
+
 
     def __repr__(self) -> str:
         return '<PDFTextState: font=%r, fontsize=%r, charspace=%r, ' \
@@ -100,7 +100,7 @@ class PDFTextState:
     def reset(self) -> None:
         self.matrix = MATRIX_IDENTITY
         self.linematrix = (0, 0)
-        return
+
 
 
 Color = Union[
@@ -125,7 +125,7 @@ class PDFGraphicState:
 
         # non stroking color
         self.ncolor: Optional[Color] = None
-        return
+
 
     def copy(self) -> "PDFGraphicState":
         obj = PDFGraphicState()
@@ -160,7 +160,7 @@ class PDFResourceManager:
     def __init__(self, caching: bool = True) -> None:
         self.caching = caching
         self._cached_fonts: Dict[object, PDFFont] = {}
-        return
+
 
     def get_procset(self, procs: Sequence[object]) -> None:
         for proc in procs:
@@ -170,7 +170,7 @@ class PDFResourceManager:
                 pass
             else:
                 pass
-        return
+
 
     def get_cmap(self, cmapname: str, strict: bool = False) -> CMapBase:
         try:
@@ -234,7 +234,7 @@ class PDFContentParser(PSStackParser[Union[PSKeyword, PDFStream]]):
         # all the methods that would attempt to access self.fp without first
         # calling self.fillfp().
         PSStackParser.__init__(self, None)  # type: ignore[arg-type]
-        return
+
 
     def fillfp(self) -> None:
         if not self.fp:
@@ -244,12 +244,12 @@ class PDFContentParser(PSStackParser[Union[PSKeyword, PDFStream]]):
             else:
                 raise PSEOF('Unexpected EOF, file truncated?')
             self.fp = BytesIO(strm.get_data())
-        return
+
 
     def seek(self, pos: int) -> None:
         self.fillfp()
         PSStackParser.seek(self, pos)
-        return
+
 
     def fillbuf(self) -> None:
         if self.charpos < len(self.buf):
@@ -262,7 +262,7 @@ class PDFContentParser(PSStackParser[Union[PSKeyword, PDFStream]]):
                 break
             self.fp = None  # type: ignore[assignment]
         self.charpos = 0
-        return
+
 
     def get_inline_data(
         self,
@@ -300,7 +300,7 @@ class PDFContentParser(PSStackParser[Union[PSKeyword, PDFStream]]):
 
     def flush(self) -> None:
         self.add_results(*self.popall())
-        return
+
 
     KEYWORD_BI = KWD(b'BI')
     KEYWORD_ID = KWD(b'ID')
@@ -327,7 +327,7 @@ class PDFContentParser(PSStackParser[Union[PSKeyword, PDFStream]]):
                     raise
         else:
             self.push((pos, token))
-        return
+
 
 
 PDFStackT = PSStackType[PDFStream]

--- a/pdfminer/pdfinterp.py
+++ b/pdfminer/pdfinterp.py
@@ -1,43 +1,43 @@
-import re
 import logging
-from typing import Dict, List, Mapping, Optional, Sequence, Tuple, Union, cast
+import re
 from io import BytesIO
-from .cmapdb import CMapDB
+from typing import Dict, List, Mapping, Optional, Sequence, Tuple, Union, cast
+
+from . import settings
 from .cmapdb import CMap
 from .cmapdb import CMapBase
-from .psparser import PSLiteral, PSTypeError
-from .psparser import PSStackType
-from .psparser import PSEOF
-from .psparser import PSKeyword
-from .psparser import literal_name
-from .psparser import keyword_name
-from .psparser import PSStackParser
-from .psparser import LIT
-from .psparser import KWD
-from . import settings
-from .pdfdevice import PDFDevice
-from .pdfdevice import PDFTextSeq
-from .pdfpage import PDFPage
-from .pdftypes import PDFException
-from .pdftypes import PDFStream
-from .pdftypes import PDFObjRef
-from .pdftypes import resolve1
-from .pdftypes import list_value
-from .pdftypes import dict_value
-from .pdftypes import stream_value
-from .pdffont import PDFFont
-from .pdffont import PDFFontError
-from .pdffont import PDFType1Font
-from .pdffont import PDFTrueTypeFont
-from .pdffont import PDFType3Font
-from .pdffont import PDFCIDFont
+from .cmapdb import CMapDB
 from .pdfcolor import PDFColorSpace
 from .pdfcolor import PREDEFINED_COLORSPACE
+from .pdfdevice import PDFDevice
+from .pdfdevice import PDFTextSeq
+from .pdffont import PDFCIDFont
+from .pdffont import PDFFont
+from .pdffont import PDFFontError
+from .pdffont import PDFTrueTypeFont
+from .pdffont import PDFType1Font
+from .pdffont import PDFType3Font
+from .pdfpage import PDFPage
+from .pdftypes import PDFException
+from .pdftypes import PDFObjRef
+from .pdftypes import PDFStream
+from .pdftypes import dict_value
+from .pdftypes import list_value
+from .pdftypes import resolve1
+from .pdftypes import stream_value
+from .psparser import KWD
+from .psparser import LIT
+from .psparser import PSEOF
+from .psparser import PSKeyword
+from .psparser import PSLiteral, PSTypeError
+from .psparser import PSStackParser
+from .psparser import PSStackType
+from .psparser import keyword_name
+from .psparser import literal_name
+from .utils import MATRIX_IDENTITY
 from .utils import Matrix, Point, PathSegment, Rect
 from .utils import choplist
 from .utils import mult_matrix
-from .utils import MATRIX_IDENTITY
-
 
 log = logging.getLogger(__name__)
 
@@ -74,7 +74,6 @@ class PDFTextState:
         # self.matrix is set
         # self.linematrix is set
 
-
     def __repr__(self) -> str:
         return '<PDFTextState: font=%r, fontsize=%r, charspace=%r, ' \
                'wordspace=%r, scaling=%r, leading=%r, render=%r, rise=%r, ' \
@@ -102,7 +101,6 @@ class PDFTextState:
         self.linematrix = (0, 0)
 
 
-
 Color = Union[
     float,                              # Greyscale
     Tuple[float, float, float],         # R, G, B
@@ -125,7 +123,6 @@ class PDFGraphicState:
 
         # non stroking color
         self.ncolor: Optional[Color] = None
-
 
     def copy(self) -> "PDFGraphicState":
         obj = PDFGraphicState()
@@ -161,7 +158,6 @@ class PDFResourceManager:
         self.caching = caching
         self._cached_fonts: Dict[object, PDFFont] = {}
 
-
     def get_procset(self, procs: Sequence[object]) -> None:
         for proc in procs:
             if proc is LITERAL_PDF:
@@ -170,7 +166,6 @@ class PDFResourceManager:
                 pass
             else:
                 pass
-
 
     def get_cmap(self, cmapname: str, strict: bool = False) -> CMapBase:
         try:
@@ -235,7 +230,6 @@ class PDFContentParser(PSStackParser[Union[PSKeyword, PDFStream]]):
         # calling self.fillfp().
         PSStackParser.__init__(self, None)  # type: ignore[arg-type]
 
-
     def fillfp(self) -> None:
         if not self.fp:
             if self.istream < len(self.streams):
@@ -245,11 +239,9 @@ class PDFContentParser(PSStackParser[Union[PSKeyword, PDFStream]]):
                 raise PSEOF('Unexpected EOF, file truncated?')
             self.fp = BytesIO(strm.get_data())
 
-
     def seek(self, pos: int) -> None:
         self.fillfp()
         PSStackParser.seek(self, pos)
-
 
     def fillbuf(self) -> None:
         if self.charpos < len(self.buf):
@@ -262,7 +254,6 @@ class PDFContentParser(PSStackParser[Union[PSKeyword, PDFStream]]):
                 break
             self.fp = None  # type: ignore[assignment]
         self.charpos = 0
-
 
     def get_inline_data(
         self,
@@ -301,7 +292,6 @@ class PDFContentParser(PSStackParser[Union[PSKeyword, PDFStream]]):
     def flush(self) -> None:
         self.add_results(*self.popall())
 
-
     KEYWORD_BI = KWD(b'BI')
     KEYWORD_ID = KWD(b'ID')
     KEYWORD_EI = KWD(b'EI')
@@ -327,7 +317,6 @@ class PDFContentParser(PSStackParser[Union[PSKeyword, PDFStream]]):
                     raise
         else:
             self.push((pos, token))
-
 
 
 PDFStackT = PSStackType[PDFStream]

--- a/pdfminer/pdfpage.py
+++ b/pdfminer/pdfpage.py
@@ -1,16 +1,16 @@
 import logging
-from pdfminer.utils import Rect
 from typing import BinaryIO, Container, Dict, Iterator, List, Optional, Tuple
+
+from pdfminer.utils import Rect
 from . import settings
-from .psparser import LIT
+from .pdfdocument import PDFDocument, PDFTextExtractionNotAllowed
+from .pdfparser import PDFParser
 from .pdftypes import PDFObjectNotFound
-from .pdftypes import resolve1
+from .pdftypes import dict_value
 from .pdftypes import int_value
 from .pdftypes import list_value
-from .pdftypes import dict_value
-from .pdfparser import PDFParser
-from .pdfdocument import PDFDocument, PDFTextExtractionNotAllowed
-
+from .pdftypes import resolve1
+from .psparser import LIT
 
 log = logging.getLogger(__name__)
 
@@ -73,7 +73,6 @@ class PDFPage:
         if not isinstance(contents, list):
             contents = [contents]
         self.contents: List[object] = contents
-
 
     def __repr__(self) -> str:
         return '<PDFPage: Resources={!r}, MediaBox={!r}>'\

--- a/pdfminer/pdfpage.py
+++ b/pdfminer/pdfpage.py
@@ -73,7 +73,7 @@ class PDFPage:
         if not isinstance(contents, list):
             contents = [contents]
         self.contents: List[object] = contents
-        return
+
 
     def __repr__(self) -> str:
         return '<PDFPage: Resources={!r}, MediaBox={!r}>'\

--- a/pdfminer/pdfparser.py
+++ b/pdfminer/pdfparser.py
@@ -1,17 +1,18 @@
 import logging
 from io import BytesIO
 from typing import BinaryIO, TYPE_CHECKING, Optional, Union
-from .psparser import PSStackParser
-from .psparser import PSKeyword
-from .psparser import PSSyntaxError
-from .psparser import PSEOF
-from .psparser import KWD
+
 from . import settings
 from .pdftypes import PDFException
-from .pdftypes import PDFStream
 from .pdftypes import PDFObjRef
-from .pdftypes import int_value
+from .pdftypes import PDFStream
 from .pdftypes import dict_value
+from .pdftypes import int_value
+from .psparser import KWD
+from .psparser import PSEOF
+from .psparser import PSKeyword
+from .psparser import PSStackParser
+from .psparser import PSSyntaxError
 
 if TYPE_CHECKING:
     from .pdfdocument import PDFDocument
@@ -46,11 +47,9 @@ class PDFParser(PSStackParser[Union[PSKeyword, PDFStream, PDFObjRef, None]]):
         self.doc: Optional["PDFDocument"] = None
         self.fallback = False
 
-
     def set_document(self, doc: "PDFDocument") -> None:
         """Associates the parser with a PDFDocument object."""
         self.doc = doc
-
 
     KEYWORD_R = KWD(b'R')
     KEYWORD_NULL = KWD(b'null')
@@ -135,8 +134,6 @@ class PDFParser(PSStackParser[Union[PSKeyword, PDFStream, PDFObjRef, None]]):
             self.push((pos, token))
 
 
-
-
 class PDFStreamParser(PDFParser):
     """
     PDFStreamParser is used to parse PDF content streams
@@ -149,10 +146,8 @@ class PDFStreamParser(PDFParser):
     def __init__(self, data: bytes) -> None:
         PDFParser.__init__(self, BytesIO(data))
 
-
     def flush(self) -> None:
         self.add_results(*self.popall())
-
 
     KEYWORD_OBJ = KWD(b'obj')
 
@@ -176,4 +171,3 @@ class PDFStreamParser(PDFParser):
             return
         # others
         self.push((pos, token))
-

--- a/pdfminer/pdfparser.py
+++ b/pdfminer/pdfparser.py
@@ -45,12 +45,12 @@ class PDFParser(PSStackParser[Union[PSKeyword, PDFStream, PDFObjRef, None]]):
         PSStackParser.__init__(self, fp)
         self.doc: Optional["PDFDocument"] = None
         self.fallback = False
-        return
+
 
     def set_document(self, doc: "PDFDocument") -> None:
         """Associates the parser with a PDFDocument object."""
         self.doc = doc
-        return
+
 
     KEYWORD_R = KWD(b'R')
     KEYWORD_NULL = KWD(b'null')
@@ -134,7 +134,7 @@ class PDFParser(PSStackParser[Union[PSKeyword, PDFStream, PDFObjRef, None]]):
             # others
             self.push((pos, token))
 
-        return
+
 
 
 class PDFStreamParser(PDFParser):
@@ -148,11 +148,11 @@ class PDFStreamParser(PDFParser):
 
     def __init__(self, data: bytes) -> None:
         PDFParser.__init__(self, BytesIO(data))
-        return
+
 
     def flush(self) -> None:
         self.add_results(*self.popall())
-        return
+
 
     KEYWORD_OBJ = KWD(b'obj')
 
@@ -176,4 +176,4 @@ class PDFStreamParser(PDFParser):
             return
         # others
         self.push((pos, token))
-        return
+

--- a/pdfminer/pdftypes.py
+++ b/pdfminer/pdftypes.py
@@ -88,7 +88,7 @@ class PDFObjRef(PDFObject):
                 raise PDFValueError('PDF object id cannot be 0.')
         self.doc = doc
         self.objid = objid
-        return
+
 
     def __repr__(self) -> str:
         return '<PDFObjRef:%d>' % (self.objid)
@@ -255,12 +255,12 @@ class PDFStream(PDFObject):
         self.data: Optional[bytes] = None
         self.objid: Optional[int] = None
         self.genno: Optional[int] = None
-        return
+
 
     def set_objid(self, objid: int, genno: int) -> None:
         self.objid = objid
         self.genno = genno
-        return
+
 
     def __repr__(self) -> str:
         if self.data is None:

--- a/pdfminer/pdftypes.py
+++ b/pdfminer/pdftypes.py
@@ -1,24 +1,23 @@
-import zlib
-import logging
 import io
+import logging
 import sys
+import zlib
 from typing import (TYPE_CHECKING, Any, Dict, Iterable, Optional, Union, List,
                     Tuple, cast)
 
-from .lzw import lzwdecode
+from . import settings
 from .ascii85 import ascii85decode
 from .ascii85 import asciihexdecode
-from .runlength import rldecode
 from .ccitt import ccittfaxdecode
+from .lzw import lzwdecode
+from .psparser import LIT
 from .psparser import PSException
 from .psparser import PSObject
-from .psparser import LIT
-from . import settings
+from .runlength import rldecode
 from .utils import apply_png_predictor
 
 if TYPE_CHECKING:
     from .pdfdocument import PDFDocument
-
 
 logger = logging.getLogger(__name__)
 
@@ -88,7 +87,6 @@ class PDFObjRef(PDFObject):
                 raise PDFValueError('PDF object id cannot be 0.')
         self.doc = doc
         self.objid = objid
-
 
     def __repr__(self) -> str:
         return '<PDFObjRef:%d>' % (self.objid)
@@ -256,11 +254,9 @@ class PDFStream(PDFObject):
         self.objid: Optional[int] = None
         self.genno: Optional[int] = None
 
-
     def set_objid(self, objid: int, genno: int) -> None:
         self.objid = objid
         self.genno = genno
-
 
     def __repr__(self) -> str:
         if self.data is None:

--- a/pdfminer/psparser.py
+++ b/pdfminer/psparser.py
@@ -76,7 +76,7 @@ class PSKeyword(PSObject):
 
     def __init__(self, name: bytes) -> None:
         self.name = name
-        return
+
 
     def __repr__(self) -> str:
         name = self.name
@@ -95,7 +95,7 @@ class PSSymbolTable(Generic[_SymbolT]):
     def __init__(self, klass: Type[_SymbolT]) -> None:
         self.dict: Dict[PSLiteral.NameType, _SymbolT] = {}
         self.klass: Type[_SymbolT] = klass
-        return
+
 
     def intern(self, name: PSLiteral.NameType) -> _SymbolT:
         if name in self.dict:
@@ -182,7 +182,7 @@ class PSBaseParser:
     def __init__(self, fp: BinaryIO) -> None:
         self.fp = fp
         self.seek(0)
-        return
+
 
     def __repr__(self) -> str:
         return '<%s: %r, bufpos=%d>' % (self.__class__.__name__, self.fp,

--- a/pdfminer/psparser.py
+++ b/pdfminer/psparser.py
@@ -2,8 +2,8 @@
 
 # -*- coding: utf-8 -*-
 
-import re
 import logging
+import re
 from typing import (Any, BinaryIO, Dict, Generic, Iterator, List,
                     Optional, Tuple, Type, TypeVar, Union)
 
@@ -77,7 +77,6 @@ class PSKeyword(PSObject):
     def __init__(self, name: bytes) -> None:
         self.name = name
 
-
     def __repr__(self) -> str:
         name = self.name
         return '/%r' % name
@@ -95,7 +94,6 @@ class PSSymbolTable(Generic[_SymbolT]):
     def __init__(self, klass: Type[_SymbolT]) -> None:
         self.dict: Dict[PSLiteral.NameType, _SymbolT] = {}
         self.klass: Type[_SymbolT] = klass
-
 
     def intern(self, name: PSLiteral.NameType) -> _SymbolT:
         if name in self.dict:
@@ -182,7 +180,6 @@ class PSBaseParser:
     def __init__(self, fp: BinaryIO) -> None:
         self.fp = fp
         self.seek(0)
-
 
     def __repr__(self) -> str:
         return '<%s: %r, bufpos=%d>' % (self.__class__.__name__, self.fp,

--- a/pdfminer/utils.py
+++ b/pdfminer/utils.py
@@ -57,7 +57,7 @@ class open_filename(object):
     ) -> None:
         if self.closing:
             self.file_handler.close()
-        return
+
 
 
 def make_compat_bytes(in_str: str) -> bytes:

--- a/pdfminer/utils.py
+++ b/pdfminer/utils.py
@@ -4,10 +4,10 @@ Miscellaneous Routines.
 import io
 import pathlib
 import struct
+from html import escape
 from typing import (Any, BinaryIO, Callable, Dict, Generic, Iterable, Iterator,
                     List, Optional, Set, TextIO, Tuple, TypeVar, Union,
                     TYPE_CHECKING, cast)
-from html import escape
 
 if TYPE_CHECKING:
     from .layout import LTComponent
@@ -57,7 +57,6 @@ class open_filename(object):
     ) -> None:
         if self.closing:
             self.file_handler.close()
-
 
 
 def make_compat_bytes(in_str: str) -> bytes:


### PR DESCRIPTION
**Pull request**

Fix #561 

Many return statements are at the end of a function and dont specify a return value. These can be removed without changing the functionality. 

**How Has This Been Tested?**

Ran the test suite. 

**Checklist**

- [x] I have added tests that prove my fix is effective or that my feature 
  works
- [x] I have added docstrings to newly created methods and classes
- [x] I have optimized the code at least one time after creating the initial 
  version
- [x] I have updated the [README.md](../README.md) or verified that this
  is not necessary
- [x] I have updated the [readthedocs](../docs/source) documentation or
  verified that this is not necessary
- [x] I have added a concise human-readable description of the change to
  [CHANGELOG.md](../CHANGELOG.md)
