### PR TITLE
Minimally fix CI

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up Python ${{ env.default-python }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ env.default-python }}
       - name: Upgrade pip, Install nox
@@ -38,9 +38,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up Python ${{ env.default-python }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ env.default-python }}
       - name: Upgrade pip, Install nox
@@ -75,12 +75,12 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Determine pip cache directory
@@ -88,7 +88,7 @@ jobs:
         run: |
           echo "::set-output name=dir::$(pip cache dir)"
       - name: Cache pip cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.pip-cache.outputs.dir }}
           key: ${{ runner.os }}-pip${{ matrix.python-version }}
@@ -105,9 +105,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up Python ${{ env.default-python }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ env.default-python }}
       - name: Upgrade pip and install nox
@@ -129,7 +129,7 @@ jobs:
       - build-docs
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install dependencies
         run: python -m pip install wheel
       - name: Set version

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -75,7 +75,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11" ] # should have 3.12 too!
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Update list of Python versions for CI
-- Version dependency on `black` to avoid CI failures (for now, should reformat)
+- Version dependency on `black` in tests to avoid CI failures (for now, should reformat)
 - Fix a `flake8` error in `tests/test_converter.py`
-- Version dependency on `mypy` to avoid CI failures (for now, should fix)
+- Version dependency on `mypy` in tests to avoid CI failures (for now, should fix)
 - Correct `type: ignore` comment in `pdfplumber/image.py`
