### PR TITLE
Fix log.debug statement in lzw.py by ensuring that self.table is always set

### DIFF
--- a/pdfminer/lzw.py
+++ b/pdfminer/lzw.py
@@ -16,7 +16,7 @@ class LZWDecoder:
         self.bpos = 8
         self.nbits = 9
         # NB: self.table stores None only in indices 256 and 257
-        self.table: Optional[List[Optional[bytes]]] = None
+        self.table: List[Optional[bytes]] = []
         self.prevbuf: Optional[bytes] = None
 
     def readbits(self, bits: int) -> int:
@@ -55,10 +55,8 @@ class LZWDecoder:
         elif code == 257:
             pass
         elif not self.prevbuf:
-            assert self.table is not None
             x = self.prevbuf = cast(bytes, self.table[code])  # assume not None
         else:
-            assert self.table is not None
             if code < len(self.table):
                 x = cast(bytes, self.table[code])  # assume not None
                 self.table.append(self.prevbuf + x[:1])
@@ -89,10 +87,13 @@ class LZWDecoder:
                 # just ignore corrupt data and stop yielding there
                 break
             yield x
-            assert self.table is not None
+
             logger.debug(
-                "nbits=%d, code=%d, output=%r, table=%r"
-                % (self.nbits, code, x, self.table[258:])
+                "nbits=%d, code=%d, output=%r, table=%r",
+                self.nbits,
+                code,
+                x,
+                self.table[258:],
             )
 
 


### PR DESCRIPTION
**Pull request**

Fix #221 by ensuring that `self.table` is always list and therefore `log.debug` never fails. 

Also ensuring that formatting of log message only happens when it is actually printend. 

**How Has This Been Tested?**

With the testsuite. It runs the lzw.py code at least once. 

**Checklist**

- [ ] I have formatted my code with [black](https://github.com/psf/black).
- [ ] I have added tests that prove my fix is effective or that my feature 
  works
- [ ] I have added docstrings to newly created methods and classes
- [ ] I have optimized the code at least one time after creating the initial 
  version
- [ ] I have updated the [README.md](../README.md) or verified that this
  is not necessary
- [ ] I have updated the [readthedocs](../docs/source) documentation or
  verified that this is not necessary
- [ ] I have added a concise human-readable description of the change to
  [CHANGELOG.md](../CHANGELOG.md)
