### PR TITLE
Ignore path constructors that do not begin with  m

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `TypeError` in encodingdb.py when name of unicode is not
   str ([#733](https://github.com/pdfminer/pdfminer.six/pull/733))
 - `TypeError` in HTMLConverter when using a bytes fontname ([#734](https://github.com/pdfminer/pdfminer.six/pull/734))
+- Ignoring (invalid) path constructors that do not begin with `m` ([#749](https://github.com/pdfminer/pdfminer.six/pull/749))
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Ignoring (invalid) path constructors that do not begin with `m` ([#749](https://github.com/pdfminer/pdfminer.six/pull/749))
+
+## [20220506]
+
+### Fixed
+
 - `IndexError` when handling invalid bfrange code map in
   CMap ([#731](https://github.com/pdfminer/pdfminer.six/pull/731))
 - `TypeError` in lzw.py when `self.table` is not set ([#732](https://github.com/pdfminer/pdfminer.six/pull/732))
 - `TypeError` in encodingdb.py when name of unicode is not
   str ([#733](https://github.com/pdfminer/pdfminer.six/pull/733))
 - `TypeError` in HTMLConverter when using a bytes fontname ([#734](https://github.com/pdfminer/pdfminer.six/pull/734))
-- Ignoring (invalid) path constructors that do not begin with `m` ([#749](https://github.com/pdfminer/pdfminer.six/pull/749))
 
 ### Added
 

--- a/pdfminer/converter.py
+++ b/pdfminer/converter.py
@@ -109,7 +109,16 @@ class PDFLayoutAnalyzer(PDFTextDevice):
         """Paint paths described in section 4.4 of the PDF reference manual"""
         shape = "".join(x[0] for x in path)
 
-        if shape.count("m") > 1:
+        if shape[:1] != "m":
+            # Per PDF Reference Section 4.4.1, "path construction operators may
+            # be invoked in any sequence, but the first one invoked must be m
+            # or re to begin a new subpath." Since pdfminer.six already
+            # converts all `re` (rectangle) operators to their equivelent
+            # `mlllh` representation, paths ingested by `.paint_path(...)` that
+            # do not begin with the `m` operator are invalid.
+            pass
+
+        elif shape.count("m") > 1:
             # recurse if there are multiple m's in this shape
             for m in re.finditer(r"m[^m]+", shape):
                 subpath = path[m.start(0) : m.end(0)]

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -215,6 +215,15 @@ class TestPaintPath:
             (71.41, 434.89),
         ]
 
+    def test_paint_path_without_starting_m(self):
+        gs = PDFGraphicState()
+        analyzer = self._get_analyzer()
+        analyzer.cur_item = LTContainer([0, 100, 0, 100])
+        paths = [[("h",)], [("l", 72.41, 433.89), ("l", 82.41, 433.89), ("h",)]]
+        for path in paths:
+            analyzer.paint_path(gs, False, False, False, path)
+        assert len(analyzer.cur_item._objs) == 0
+
 
 class TestBinaryDetector:
     def test_stringio(self):


### PR DESCRIPTION
I have encountered a couple of PDFs (see https://github.com/jsvine/pdfplumber/issues/636#issue-1192550515 and https://github.com/jsvine/pdfplumber/discussions/644#discussion-4023909) that include a `("h", )` path — i.e., just the `h` operator and no others. This causes this second statement here to throw `ValueError: not enough values to unpack (expected 2, got 1)`: https://github.com/pdfminer/pdfminer.six/blob/1bf3c42b59125f4491d863e1c11dca7ebbe96adc/pdfminer/converter.py#L126-L129

**Pull request**

Although there may be narrower solutions to this particular problem (e.g., handling the specific edge-case of `("h",)`), this PR introduces what — at least to me — seems like the most generalized-yet-accurate solution, after reading the PDF Reference. 

Per Section 4.4.1, "path construction operators may be invoked in any sequence, but the first one invoked must be `m` or `re` to begin a new subpath." Since pdfminer.six already converts all `re` (rectangle) operators to their equivelent `mlllh` representation, paths ingested by `.paint_path(...)` that do not begin with the `m` operator are invalid.

I am, however, open to other approaches 👍 

**How Has This Been Tested?**

I have added a test to `tests/test_converter.py`. I have also examined all non-encrypted PDFs in the `samples/` directory. Of the 31,116 paths and subpaths in those 33 PDFs, all start with the “m” operator (or have been translated from the “re” operator to take that form).

**Checklist**

- [x] I have formatted my code with [black](https://github.com/psf/black).
- [x] I have added tests that prove my fix is effective or that my feature 
  works
- [x] [not applicable] I have added docstrings to newly created methods and classes
- [x] I have optimized the code at least one time after creating the initial 
  version
- [x] I have updated the [README.md](../README.md) or verified that this
  is not necessary
- [x] I have updated the [readthedocs](../docs/source) documentation or
  verified that this is not necessary
- [x] I have added a concise human-readable description of the change to
  [CHANGELOG.md](../CHANGELOG.md)
