### PR TITLE
Raise more specific error if Pillow cannot be imported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Export type annotations from pypi package per PEP561 ([#679](https://github.com/pdfminer/pdfminer.six/pull/679))
 - Support for identity cmap's ([#626](https://github.com/pdfminer/pdfminer.six/pull/626))
 - Add support for PDF page labels ([#680](https://github.com/pdfminer/pdfminer.six/pull/680))
+- Installation of Pillow as an optional extra dependency ([#714](https://github.com/pdfminer/pdfminer.six/pull/714))
 
 ### Fixed
 - Hande decompression error due to CRC checksum error ([#637](https://github.com/pdfminer/pdfminer.six/pull/637))

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ How to use
 
   `pip install pdfminer.six`
 
+* (Optionally) install extra dependencies for extracting images.
+
+  `pip install 'pdfminer.six[image]`
+
 * Use command-line interface to extract text from pdf:
 
   `python pdf2txt.py samples/simple1.pdf`

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -66,6 +66,13 @@ Before using it, you must install it using Python 3.6 or newer.
     $ pip install pdfminer.six
 
 
+Optionally install extra dependencies that are needed to extract jpg images.
+
+::
+
+    $ pip install 'pdfminer.six[image]'
+
+
 Contributing
 ============
 

--- a/pdfminer/image.py
+++ b/pdfminer/image.py
@@ -13,8 +13,8 @@ from .pdftypes import LITERALS_DCT_DECODE, LITERALS_JBIG2_DECODE, LITERALS_JPX_D
 
 PIL_ERROR_MESSAGE = (
     "Could not import Pillow. This dependency of pdfminer.six is not "
-    "installed by default. But to save images to a file, you do need "
-    "it. Install it with `pip install 'pdfminer.six[image]' "
+    "installed by default. You need it to to save jpg images to a file. Install it "
+    "with `pip install 'pdfminer.six[image]' "
 )
 
 

--- a/pdfminer/image.py
+++ b/pdfminer/image.py
@@ -14,7 +14,7 @@ from .pdftypes import LITERALS_DCT_DECODE, LITERALS_JBIG2_DECODE, LITERALS_JPX_D
 PIL_ERROR_MESSAGE = (
     "Could not import Pillow. This dependency of pdfminer.six is not "
     "installed by default. You need it to to save jpg images to a file. Install it "
-    "with `pip install 'pdfminer.six[image]' "
+    "with `pip install 'pdfminer.six[image]'`"
 )
 
 

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     extras_require={
         "dev": ["pytest", "nox", "black", "mypy == 0.931"],
         "docs": ["sphinx", "sphinx-argparse"],
+        "image": ["Pillow"],
     },
     description="PDF parser and analyzer",
     long_description=readme,


### PR DESCRIPTION
**Pull request**

Fix #701 

**How Has This Been Tested?**

Extracting images without PIL installed and seeing the error message. 

**Checklist**

- [x] I have formatted my code with [black](https://github.com/psf/black).
- [x] I have added tests that prove my fix is effective or that my feature 
  works
- [x] I have added docstrings to newly created methods and classes
- [x] I have optimized the code at least one time after creating the initial 
  version
- [x] I have updated the [README.md](../README.md) or verified that this
  is not necessary
- [x] I have updated the [readthedocs](../docs/source) documentation or
  verified that this is not necessary
- [x] I have added a concise human-readable description of the change to
  [CHANGELOG.md](../CHANGELOG.md)
