### PR TITLE
Log warning and continue gracefully if errors in cmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,20 @@
 # Changelog
-All notable changes in pdfminer.six will be documented in this file. 
+
+All notable changes in pdfminer.six will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+### Fixed
+
+- `IndexError` when handling invalid bfrange code map in
+  CMap ([#731](https://github.com/pdfminer/pdfminer.six/pull/731))
 
 ## [20220319]
 
 ### Added
+
 - Export type annotations from pypi package per PEP561 ([#679](https://github.com/pdfminer/pdfminer.six/pull/679))
 - Support for identity cmap's ([#626](https://github.com/pdfminer/pdfminer.six/pull/626))
 - Add support for PDF page labels ([#680](https://github.com/pdfminer/pdfminer.six/pull/680))

--- a/pdfminer/cmapdb.py
+++ b/pdfminer/cmapdb.py
@@ -474,3 +474,18 @@ class CMapParser(PSStackParser[PSKeyword]):
                 "(cid) values in the output. "
             )
             log.warning(base_msg + msg)
+
+
+def main(argv: List[str]) -> None:
+    args = argv[1:]
+    for fname in args:
+        fp = open(fname, "rb")
+        cmap = FileUnicodeMap()
+        CMapParser(cmap, fp).run()
+        fp.close()
+        cmap.dump()
+    return
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/pdfminer/cmapdb.py
+++ b/pdfminer/cmapdb.py
@@ -28,7 +28,8 @@ from typing import (
     TextIO,
     Tuple,
     Union,
-    cast, Set,
+    cast,
+    Set,
 )
 
 from .encodingdb import name2unicode
@@ -362,23 +363,27 @@ class CMapParser(PSStackParser[PSKeyword]):
             objs = [obj for (__, obj) in self.popall()]
             for (start_byte, end_byte, cid) in choplist(3, objs):
                 if not isinstance(start_byte, bytes):
-                    self._warn_once('The start object of begincidrange is not a byte.')
+                    self._warn_once("The start object of begincidrange is not a byte.")
                     continue
                 if not isinstance(end_byte, bytes):
-                    self._warn_once('The end object of begincidrange is not a byte.')
+                    self._warn_once("The end object of begincidrange is not a byte.")
                     continue
                 if not isinstance(cid, int):
-                    self._warn_once('The cid object of begincidrange is not a byte.')
+                    self._warn_once("The cid object of begincidrange is not a byte.")
                     continue
                 if len(start_byte) != len(end_byte):
-                    self._warn_once('The start and end byte of begincidrange have '
-                                    'different lengths.')
+                    self._warn_once(
+                        "The start and end byte of begincidrange have "
+                        "different lengths."
+                    )
                     continue
                 start_prefix = start_byte[:-4]
                 end_prefix = end_byte[:-4]
                 if start_prefix != end_prefix:
-                    self._warn_once('The prefix of the start and end byte of '
-                                    'begincidrange are not the same.')
+                    self._warn_once(
+                        "The prefix of the start and end byte of "
+                        "begincidrange are not the same."
+                    )
                     continue
                 svar = start_byte[-4:]
                 evar = end_byte[-4:]
@@ -409,20 +414,22 @@ class CMapParser(PSStackParser[PSKeyword]):
             objs = [obj for (__, obj) in self.popall()]
             for (start_byte, end_byte, code) in choplist(3, objs):
                 if not isinstance(start_byte, bytes):
-                    self._warn_once('The start object is not a byte.')
+                    self._warn_once("The start object is not a byte.")
                     continue
                 if not isinstance(end_byte, bytes):
-                    self._warn_once('The end object is not a byte.')
+                    self._warn_once("The end object is not a byte.")
                     continue
                 if len(start_byte) != len(end_byte):
-                    self._warn_once('The start and end byte have different lengths.')
+                    self._warn_once("The start and end byte have different lengths.")
                     continue
                 start = nunpack(start_byte)
                 end = nunpack(end_byte)
                 if isinstance(code, list):
                     if len(code) != end - start + 1:
-                        self._warn_once('The difference between the start and end '
-                                        'offsets does not match the code length.')
+                        self._warn_once(
+                            "The difference between the start and end "
+                            "offsets does not match the code length."
+                        )
                     for cid, unicode_value in zip(range(start, end + 1), code):
                         self.cmap.add_cid2unichr(cid, unicode_value)
                 else:
@@ -460,7 +467,9 @@ class CMapParser(PSStackParser[PSKeyword]):
     def _warn_once(self, msg: str) -> None:
         if msg not in self._warnings:
             self._warnings.add(msg)
-            base_msg = 'Ignoring (part of) ToUnicode map because the PDF data ' \
-                       'does not conform to the format. This could result in ' \
-                       '(cid) values in the output. '
+            base_msg = (
+                "Ignoring (part of) ToUnicode map because the PDF data "
+                "does not conform to the format. This could result in "
+                "(cid) values in the output. "
+            )
             log.warning(base_msg + msg)

--- a/pdfminer/cmapdb.py
+++ b/pdfminer/cmapdb.py
@@ -465,6 +465,7 @@ class CMapParser(PSStackParser[PSKeyword]):
         self.push((pos, token))
 
     def _warn_once(self, msg: str) -> None:
+        """Warn once for each unique message"""
         if msg not in self._warnings:
             self._warnings.add(msg)
             base_msg = (

--- a/pdfminer/cmapdb.py
+++ b/pdfminer/cmapdb.py
@@ -420,7 +420,7 @@ class CMapParser(PSStackParser[PSKeyword]):
                 start = nunpack(start_byte)
                 end = nunpack(end_byte)
                 if isinstance(code, list):
-                    if len(code) > end - start + 1:
+                    if len(code) != end - start + 1:
                         self._warn_once('The difference between the start and end '
                                         'offsets does not match the code length.')
                     for cid, unicode_value in zip(range(start, end + 1), code):

--- a/pdfminer/cmapdb.py
+++ b/pdfminer/cmapdb.py
@@ -28,7 +28,7 @@ from typing import (
     TextIO,
     Tuple,
     Union,
-    cast,
+    cast, Set,
 )
 
 from .encodingdb import name2unicode
@@ -285,7 +285,7 @@ class CMapParser(PSStackParser[PSKeyword]):
         self.cmap = cmap
         # some ToUnicode maps don't have "begincmap" keyword.
         self._in_cmap = True
-        self._warnings = set()
+        self._warnings: Set[str] = set()
         return
 
     def run(self) -> None:
@@ -457,25 +457,10 @@ class CMapParser(PSStackParser[PSKeyword]):
 
         self.push((pos, token))
 
-    def _warn_once(self, msg):
+    def _warn_once(self, msg: str) -> None:
         if msg not in self._warnings:
             self._warnings.add(msg)
             base_msg = 'Ignoring (part of) ToUnicode map because the PDF data ' \
                        'does not conform to the format. This could result in ' \
                        '(cid) values in the output. '
             log.warning(base_msg + msg)
-
-
-def main(argv: List[str]) -> None:
-    args = argv[1:]
-    for fname in args:
-        fp = open(fname, "rb")
-        cmap = FileUnicodeMap()
-        CMapParser(cmap, fp).run()
-        fp.close()
-        cmap.dump()
-    return
-
-
-if __name__ == "__main__":
-    main(sys.argv)


### PR DESCRIPTION
**Pull request**

Log warning and gracefully ignore errors in CMaps. 

Fixes #218 by skipping assigning cid's in a "bfrange" if the difference between `srcCode1` and `srcCode2` is bigger than the `dstString`. 

<details>
  <summary>PDF Reference Section 5.9.2</summary>

  ![image](https://user-images.githubusercontent.com/3833456/159138650-c159b628-cbf4-4660-a3fb-4da750e03b12.png)

</details>

**How Has This Been Tested?**

On both anomaly PDF's from issue #218.

**Checklist**

- [x] I have formatted my code with [black](https://github.com/psf/black).
- [x] I have added tests that prove my fix is effective or that my feature 
  works
- [x] I have added docstrings to newly created methods and classes
- [x] I have optimized the code at least one time after creating the initial 
  version
- [x] I have updated the [README.md](../README.md) or verified that this
  is not necessary
- [x] I have updated the [readthedocs](../docs/source) documentation or
  verified that this is not necessary
- [x] I have added a concise human-readable description of the change to
  [CHANGELOG.md](../CHANGELOG.md)
