### PR TITLE
Add 3 public instance variables in LTChar (#202 and other connected)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Exporting images without any specific encoding ([#737](https://github.com/pdfminer/pdfminer.six/pull/737))
+- Adding textwidth, fontsize and scaling as public instance variables in layout.LTChar ([#742](https://github.com/pdfminer/pdfminer.six/pull/742))
 
 ## [20220319]
 

--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -357,6 +357,9 @@ class LTChar(LTComponent, LTText):
         self.fontname = font.fontname
         self.ncs = ncs
         self.graphicstate = graphicstate
+        self.textwidth = textwidth
+        self.fontsize = fontsize
+        self.scaling = scaling
         self.adv = textwidth * fontsize * scaling
         # compute the boundary rectangle.
         if font.is_vertical():


### PR DESCRIPTION
**Pull request**
Fix #202 
Fix #211 

Making the three variables in layout.LTChar textwidth, fontsize and scaling public instance variables in order to access them. 

**How Has This Been Tested?**

```
for c in  o._objs:
    if isinstance(c, pdfminer.layout.LTChar):
        fontsize = c.fontsize
        textwidth = c.textwidth
        scaling = c.scaling
```

**Checklist**

- [X] I have formatted my code with [black](https://github.com/psf/black).
- [X] I have added tests that prove my fix is effective or that my feature 
  works
- [ ] I have added docstrings to newly created methods and classes
- [ ] I have optimized the code at least one time after creating the initial 
  version
- [X] I have updated the [README.md](../README.md) or verified that this
  **is not necessary**
- [X] I have updated the [readthedocs](../docs/source) documentation or
  verified that this **is not necessary**
- [X] I have added a concise human-readable description of the change to
  [CHANGELOG.md](../CHANGELOG.md)
