### PR TITLE
fix-795

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Installing typing-extensions on Python 3.6 and 3.7 ([#775](https://github.com/pdfminer/pdfminer.six/pull/775))
 - `TypeError` in cmapdb.py when parsing null characters ([#768](https://github.com/pdfminer/pdfminer.six/pull/768))
 - Color "convenience operators" now (per spec) also set color space ([#779](https://github.com/pdfminer/pdfminer.six/issues/779))
+- `ValueError` when extracting images, due to breaking changes in Pillow ([#795](https://github.com/pdfminer/pdfminer.six/issues/795))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `TypeError` when getting default width of font ([#720](https://github.com/pdfminer/pdfminer.six/issues/720))
 - Installing typing-extensions on Python 3.6 and 3.7 ([#775](https://github.com/pdfminer/pdfminer.six/pull/775))
 - `TypeError` in cmapdb.py when parsing null characters ([#768](https://github.com/pdfminer/pdfminer.six/pull/768))
-- Color "convenience operators" now (per spec) also set color space ([#779](https://github.com/pdfminer/pdfminer.six/issues/779))
-- `ValueError` when extracting images, due to breaking changes in Pillow ([#795](https://github.com/pdfminer/pdfminer.six/issues/795))
+- Color "convenience operators" now (per spec) also set color space ([#794](https://github.com/pdfminer/pdfminer.six/pull/794))
+- `ValueError` when extracting images, due to breaking changes in Pillow ([#827](https://github.com/pdfminer/pdfminer.six/pull/827))
 
 ### Deprecated
 

--- a/pdfminer/image.py
+++ b/pdfminer/image.py
@@ -225,20 +225,24 @@ class ImageWriter:
         with open(path, "wb") as fp:
             try:
                 from PIL import Image  # type: ignore[import]
+                from PIL import ImageOps
             except ImportError:
                 raise ImportError(PIL_ERROR_MESSAGE)
 
-            mode: Literal["1", "8", "RGB", "CMYK"]
+            mode: Literal["1", "L", "RGB", "CMYK"]
             if image.bits == 1:
                 mode = "1"
             elif image.bits == 8 and channels == 1:
-                mode = "8"
+                mode = "L"
             elif image.bits == 8 and channels == 3:
                 mode = "RGB"
             elif image.bits == 8 and channels == 4:
                 mode = "CMYK"
 
             img = Image.frombytes(mode, image.srcsize, image.stream.get_data(), "raw")
+            if mode == "L":
+                img = ImageOps.invert(img)
+
             img.save(fp)
 
         return name


### PR DESCRIPTION
**Pull request**

Patch fix for the breaking change in the Pillow library where mode 8 is [changed to L](https://pillow.readthedocs.io/en/stable/handbook/concepts.html#concept-modes) as pointed out by [joaquimcampos](https://github.com/joaquimcampos) in https://github.com/pdfminer/pdfminer.six/issues/795

**How Has This Been Tested?**

With nox and the pdf from issue #795.

**Checklist**

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md). 
- [x] I have added a concise human-readable description of the change to [CHANGELOG.md](../CHANGELOG.md).
- [x] I have tested that this fix is effective or that this feature works.
- [x] I have added docstrings to newly created methods and classes.
- [x] I have updated the [README.md](../README.md) and the [readthedocs](../docs/source) documentation. Or verified that this is not necessary.
