### PR TITLE
Raise KeyError when name in name2unicode is not of type str

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,20 @@
 # Changelog
-All notable changes in pdfminer.six will be documented in this file. 
+
+All notable changes in pdfminer.six will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+### Fixed
+
+- `TypeError` in encodingdb.py when name of unicode is not
+  str ([#733](https://github.com/pdfminer/pdfminer.six/pull/733))
 
 ## [20220319]
 
 ### Added
+
 - Export type annotations from pypi package per PEP561 ([#679](https://github.com/pdfminer/pdfminer.six/pull/679))
 - Support for identity cmap's ([#626](https://github.com/pdfminer/pdfminer.six/pull/626))
 - Add support for PDF page labels ([#680](https://github.com/pdfminer/pdfminer.six/pull/680))

--- a/pdfminer/encodingdb.py
+++ b/pdfminer/encodingdb.py
@@ -25,6 +25,12 @@ def name2unicode(name: str) -> str:
     :returns unicode character if name resembles something,
     otherwise a KeyError
     """
+    if not isinstance(name, str):
+        raise KeyError(
+            'Could not convert unicode name "%s" to character because '
+            "it should be of type str but is of type %s" % (name, type(name))
+        )
+
     name = name.split(".")[0]
     components = name.split("_")
 


### PR DESCRIPTION
**Pull request**

Fixes #541 by converting the TypeError into a KeyError that is caught by the parent function. 

**How Has This Been Tested?**

With the example PDF from the related issue. 

**Checklist**

- [x] I have formatted my code with [black](https://github.com/psf/black).
- [x] I have added tests that prove my fix is effective or that my feature 
  works
- [x] I have added docstrings to newly created methods and classes
- [x] I have optimized the code at least one time after creating the initial 
  version
- [x] I have updated the [README.md](../README.md) or verified that this
  is not necessary
- [x] I have updated the [readthedocs](../docs/source) documentation or
  verified that this is not necessary
- [x] I have added a concise human-readable description of the change to
  [CHANGELOG.md](../CHANGELOG.md)
