### PR TITLE
Support zipped jpegs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Support for zipped jpeg's ([#938](https://github.com/pdfminer/pdfminer.six/pull/938))
+
 ### Fixed
 
 - Resolving mediabox and pdffont ([#834](https://github.com/pdfminer/pdfminer.six/pull/834))

--- a/pdfminer/image.py
+++ b/pdfminer/image.py
@@ -104,10 +104,10 @@ class ImageWriter:
 
         filters = image.stream.get_filters()
 
-        if len(filters) == 1 and filters[0][0] in LITERALS_DCT_DECODE:
+        if filters[-1][0] in LITERALS_DCT_DECODE:
             name = self._save_jpeg(image)
 
-        elif len(filters) == 1 and filters[0][0] in LITERALS_JPX_DECODE:
+        elif filters[-1][0] in LITERALS_JPX_DECODE:
             name = self._save_jpeg2000(image)
 
         elif self._is_jbig2_iamge(image):
@@ -132,8 +132,7 @@ class ImageWriter:
 
     def _save_jpeg(self, image: LTImage) -> str:
         """Save a JPEG encoded image"""
-        raw_data = image.stream.get_rawdata()
-        assert raw_data is not None
+        data = image.stream.get_data()
 
         name, path = self._create_unique_image_name(image, ".jpg")
         with open(path, "wb") as fp:
@@ -143,20 +142,19 @@ class ImageWriter:
                 except ImportError:
                     raise ImportError(PIL_ERROR_MESSAGE)
 
-                ifp = BytesIO(raw_data)
+                ifp = BytesIO(data)
                 i = Image.open(ifp)
                 i = ImageChops.invert(i)
                 i = i.convert("RGB")
                 i.save(fp, "JPEG")
             else:
-                fp.write(raw_data)
+                fp.write(data)
 
         return name
 
     def _save_jpeg2000(self, image: LTImage) -> str:
         """Save a JPEG 2000 encoded image"""
-        raw_data = image.stream.get_rawdata()
-        assert raw_data is not None
+        data = image.stream.get_data()
 
         name, path = self._create_unique_image_name(image, ".jp2")
         with open(path, "wb") as fp:
@@ -169,7 +167,7 @@ class ImageWriter:
             # that I have tried cannot open the file. However,
             # open and saving with PIL produces a file that
             # seems to be easily opened by other programs
-            ifp = BytesIO(raw_data)
+            ifp = BytesIO(data)
             i = Image.open(ifp)
             i.save(fp, "JPEG2000")
         return name

--- a/tests/test_tools_pdf2txt.py
+++ b/tests/test_tools_pdf2txt.py
@@ -177,3 +177,9 @@ class TestDumpImages:
     def test_nonfree_cmp_itext_logo(self):
         """Test a pdf with Type3 font"""
         run("nonfree/cmp_itext_logo.pdf")
+
+    def test_contrib_issue_495_pdfobjref(self):
+        """Test for extracting a zipped pdf"""
+        filepath = absolute_sample_path("contrib/issue_495_pdfobjref.pdf")
+        image_files = self.extract_images(filepath)
+        assert image_files[0].endswith("jpg")


### PR DESCRIPTION
**Pull request**

Closes #937 

Also support jpegs with preceding other filters. First apply those filters and finally store the jpegs. 

**How Has This Been Tested?**

I've added a test based on the pdf of #906. 

**Checklist**

- [x] I have read [CONTRIBUTING.md](https://github.com/pdfminer/pdfminer.six/blob/master/CONTRIBUTING.md). 
- [x] I have added a concise human-readable description of the change to [CHANGELOG.md](https://github.com/pdfminer/pdfminer.six/blob/master/CHANGELOG.md).
- [x] I have tested that this fix is effective or that this feature works.
- [x] I have added docstrings to newly created methods and classes.
- [x] I have updated the [README.md](https://github.com/pdfminer/pdfminer.six/blob/master/README.md) and the [readthedocs](https://github.com/pdfminer/pdfminer.six/tree/master/docs/source) documentation. Or verified that this is not necessary.