+- Version dependency on `pip` and `setuptools` in tests to avoid CI failures (for now, should *really* fix that bogus version string!)
 - `ValueError` when bmp images with 1 bit channel are decoded ([#773](https://github.com/pdfminer/pdfminer.six/issues/773))
 - `ValueError` when trying to decrypt empty metadata values ([#766](https://github.com/pdfminer/pdfminer.six/issues/766))
 - Sphinx errors during building of documentation ([#760](https://github.com/pdfminer/pdfminer.six/pull/760))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Update list of Python versions for CI
+- Version dependency on `black` to avoid CI failures (for now, should reformat)
+- Fix a `flake8` error in `tests/test_converter.py`
+- Version dependency on `mypy` to avoid CI failures (for now, should fix)
+- Correct `type: ignore` comment in `pdfplumber/image.py`
 - `ValueError` when bmp images with 1 bit channel are decoded ([#773](https://github.com/pdfminer/pdfminer.six/issues/773))
 - `ValueError` when trying to decrypt empty metadata values ([#766](https://github.com/pdfminer/pdfminer.six/issues/766))
 - Sphinx errors during building of documentation ([#760](https://github.com/pdfminer/pdfminer.six/pull/760))
@@ -27,16 +32,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Deprecated
 
 - Usage of `if __name__ == "__main__"` where it was only intended for testing purposes ([#756](https://github.com/pdfminer/pdfminer.six/pull/756))
-
-## [20231115]
-
-### Fixed
-
-- Update list of Python versions for CI
-- Version dependency on `black` to avoid CI failures (for now, should reformat)
-- Fix a `flake8` error in `tests/test_converter.py`
-- Version dependency on `mypy` to avoid CI failures (for now, should fix)
-- Correct `type: ignore` comment in `pdfplumber/image.py`
 
 ## [20220524]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Update list of Python versions for CI
+- Version dependency on `black` to avoid CI failures
 
 ## [20220524]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Removed
+- Support for Python 3.6 and 3.7 ([#921](https://github.com/pdfminer/pdfminer.six/pull/921))
+
 ### Added
 
 - Output converter for the hOCR format ([#651](https://github.com/pdfminer/pdfminer.six/pull/651))
@@ -14,12 +17,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Update list of Python versions for CI
-- Version dependency on `black` in tests to avoid CI failures (for now, should reformat)
-- Fix a `flake8` error in `tests/test_converter.py`
-- Version dependency on `mypy` in tests to avoid CI failures (for now, should fix)
-- Correct `type: ignore` comment in `pdfplumber/image.py`
-- Version dependency on `pip` and `setuptools` in tests to avoid CI failures (for now, should *really* fix that bogus version string!)
+- Broken CI/CD pipeline by setting upper version limit for black, mypy, pip and setuptools ([#921](https://github.com/pdfminer/pdfminer.six/pull/921))
+- `flake8` failures ([#921](https://github.com/pdfminer/pdfminer.six/pull/921))
 - `ValueError` when bmp images with 1 bit channel are decoded ([#773](https://github.com/pdfminer/pdfminer.six/issues/773))
 - `ValueError` when trying to decrypt empty metadata values ([#766](https://github.com/pdfminer/pdfminer.six/issues/766))
 - Sphinx errors during building of documentation ([#760](https://github.com/pdfminer/pdfminer.six/pull/760))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Usage of `if __name__ == "__main__"` where it was only intended for testing purposes ([#756](https://github.com/pdfminer/pdfminer.six/pull/756))
 
+## [20231115]
+
+### Fixed
+
+- Update list of Python versions for CI
+
 ## [20220524]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Update list of Python versions for CI
-- Version dependency on `black` to avoid CI failures
+- Version dependency on `black` to avoid CI failures (for now, should reformat)
+- Fix a `flake8` error in `tests/test_converter.py`
+- Version dependency on `mypy` to avoid CI failures (for now, should fix)
+- Correct `type: ignore` comment in `pdfplumber/image.py`
 
 ## [20220524]
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Features
 How to use
 ----------
 
-* Install Python 3.6 or newer.
+* Install Python 3.8 or newer.
 * Install pdfminer.six.
 
   `pip install pdfminer.six`

--- a/noxfile.py
+++ b/noxfile.py
@@ -3,7 +3,7 @@ import os
 import nox
 
 
-PYTHON_ALL_VERSIONS = ["3.8", "3.9", "3.10", "3.11", "3.12"]
+PYTHON_ALL_VERSIONS = ["3.8", "3.9", "3.10", "3.11"]  # should have 3.12
 PYTHON_MODULES = ["pdfminer", "tools", "tests", "noxfile.py", "setup.py"]
 
 
@@ -45,6 +45,8 @@ def tests(session):
 
 @nox.session
 def docs(session):
+    session.install("pip<23")
+    session.install("setuptools<58")
     session.install("-e", ".[docs]")
     session.run(
         "python", "-m", "sphinx", "-b", "html", "docs/source", "docs/build/html"

--- a/noxfile.py
+++ b/noxfile.py
@@ -37,6 +37,8 @@ def types(session):
 
 @nox.session(python=PYTHON_ALL_VERSIONS)
 def tests(session):
+    session.install("pip<23")
+    session.install("setuptools<58")
     session.install("-e", ".[dev]")
     session.run("pytest")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -3,13 +3,13 @@ import os
 import nox
 
 
-PYTHON_ALL_VERSIONS = ["3.6", "3.7", "3.8", "3.9", "3.10"]
+PYTHON_ALL_VERSIONS = ["3.8", "3.9", "3.10", "3.11", "3.12"]
 PYTHON_MODULES = ["pdfminer", "tools", "tests", "noxfile.py", "setup.py"]
 
 
 @nox.session
 def format(session):
-    session.install("black")
+    session.install("black<23")
     # Format files locally with black, but only check in cicd
     if "CI" in os.environ:
         session.run("black", "--check", *PYTHON_MODULES)

--- a/noxfile.py
+++ b/noxfile.py
@@ -25,7 +25,7 @@ def lint(session):
 
 @nox.session
 def types(session):
-    session.install("mypy")
+    session.install("mypy<1")
     session.run(
         "mypy",
         "--install-types",

--- a/pdfminer/image.py
+++ b/pdfminer/image.py
@@ -8,7 +8,7 @@ try:
     from typing import Literal
 except ImportError:
     # Literal was introduced in Python 3.8
-    from typing_extensions import Literal  # type: ignore[misc]
+    from typing_extensions import Literal  # type: ignore[assignment]
 
 from .jbig2 import JBIG2StreamReader, JBIG2StreamWriter
 from .layout import LTImage

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -173,7 +173,7 @@ class TestPaintPath:
         # they all have shape 'ml' not 'mlh'
         ml_pdf = extract_pages("samples/contrib/pr-00530-ml-lines.pdf")
         ml_pdf_page = list(ml_pdf)[0]
-        assert sum(type(item) == LTLine for item in ml_pdf_page) == 6
+        assert sum(type(item) is LTLine for item in ml_pdf_page) == 6
 
     def _get_analyzer(self):
         analyzer = PDFLayoutAnalyzer(None)


### PR DESCRIPTION
**Pull request**

Python versions in CI were very out of date - 3.6 and 3.7 are now end-of-life and no longer supported. See https://devguide.python.org/versions/

But beyond that a lot of things passed CI only because of specific older versions of tooling (`black`, `mypy`, `pip` among other things). These problems **should be fixed for real** but this will at least get CI working again.  I will separate PRs for these problems, which are partly formatting but also some type-checking issues (there are quite a lot of type-checking issues) and of course the issue of `-VERSION-` as the default version string (really there should be a way to get to semantic versioning...)

**How Has This Been Tested?**

It wasn't tested when first pushed because there isn't any easy way to test GitHub CI recipes 😡  But now it seems to work :)

**Checklist**

- [ x ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md). 
- [ x ] I have added a concise human-readable description of the change to [CHANGELOG.md](../CHANGELOG.md).
- [ x ] I have tested that this fix is effective or that this feature works.
- [ x ] I have added docstrings to newly created methods and classes. (not applicable)
- [ x ] I have updated the [README.md](../README.md) and the [readthedocs](../docs/source) documentation. Or verified that this is not necessary. (not applicable)