### PR TITLE
Remove upper version bounds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@ setup(
     packages=["pdfminer"],
     package_data={"pdfminer": ["cmap/*.pickle.gz", "py.typed"]},
     install_requires=[
-        "charset-normalizer~=2.0.0",
-        "cryptography~=36.0.0",
+        "charset-normalizer >= 2.0.0",
+        "cryptography >= 36.0.0",
     ],
     extras_require={
         "dev": ["pytest", "nox", "black", "mypy == 0.931"],


### PR DESCRIPTION
Using an upper bound for dependency versions on a library is a source of troubles for users.
Let's not do it as it makes pdfminer wreck havoc downstream.

@pietermarsman you introduced this in this recent commit https://github.com/pdfminer/pdfminer.six/commit/1bf3c42b59125f4491d863e1c11dca7ebbe96adc#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R20

Because of this change, I cannot upgrade to the latest pdfminer short of downgrading cryptography which is a security risk and not an issue for pdfminer proper.

For a longer and comprehensive exploration of the issue, please read this excellent article  https://iscinumpy.dev/post/bound-version-constraints/ by @henryiii

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>

**Pull request**

Please remove this paragraph and replace it with a description of your PR.
Also include links to the issues that it fixes. 

**How Has This Been Tested?**

Please repalce this paragraph with a description of how this PR has been 
tested. Include the necessary instructions and files such that other can
reproduce it.

**Checklist**

- [ ] I have formatted my code with [black](https://github.com/psf/black).
- [ ] I have added tests that prove my fix is effective or that my feature 
  works
- [ ] I have added docstrings to newly created methods and classes
- [ ] I have optimized the code at least one time after creating the initial 
  version
- [ ] I have updated the [README.md](../README.md) or verified that this
  is not necessary
- [ ] I have updated the [readthedocs](../docs/source) documentation or
  verified that this is not necessary
- [ ] I have added a concise human-readable description of the change to
  [CHANGELOG.md](../CHANGELOG.md)
