### PR TITLE
Install typing_extensions on Python 3.6 and 3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `ValueError` when trying to decrypt empty metadata values ([#766](https://github.com/pdfminer/pdfminer.six/issues/766))
 - Sphinx errors during building of documentation ([#760](https://github.com/pdfminer/pdfminer.six/pull/760))
 - `TypeError` when getting default width of font ([#720](https://github.com/pdfminer/pdfminer.six/issues/720))
+- Install typing-extensions on Python 3.6 and 3.7 ([#775](https://github.com/pdfminer/pdfminer.six/pull/775))
 
 ### Deprecated
 

--- a/pdfminer/image.py
+++ b/pdfminer/image.py
@@ -7,6 +7,7 @@ from typing import BinaryIO, Tuple
 try:
     from typing import Literal
 except ImportError:
+    # Literal was introduced in Python 3.8
     from typing_extensions import Literal  # type: ignore[misc]
 
 from .jbig2 import JBIG2StreamReader, JBIG2StreamWriter

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     install_requires=[
         "charset-normalizer >= 2.0.0",
         "cryptography >= 36.0.0",
+        "typing_extensions; python_version < \"3.8\"",
     ],
     extras_require={
         "dev": ["pytest", "nox", "black", "mypy == 0.931"],

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     install_requires=[
         "charset-normalizer >= 2.0.0",
         "cryptography >= 36.0.0",
-        "typing_extensions; python_version < \"3.8\"",
+        'typing_extensions; python_version < "3.8"',
     ],
     extras_require={
         "dev": ["pytest", "nox", "black", "mypy == 0.931"],


### PR DESCRIPTION
**Pull request**

Fix #762 

**How Has This Been Tested?**

Used Python 3.6 and ran `python setup.py install` and checked if typing-extensions was installed. It was! :) 

**Checklist**

- [x] I have formatted my code with [black](https://github.com/psf/black).
- [x] I have added tests that prove my fix is effective or that my feature 
  works
- [x] I have added docstrings to newly created methods and classes
- [x] I have optimized the code at least one time after creating the initial 
  version
- [x] I have updated the [README.md](../README.md) or verified that this
  is not necessary
- [x] I have updated the [readthedocs](../docs/source) documentation or
  verified that this is not necessary
- [x] I have added a concise human-readable description of the change to
  [CHANGELOG.md](../CHANGELOG.md)
