### PR TITLE
Fix crash with unencrypted metadata values (Fixes #766).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Crash when trying to decrypt empty metadata values ([#766](https://github.com/pdfminer/pdfminer.six/issues/766))
 - Sphinx errors during building of documentation ([#760](https://github.com/pdfminer/pdfminer.six/pull/760))
 - `TypeError` when getting default width of font ([#720](https://github.com/pdfminer/pdfminer.six/issues/720))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Crash when trying to decrypt empty metadata values ([#766](https://github.com/pdfminer/pdfminer.six/issues/766))
+- `ValueError` when trying to decrypt empty metadata values ([#766](https://github.com/pdfminer/pdfminer.six/issues/766))
 - Sphinx errors during building of documentation ([#760](https://github.com/pdfminer/pdfminer.six/pull/760))
 - `TypeError` when getting default width of font ([#720](https://github.com/pdfminer/pdfminer.six/issues/720))
 

--- a/pdfminer/pdftypes.py
+++ b/pdfminer/pdftypes.py
@@ -138,7 +138,7 @@ def resolve_all(x: object, default: object = None) -> Any:
 def decipher_all(decipher: DecipherCallable, objid: int, genno: int, x: object) -> Any:
     """Recursively deciphers the given object."""
     if isinstance(x, bytes):
-        if not len(x):
+        if len(x) == 0:
             return x
         return decipher(objid, genno, x)
     if isinstance(x, list):

--- a/pdfminer/pdftypes.py
+++ b/pdfminer/pdftypes.py
@@ -138,6 +138,8 @@ def resolve_all(x: object, default: object = None) -> Any:
 def decipher_all(decipher: DecipherCallable, objid: int, genno: int, x: object) -> Any:
     """Recursively deciphers the given object."""
     if isinstance(x, bytes):
+        if not len(x):
+            return x
         return decipher(objid, genno, x)
     if isinstance(x, list):
         x = [decipher_all(decipher, objid, genno, v) for v in x]


### PR DESCRIPTION
**Pull request**

This PR fixes a crash when the metadata contains empty (unencrypted) values.

https://github.com/pdfminer/pdfminer.six/issues/766

**How Has This Been Tested?**

I manually tested against the PDF I have, I sadly cannot share it because it contains personal information. I do not know enough about PDFs to generate a PDF triggering that error :/

**Checklist**

- [x] I have formatted my code with [black](https://github.com/psf/black).
- [x] I have added tests that prove my fix is effective or that my feature 
  works
- [x] I have added docstrings to newly created methods and classes
- [x] I have optimized the code at least one time after creating the initial 
  version
- [x] I have updated the [README.md](../README.md) or verified that this
  is not necessary
- [x] I have updated the [readthedocs](../docs/source) documentation or
  verified that this is not necessary
- [x] I have added a concise human-readable description of the change to
  [CHANGELOG.md](../CHANGELOG.md)
