### PR TITLE
Issue #720 PDFObjRef insted of int

### DIFF
--- a/pdfminer/pdfpage.py
+++ b/pdfminer/pdfpage.py
@@ -60,7 +60,8 @@ class PDFPage:
         self.resources: Dict[object, object] = resolve1(
             self.attrs.get("Resources", dict())
         )
-        self.mediabox: Rect = resolve1(self.attrs["MediaBox"])
+        self.mediabox= [resolve1(mediabox_param) for mediabox_param in self.attrs['MediaBox']]
+        self.mediabox: Rect = resolve1(self.mediabox)
         if "CropBox" in self.attrs:
             self.cropbox: Rect = resolve1(self.attrs["CropBox"])
         else:


### PR DESCRIPTION
self.attrs['MediaBox'] contains params with type PDFObjRef insted of int.
I used resolve1 on all params in self.attrs['MediaBox'] to eliminate problem