### PR TITLE
Add `contains` method to `LTComponent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Output converter for the hOCR format ([#651](https://github.com/pdfminer/pdfminer.six/pull/651))
 - Font name aliases for Arial, Courier New and Times New Roman ([#790](https://github.com/pdfminer/pdfminer.six/pull/790))
+- Adds `contains` method to `LTComponent` to check whether it contains another `LTComponent`.
 
 ### Fixed
 

--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -209,6 +209,12 @@ class LTComponent(LTItem):
             return 0
 
     def contains (self, obj: "LTComponent") -> bool:
+        """Check whether this object contains another :obj:`LTComponent`.
+        
+        :param obj: The object to check whether it is contained or not.
+        :return: :obj:`True` if the object is contained or :obj:`False`
+            otherwise.
+        """
         assert isinstance(obj, LTComponent), str(type(obj))
         return (self.x0 <= obj.x0 and self.y0 <= obj.y0
                 and self.x1 >= obj.x1 and self.y1 >= obj.y1)

--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -208,6 +208,11 @@ class LTComponent(LTItem):
         else:
             return 0
 
+    def contains (self, obj: "LTComponent") -> bool:
+        assert isinstance(obj, LTComponent), str(type(obj))
+        return (self.x0 <= obj.x0 and self.y0 <= obj.y0
+                and self.x1 >= obj.x1 and self.y1 >= obj.y1)
+
 
 class LTCurve(LTComponent):
     """A generic Bezier curve"""


### PR DESCRIPTION
**Pull request**
This PR adds a utility method to check whether a `LTComponent` is contained within another `LTComponent`.

**How Has This Been Tested?**

[test_doc.pdf](https://github.com/pdfminer/pdfminer.six/files/9525947/test_doc.pdf)

```Python
from pdfminer.high_level import extract_pages


def main():
    for page_layout in extract_pages("test_doc.pdf"):
        text_1, text_2, rect = page_layout
        print("Rect contains Text 1? (true):", rect.contains(text_1))
        assert(rect.contains(text_1))
        print("Rect contains Text 2? (false):", rect.contains(text_2))
        assert(not rect.contains(text_2))
        print("Text 1 contains Text 2? (false):", text_1.contains(text_2))
        assert(not text_1.contains(text_2))
        print("Text 2 contains Rect? (false):", text_2.contains(rect))
        assert(not text_2.contains(rect))
        print("Rect contains itself? (true):", rect.contains(rect))
        assert(rect.contains(rect))


if __name__ == "__main__":
    main()
```

**Checklist**

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md). 
- [ ] I have added a concise human-readable description of the change to [CHANGELOG.md](../CHANGELOG.md).
- [x] I have tested that this fix is effective or that this feature works.
- [x] I have added docstrings to newly created methods and classes.
- [x] I have updated the [README.md](../README.md) and the [readthedocs](../docs/source) documentation. Or verified that this is not necessary.
