### PR TITLE
Fix unknown fontname in TrueType(Arial, TimesNewRoman) (#767)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - 'ValueError': when bmp images with 1 bit channel are decoded ([#773](https://github.com/pdfminer/pdfminer.six/issues/773))
+- `unknown` fontname in TrueType(Arial, TimesNewRoman) ([#767](https://github.com/pdfminer/pdfminer.six/issues/767))
 - `ValueError` when trying to decrypt empty metadata values ([#766](https://github.com/pdfminer/pdfminer.six/issues/766))
 - Sphinx errors during building of documentation ([#760](https://github.com/pdfminer/pdfminer.six/pull/760))
 - `TypeError` when getting default width of font ([#720](https://github.com/pdfminer/pdfminer.six/issues/720))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
 - Output converter for the hOCR format ([#651](https://github.com/pdfminer/pdfminer.six/pull/651))
+- Font name aliases for Arial, Courier New and Times New Roman ([#790](https://github.com/pdfminer/pdfminer.six/pull/790))
 
 ### Fixed
 
-- 'ValueError': when bmp images with 1 bit channel are decoded ([#773](https://github.com/pdfminer/pdfminer.six/issues/773))
-- `unknown` fontname in TrueType(Arial, TimesNewRoman) ([#767](https://github.com/pdfminer/pdfminer.six/issues/767))
+- `ValueError` when bmp images with 1 bit channel are decoded ([#773](https://github.com/pdfminer/pdfminer.six/issues/773))
 - `ValueError` when trying to decrypt empty metadata values ([#766](https://github.com/pdfminer/pdfminer.six/issues/766))
 - Sphinx errors during building of documentation ([#760](https://github.com/pdfminer/pdfminer.six/pull/760))
 - `TypeError` when getting default width of font ([#720](https://github.com/pdfminer/pdfminer.six/issues/720))
-- Install typing-extensions on Python 3.6 and 3.7 ([#775](https://github.com/pdfminer/pdfminer.six/pull/775))
+- Installing typing-extensions on Python 3.6 and 3.7 ([#775](https://github.com/pdfminer/pdfminer.six/pull/775))
 - `TypeError` in cmapdb.py when parsing null characters ([#768](https://github.com/pdfminer/pdfminer.six/pull/768))
 
 ### Deprecated

--- a/pdfminer/fontmetrics.py
+++ b/pdfminer/fontmetrics.py
@@ -4448,6 +4448,8 @@ FONT_METRICS = {
     ),
 }
 
+# Aliases defined in implementation note 62 in Appecix H. related to section 5.5.1
+# (Type 1 Fonts) in the PDF Reference.
 FONT_METRICS["Arial"] = FONT_METRICS["Helvetica"]
 FONT_METRICS["Arial,Italic"] = FONT_METRICS["Helvetica-Oblique"]
 FONT_METRICS["Arial,Bold"] = FONT_METRICS["Helvetica-Bold"]

--- a/pdfminer/fontmetrics.py
+++ b/pdfminer/fontmetrics.py
@@ -4447,3 +4447,16 @@ FONT_METRICS = {
         },
     ),
 }
+
+FONT_METRICS["Arial"] = FONT_METRICS["Helvetica"]
+FONT_METRICS["Arial,Italic"] = FONT_METRICS["Helvetica-Oblique"]
+FONT_METRICS["Arial,Bold"] = FONT_METRICS["Helvetica-Bold"]
+FONT_METRICS["Arial,BoldItalic"] = FONT_METRICS["Helvetica-BoldOblique"]
+FONT_METRICS["CourierNew"] = FONT_METRICS["Courier"]
+FONT_METRICS["CourierNew,Italic"] = FONT_METRICS["Courier-Oblique"]
+FONT_METRICS["CourierNew,Bold"] = FONT_METRICS["Courier-Bold"]
+FONT_METRICS["CourierNew,BoldItalic"] = FONT_METRICS["Courier-BoldOblique"]
+FONT_METRICS["TimesNewRoman"] = FONT_METRICS["Times-Roman"]
+FONT_METRICS["TimesNewRoman,Italic"] = FONT_METRICS["Times-Italic"]
+FONT_METRICS["TimesNewRoman,Bold"] = FONT_METRICS["Times-Bold"]
+FONT_METRICS["TimesNewRoman,BoldItalic"] = FONT_METRICS["Times-BoldItalic"]


### PR DESCRIPTION
**Pull request**

Fix #767
Support TrueType fonts(Arial, TimesNewRoman, CourierNew).
reference: [Section 5.5.1 of the PDF Reference](https://ghostscript.com/~robin/pdf_reference17.pdf)

**How Has This Been Tested?**

[Test pdf file](https://github.com/pdfminer/pdfminer.six/files/8985522/C019_ASME00_Manipulator_calibration.pdf)

```python
# Part of confirmation code
resource_manager = PDFResourceManager()
device = PDFPageAggregator(resource_manager, laparams=LAParams(detect_vertical=True))
with open(input_file, 'rb') as fp:
    interpreter = PDFPageInterpreter(resource_manager, device)
    
    for page in PDFPage.get_pages(fp, check_extractable=False):
        interpreter.process_page(page)
        layout = device.get_result()

        for lt in layout:
            ...
```

with Python 3.8.13.

Confirmed worked with "Arial", "Arial,Bold", "TimesNewRoman", "TimesNewRoman,Italic", "TimesNewRoman,Bold".
While the "Arial,Italic", "Arial,BoldItalic", "TimesNewRoman,BoldItalic", "CourierNew*" not yet confirmed. (no data to confirm)

**Checklist**

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md). 
- [x] I have added a concise human-readable description of the change to [CHANGELOG.md](../CHANGELOG.md).
- [x] I have tested that this fix is effective or that this feature works.
- [ ] I have added docstrings to newly created methods and classes.
- [x] I have updated the [README.md](../README.md) and the [readthedocs](../docs/source) documentation. Or verified that this is not necessary.
