### PR TITLE
Fixing formatting artefact in code comment

### DIFF
--- a/pdfminer/pdfinterp.py
+++ b/pdfminer/pdfinterp.py
@@ -115,8 +115,8 @@ class PDFTextState:
 Color = Union[
     float,  # Greyscale
     Tuple[float, float, float],  # R, G, B
-    Tuple[float, float, float, float],
-]  # C, M, Y, K
+    Tuple[float, float, float, float],  # C, M, Y, K
+]
 
 
 class PDFGraphicState:


### PR DESCRIPTION
**Pull request**

This fixes code comment being on differnt line than the item it comments.

**How Has This Been Tested?**

Should be no impact (if I didn't mess up the spacing)

**Checklist**

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md). 
- [ ] I have added a concise human-readable description of the change to [CHANGELOG.md](../CHANGELOG.md).
- [ ] I have tested that this fix is effective or that this feature works.
- [ ] I have added docstrings to newly created methods and classes.
- [X] I have updated the [README.md](../README.md) and the [readthedocs](../docs/source) documentation. Or verified that this is not necessary.
