### PR TITLE
Fix #903: Keep track of OCG for LTCurve, LTLine, LTRect

### DIFF
--- a/pdfminer/converter.py
+++ b/pdfminer/converter.py
@@ -167,6 +167,7 @@ class PDFLayoutAnalyzer(PDFTextDevice):
                     gstate.ncolor,
                     original_path=transformed_path,
                     dashing_style=gstate.dash,
+                    ocg=gstate.ocg
                 )
                 self.cur_item.add(line)
 
@@ -188,6 +189,7 @@ class PDFLayoutAnalyzer(PDFTextDevice):
                         gstate.ncolor,
                         transformed_path,
                         gstate.dash,
+                        gstate.ocg
                     )
                     self.cur_item.add(rect)
                 else:
@@ -201,6 +203,7 @@ class PDFLayoutAnalyzer(PDFTextDevice):
                         gstate.ncolor,
                         transformed_path,
                         gstate.dash,
+                        gstate.ocg
                     )
                     self.cur_item.add(curve)
             else:
@@ -214,6 +217,7 @@ class PDFLayoutAnalyzer(PDFTextDevice):
                     gstate.ncolor,
                     transformed_path,
                     gstate.dash,
+                    gstate.ocg
                 )
                 self.cur_item.add(curve)
 

--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -217,6 +217,7 @@ class LTCurve(LTComponent):
     pathing information from the pdf (e.g. for reconstructing Bezier Curves).
 
     `dashing_style` contains the Dashing information if any.
