### PR TITLE
Add github action for releasing to pypi if git tag is added.

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -132,7 +132,7 @@ jobs:
             VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,' | sed -e 's/^v//')
           else
             VERSION=$(date +%Y%m%d).${GITHUB_SHA::7}
-          end
+          fi
           echo ${VERSION}
           sed -i "s/__VERSION__/${VERSION}/g" pdfminer/__init__.py
           cat pdfminer/__init__.py

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
     tags:
-      - v*
+      - [ 0-9 ]{ 8 }  # match version tags with format like 20220319
   pull_request: # run on pr's against master
     branches:
       - master

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -6,7 +6,7 @@ on:
       - master
       - develop
     tags:
-      - "v*.*.*"
+      - v*
   pull_request: # run on pr's against master or develop
     branches:
       - master

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -131,14 +131,13 @@ jobs:
           then
             VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,' | sed -e 's/^v//')
           else
-            VERSION=$(date +%Y%m%d).${GITHUB_SHA::7}
+            VERSION=$(date +%Y%m%d).$(date +%H%M%S)
           fi
           echo ${VERSION}
           sed -i "s/__VERSION__/${VERSION}/g" pdfminer/__init__.py
-          cat pdfminer/__init__.py
       - name: Build package
         run: python setup.py sdist bdist_wheel
-      - name: Publish distribution to Test PyPI
+      - name: Publish package to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -6,7 +6,7 @@ on:
       - master
       - develop
     tags:
-      - v*
+      - "v*.*.*"
   pull_request: # run on pr's against master or develop
     branches:
       - master
@@ -137,22 +137,21 @@ jobs:
           sed -i "s/__VERSION__/${VERSION}/g" pdfminer/__init__.py
       - name: Build package
         run: python setup.py sdist bdist_wheel
-      - name: Publish package to PyPi
-        if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Generate changelog
+        run: sed '1,/## \[/d;/## \[/Q' CHANGELOG.md > ${{ github.workspace }}-CHANGELOG.md
+      #      - name: Publish package to PyPi
+      #        if: startsWith(github.ref, 'refs/tags')
+      #        uses: pypa/gh-action-pypi-publish@release/v1
+      #        with:
+      #          user: __token__
+      #          password: ${{ secrets.PYPI_API_TOKEN }}
       - name: Create GitHub release
         if: startsWith(github.ref, 'refs/tags')
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v1
         id: create_release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          body: |
