### PR TITLE
Fix #934: Create correct cidcoding name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Resolving mediabox and pdffont ([#834](https://github.com/pdfminer/pdfminer.six/pull/834))
 - Keywords that aren't terminated by the pattern `END_KEYWORD` before end-of-stream are parsed ([#885](https://github.com/pdfminer/pdfminer.six/pull/885))
 - `ValueError` wrong error message when specifying codec for text output  ([#902](https://github.com/pdfminer/pdfminer.six/pull/902))
-- Fixed to read cmap data correctly. ([#934](https://github.com/pdfminer/pdfminer.six/issues/934))
+- Reading cmap's with whitespace in the name ([#935](https://github.com/pdfminer/pdfminer.six/pull/935))
 
 ## [20231228]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Resolving mediabox and pdffont ([#834](https://github.com/pdfminer/pdfminer.six/pull/834))
 - Keywords that aren't terminated by the pattern `END_KEYWORD` before end-of-stream are parsed ([#885](https://github.com/pdfminer/pdfminer.six/pull/885))
 - `ValueError` wrong error message when specifying codec for text output  ([#902](https://github.com/pdfminer/pdfminer.six/pull/902))
+- Fixed to read cmap data correctly. ([#934](https://github.com/pdfminer/pdfminer.six/issues/934))
 
 ## [20231228]
 

--- a/pdfminer/pdffont.py
+++ b/pdfminer/pdffont.py
@@ -1063,7 +1063,7 @@ class PDFCIDFont(PDFFont):
         cid_ordering = resolve1(self.cidsysteminfo.get("Ordering", b"unknown")).decode(
             "latin1"
         )
-        self.cidcoding = "{}-{}".format(cid_registry, cid_ordering)
+        self.cidcoding = "{}-{}".format(cid_registry.strip(), cid_ordering.strip())
         self.cmap: CMapBase = self.get_cmap_from_spec(spec, strict)
 
         try:


### PR DESCRIPTION
**Pull request**

In some PDF files, cmap data could not be read correctly.
This was due to unintentional whitespace in the filename used to read the cmap file.
This fix will allow cmap to be read correctly in some PDF files.

The PDF file where this occurs is [bs104761.pdf](https://github.com/pdfminer/pdfminer.six/files/13873023/bs104761.pdf) in #934.

The PDF contained whitespace in `cid_registry` and `cid_ordering`.

cid_registry: `Adobe`
cid_ordering: `Japan1\n\n\n\n\n\n\n\n\n\n`

Therefore, `strip()` was used to remove the whitespace characters.

**How Has This Been Tested?**

With the corrected version, the text extraction can be performed correctly in bs104761.pdf.

```
$ python tools/pdf2txt.py bs104761.pdf | head
WARNING:pdfminer.pdfpage:The PDF <_io.BufferedReader name='bs104761.pdf'> contains a metadata field indicating that it should not allow text extraction. Ignoring this field and proceeding. Use the check_extractable if you want to raise an error in this case
商号　アルファテックス株式会社

貸 借 対 照 表

令 和 3 年 3 月 31 日 現 在

代表者 石川　春

科　　　　　目
産

```

Behavior before modification:
```
$ python tools/pdf2txt.py bs104761.pdf | head
WARNING:pdfminer.pdfpage:The PDF <_io.BufferedReader name='bs104761.pdf'> contains a metadata field indicating that it should not allow text extraction. Ignoring this field and proceeding. Use the check_extractable if you want to raise an error in this case
(cid:2446)(cid:2040)(cid:633)(cid:926)(cid:999)(cid:977)(cid:925)(cid:962)(cid:959)(cid:939)(cid:949)(cid:1490)(cid:2268)(cid:1393)(cid:2302)

(cid:2879) (cid:2310) (cid:2864) (cid:2480) (cid:3503)

(cid:4009) (cid:4072) (cid:250) (cid:3301) (cid:250) (cid:1860) (cid:250)(cid:248) (cid:3284) (cid:1905) (cid:2127)

(cid:2885)(cid:3503)(cid:2304)(cid:231)(cid:2676)(cid:2706)(cid:633)(cid:2399)

(cid:1354)(cid:633)(cid:633)(cid:633)(cid:633)(cid:633)(cid:3816)
(cid:2184)
```



**Checklist**

- [x] I have read [CONTRIBUTING.md](https://github.com/pdfminer/pdfminer.six/blob/master/CONTRIBUTING.md). 
- [x] I have added a concise human-readable description of the change to [CHANGELOG.md](https://github.com/pdfminer/pdfminer.six/blob/master/CHANGELOG.md).
- [x] I have tested that this fix is effective or that this feature works.
- [x] I have added docstrings to newly created methods and classes.
- [x] I have updated the [README.md](https://github.com/pdfminer/pdfminer.six/blob/master/README.md) and the [readthedocs](https://github.com/pdfminer/pdfminer.six/tree/master/docs/source) documentation. Or verified that this is not necessary.