+    `ocg` contains the layer (Optional Content Group) information if any.
     """
 
     def __init__(
@@ -230,6 +231,7 @@ class LTCurve(LTComponent):
         non_stroking_color: Optional[Color] = None,
         original_path: Optional[List[PathSegment]] = None,
         dashing_style: Optional[Tuple[object, object]] = None,
+        ocg: str = None
     ) -> None:
         LTComponent.__init__(self, get_bound(pts))
         self.pts = pts
@@ -241,6 +243,7 @@ class LTCurve(LTComponent):
         self.non_stroking_color = non_stroking_color
         self.original_path = original_path
         self.dashing_style = dashing_style
+        self.ocg = ocg
 
     def get_pts(self) -> str:
         return ",".join("%.3f,%.3f" % p for p in self.pts)
@@ -264,6 +267,7 @@ class LTLine(LTCurve):
         non_stroking_color: Optional[Color] = None,
         original_path: Optional[List[PathSegment]] = None,
         dashing_style: Optional[Tuple[object, object]] = None,
+        ocg: str = None,
     ) -> None:
         LTCurve.__init__(
             self,
@@ -276,6 +280,7 @@ class LTLine(LTCurve):
             non_stroking_color,
             original_path,
             dashing_style,
+            ocg,
         )
 
 
@@ -296,6 +301,7 @@ class LTRect(LTCurve):
         non_stroking_color: Optional[Color] = None,
         original_path: Optional[List[PathSegment]] = None,
         dashing_style: Optional[Tuple[object, object]] = None,
+        ocg: str = None,
     ) -> None:
         (x0, y0, x1, y1) = bbox
         LTCurve.__init__(
@@ -309,6 +315,7 @@ class LTRect(LTCurve):
             non_stroking_color,
             original_path,
             dashing_style,
+            ocg,
         )
 
 

--- a/pdfminer/pdfinterp.py
+++ b/pdfminer/pdfinterp.py
@@ -443,9 +443,14 @@ class PDFPageInterpreter:
         return
 
     def do_Q(self) -> None:
-        """Restore graphics state"""
+        """
+        Restore graphics state
+        But maintain the freshly declared OCG (layer group)
+        """
+        curr_ocg = self.graphicstate.ocg
         if self.gstack:
             self.set_current_state(self.gstack.pop())
+        self.graphicstate.ocg = curr_ocg
         return
 
     def do_cm(

--- a/pdfminer/pdfinterp.py
+++ b/pdfminer/pdfinterp.py
@@ -135,7 +135,8 @@ class PDFGraphicState:
         # non stroking color
         self.ncolor: Optional[Color] = None
 
-        self.ocg: str = None # optional content group name
+        # OCG (Optional Content Group)
+        self.ocg: str = None
 
     def copy(self) -> "PDFGraphicState":
         obj = PDFGraphicState()

--- a/pdfminer/pdfinterp.py
+++ b/pdfminer/pdfinterp.py
@@ -135,6 +135,8 @@ class PDFGraphicState:
         # non stroking color
         self.ncolor: Optional[Color] = None
 
+        self.ocg: str = None # optional content group name
+
     def copy(self) -> "PDFGraphicState":
         obj = PDFGraphicState()
         obj.linewidth = self.linewidth
@@ -146,13 +148,14 @@ class PDFGraphicState:
         obj.flatness = self.flatness
         obj.scolor = self.scolor
         obj.ncolor = self.ncolor
+        obj.ocg = self.ocg
         return obj
 
     def __repr__(self) -> str:
         return (
             "<PDFGraphicState: linewidth=%r, linecap=%r, linejoin=%r, "
             " miterlimit=%r, dash=%r, intent=%r, flatness=%r, "
-            " stroking color=%r, non stroking color=%r>"
+            " stroking color=%r, non stroking color=%r, ocg=%r>"
             % (
                 self.linewidth,
                 self.linecap,
@@ -163,6 +166,7 @@ class PDFGraphicState:
                 self.flatness,
                 self.scolor,
                 self.ncolor,
+                self.ocg
             )
         )
 
@@ -766,11 +770,14 @@ class PDFPageInterpreter:
     def do_BMC(self, tag: PDFStackT) -> None:
         """Begin marked-content sequence"""
         self.device.begin_tag(cast(PSLiteral, tag))
+        self.ocg = tag # set ocg property
+        # TODO: there was somethig else we have to change.. the graphic state gets reset after some command. 
         return
 
     def do_BDC(self, tag: PDFStackT, props: PDFStackT) -> None:
         """Begin marked-content sequence with property list"""
         self.device.begin_tag(cast(PSLiteral, tag), props)
+        self.ocg = tag # set ocg property
         return
 
     def do_EMC(self) -> None:

--- a/pdfminer/pdfinterp.py
+++ b/pdfminer/pdfinterp.py
@@ -775,14 +775,13 @@ class PDFPageInterpreter:
     def do_BMC(self, tag: PDFStackT) -> None:
         """Begin marked-content sequence"""
         self.device.begin_tag(cast(PSLiteral, tag))
-        self.ocg = tag # set ocg property
-        # TODO: there was somethig else we have to change.. the graphic state gets reset after some command. 
         return
 
     def do_BDC(self, tag: PDFStackT, props: PDFStackT) -> None:
         """Begin marked-content sequence with property list"""
         self.device.begin_tag(cast(PSLiteral, tag), props)
-        self.ocg = tag # set ocg property
+        # Set graphic state OCG attribute 
+        self.graphicstate.ocg = str(props).strip('/')
         return
 
     def do_EMC(self) -> None:


### PR DESCRIPTION
**Pull request**

This PR fixes [Issue 903](https://github.com/pdfminer/pdfminer.six/issues/903) which was raised by me after encountering this problem.

Many vector PDFs have [Optional Content Groups](https://www.oreilly.com/library/view/developing-with-pdf/9781449327903/ch10.html) (OCGs), also referred to as layers. When extracting LTComponents like LTCurve, LTLine, and LTRect, one may find the need to keep track of which OCG the LTComponent is attributed to. This is accomplished by:

1. Adding `ocg` attributes to LTCurve, LTLine, and LTRect in 'pdfminer/layout.py'
2. Setting the `ocg` attribute in 'pdfminer/converter.py'
3. Adding an `ocg` attribute to the PDFGraphicState object in 'pdfminer/pdfinterp.py'
4. Setting the PDFGraphicState's `ocg` attribute in 'pdfminer/pdfinterp.py' when the vector graphic BDC command is encountered in the PDF's stream _and_ ensuring the current `ocg` value is maintained even when the graphic state is restored with the vector graphic Q command.

**How Has This Been Tested?**

Please *remove* this paragraph with a description of how this PR has been tested.
[TODO]

**Checklist**

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md). 
- [ ] I have added a concise human-readable description of the change to [CHANGELOG.md](../CHANGELOG.md).
- [x] I have tested that this fix is effective or that this feature works.
- [x] I have added docstrings to newly created methods and classes.
- [ ] I have updated the [README.md](../README.md) and the [readthedocs](../docs/source) documentation. Or verified that this is not necessary.
