### PR TITLE
Ignore null characters in PSBaseParser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Sphinx errors during building of documentation ([#760](https://github.com/pdfminer/pdfminer.six/pull/760))
+- `TypeError` in cmapdb.py when parsing null characters ([#768](https://github.com/pdfminer/pdfminer.six/pull/768))
 
 ## [20220524]
 

--- a/pdfminer/psparser.py
+++ b/pdfminer/psparser.py
@@ -334,6 +334,8 @@ class PSBaseParser:
             self._curtoken = b""
             self._parse1 = self._parse_wclose
             return j + 1
+        elif c == b"\x00":
+            return j + 1
         else:
             self._add_token(KWD(c))
             return j + 1


### PR DESCRIPTION
**Pull request**

Beforehand, null characters parsed by PSBaseParser were encoded as PSKeyword tokens. This caused issue #617, as pdfdevice.py would attempt to decode the null character PSKeyword, when it expects a byte string, as opposed to a PSKeyword, causing pdfminer.six to crash.

As null characters are superfluous within PSBaseParser, ignore them.

**How Has This Been Tested?**

A PDF included in issue #617 recreates the bug. With this commit, the bug is fixed.

**Checklist**

- [x] I have formatted my code with [black](https://github.com/psf/black).
- [ ] I have added tests that prove my fix is effective or that my feature 
  works
- [ ] I have added docstrings to newly created methods and classes
- [x] I have optimized the code at least one time after creating the initial 
  version
- [ ] I have updated the [README.md](../README.md) or verified that this
  is not necessary
- [ ] I have updated the [readthedocs](../docs/source) documentation or
  verified that this is not necessary
- [x] I have added a concise human-readable description of the change to
  [CHANGELOG.md](../CHANGELOG.md)
