### PR TITLE
Update highlevel.rst

### DIFF
--- a/docs/source/tutorial/highlevel.rst
+++ b/docs/source/tutorial/highlevel.rst
@@ -57,3 +57,4 @@ Or to convert it to html and use layout analysis:
     >>> with open('samples/simple1.pdf', 'rb') as fin:
     ...     extract_text_to_fp(fin, output_string, laparams=LAParams(),
     ...                        output_type='html', codec=None)
+    >>> print(output_string.getvalue().strip())


### PR DESCRIPTION
The last code block missing print

**Pull request**

Revise the documentation part, I found the last code block in "Extract text from a PDF using Python" part missing print 
Fix: I just add it.

**How Has This Been Tested?**

![image](https://user-images.githubusercontent.com/19734910/163510407-428e3b02-8be7-4457-b8ab-ac9b5096d1de.png)


**Checklist**

- [ ] I have formatted my code with [black](https://github.com/psf/black).
- [ ] I have added tests that prove my fix is effective or that my feature 
  works
- [ ] I have added docstrings to newly created methods and classes
- [ ] I have optimized the code at least one time after creating the initial 
  version
- [ ] I have updated the [README.md](../README.md) or verified that this
  is not necessary
- [ ] I have updated the [readthedocs](../docs/source) documentation or
  verified that this is not necessary
- [ ] I have added a concise human-readable description of the change to
  [CHANGELOG.md](../CHANGELOG.md)