-            Copy this from CHANGELOG.md
-          draft: false
-          prerelease: false
+          token: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+          body_path: ${{ github.workspace }}-CHANGELOG.md
+          files: |
+            dist/*.tar.gz
+            dist/*.whl

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -121,14 +121,21 @@ jobs:
       - tests
       - build-docs
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
       - name: Install dependencies
         run: python -m pip install wheel
       - name: Set version
         run: |
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,' | sed -e 's/^v//')
-          [[ "${{ github.ref }}" != "refs/tags/"* ]] && VERSION=$(date +%Y%m%d).${VERSION}
+          if [[ "${{ github.ref }}" == "refs/tags/"* ]]
+          then
+            VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,' | sed -e 's/^v//')
+          else
+            VERSION=$(date +%Y%m%d).${GITHUB_SHA::7}
+          end
+          echo ${VERSION}
           sed -i "s/__VERSION__/${VERSION}/g" pdfminer/__init__.py
-          cat pdfminer/__init.py
+          cat pdfminer/__init__.py
       - name: Build package
         run: python setup.py sdist bdist_wheel
       - name: Publish distribution to Test PyPI

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,16 +1,14 @@
 name: Continuous integration
 
 on:
-  push: # run when commits are added to master or develop
+  push: # run when commits are added to master
     branches:
       - master
-      - develop
     tags:
       - v*
-  pull_request: # run on pr's against master or develop
+  pull_request: # run on pr's against master
     branches:
       - master
-      - develop
 
 env:
   default-python: "3.10"

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -150,3 +150,16 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Create GitHub release
+        if: startsWith(github.ref, 'refs/tags')
+        uses: actions/create-release@v1
+        id: create_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body: |
+            Copy this from CHANGELOG.md
+          draft: false
+          prerelease: false

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
       - develop
+    tags:
+      - v*
   pull_request: # run on pr's against master or develop
     branches:
       - master
@@ -108,3 +110,37 @@ jobs:
       - name: Build docs
         run: |
           nox --error-on-missing-interpreters --non-interactive --session docs
+
+  publish:
+    name: Publish to PyPi
+    runs-on: ubuntu-latest
+    needs:
+      - check-code-formatting
+      - check-coding-style
+      - check-static-types
+      - tests
+      - build-docs
+    steps:
+      - name: Install dependencies
+        run: python -m pip install wheel
+      - name: Set version
+        run: |
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,' | sed -e 's/^v//')
+          [[ "${{ github.ref }}" != "refs/tags/"* ]] && VERSION=$(date +%Y%m%d).${VERSION}
+          sed -i "s/__VERSION__/${VERSION}/g" pdfminer/__init__.py
+          cat pdfminer/__init.py
+      - name: Build package
+        run: python setup.py sdist bdist_wheel
+      - name: Publish distribution to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+          verbose: true
+      - name: Publish package to PyPi
+        if: startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -139,12 +139,12 @@ jobs:
         run: python setup.py sdist bdist_wheel
       - name: Generate changelog
         run: sed '1,/## \[/d;/## \[/Q' CHANGELOG.md > ${{ github.workspace }}-CHANGELOG.md
-      #      - name: Publish package to PyPi
-      #        if: startsWith(github.ref, 'refs/tags')
-      #        uses: pypa/gh-action-pypi-publish@release/v1
-      #        with:
-      #          user: __token__
-      #          password: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Publish package to PyPi
+        if: startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
       - name: Create GitHub release
         if: startsWith(github.ref, 'refs/tags')
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -137,13 +137,6 @@ jobs:
           sed -i "s/__VERSION__/${VERSION}/g" pdfminer/__init__.py
       - name: Build package
         run: python setup.py sdist bdist_wheel
-      - name: Publish package to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
-          verbose: true
       - name: Publish package to PyPi
         if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,8 +27,8 @@ Any contribution is appreciated! You might want to:
 ## Guideline for creating pull request
 
 * A pull request should close an existing issue.
-* Pull requests should be merged to develop, not master. This ensures that master always equals the released version.  
-* Include unit tests when possible. In case of bugs, this will help to prevent the same mistake in the future. In case 
+* Pull requests should be merged to master. Version tags are used indicate the releases.
+* Include unit tests when possible. In case of bugs, this will help to prevent the same mistake in the future. In case
   of features, this will show that your code works correctly.
 * Code should work for Python 3.6+.
 * Code should be formatted with [black](https://github.com/psf/black). 

--- a/Makefile
+++ b/Makefile
@@ -1,36 +1,10 @@
 ##  Makefile (for maintenance purpose)
 ##
 
-PACKAGE=pdfminer
-
 PYTHON=python
-GIT=git
 RM=rm -f
 CP=cp -f
 MKDIR=mkdir
-
-all:
-
-install:
-	$(PYTHON) setup.py install --home=$(HOME)
-
-clean:
-	-$(PYTHON) setup.py clean
-	-$(RM) -r build dist MANIFEST
-	-cd $(PACKAGE) && $(MAKE) clean
-	-cd tools && $(MAKE) clean
-	-cd samples && $(MAKE) clean
-
-distclean: clean cmap_clean
-
-sdist: distclean MANIFEST.in
-	$(PYTHON) setup.py sdist
-register: distclean MANIFEST.in
-	$(PYTHON) setup.py sdist upload register
-
-WEBDIR=../euske.github.io/$(PACKAGE)
-publish:
-	$(CP) docs/*.html docs/*.png docs/*.css $(WEBDIR)
 
 CONV_CMAP=$(PYTHON) tools/conv_cmap.py
 CMAPSRC=cmaprsrc

--- a/pdfminer/Makefile
+++ b/pdfminer/Makefile
@@ -1,9 +1,0 @@
-# Makefile for pdfminer
-
-RM=rm -f
-
-all:
-
-clean:
-	-$(RM) *.pyc *.pyo
-	cd cmap && make clean

--- a/pdfminer/__init__.py
+++ b/pdfminer/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "20211012"
+__version__ = "__VERSION__"  # auto replaced with tag in gitlab actions
 
 if __name__ == "__main__":
     print(__version__)

--- a/pdfminer/__init__.py
+++ b/pdfminer/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "__VERSION__"  # auto replaced with tag in gitlab actions
+__version__ = "__VERSION__"  # auto replaced with tag in github actions
 
 if __name__ == "__main__":
     print(__version__)

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,8 +1,0 @@
-# Makefile for tools
-
-RM=rm -f
-
-all:
-
-clean:
-	-$(RM) *.pyc *.pyo *.cgic *.cgio


### PR DESCRIPTION
**Pull request**

Make publishing of new release to PyPi easier by adding github action automation. 

For pull request, the package is published to test.pypi.org with a version similar to 20220315.232503 (the current date and time). 

For version tags, the package is published to test.pypi.org and pypi.org with the version tag (excluding the preceding v) as a version. 

Fixes #686 

**How Has This Been Tested?**

Publishing to test PyPi works. 

Still need to test if publishing to real PyPi and generating a github release also works. 

**Checklist**

- [x] I have formatted my code with [black](https://github.com/psf/black).
- [x] I have added tests that prove my fix is effective or that my feature 
  works
- [x] I have added docstrings to newly created methods and classes
- [x] I have optimized the code at least one time after creating the initial 
  version
- [x] I have updated the [README.md](../README.md) or verified that this
  is not necessary
- [x] I have updated the [readthedocs](../docs/source) documentation or
  verified that this is not necessary
- [x] I have added a concise human-readable description of the change to
  [CHANGELOG.md](../CHANGELOG.md)
