### PR TITLE
allow @ in identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Support for zipped jpeg's ([#938](https://github.com/pdfminer/pdfminer.six/pull/938))
+- Allow `@` as part of an identifier
 
 ### Fixed
 

--- a/pdfminer/psparser.py
+++ b/pdfminer/psparser.py
@@ -317,7 +317,7 @@ class PSBaseParser:
             self._curtoken = c
             self._parse1 = self._parse_float
             return j + 1
-        elif c.isalpha():
+        elif c.isalpha() or c == b"@":
             self._curtoken = c
             self._parse1 = self._parse_keyword
             return j + 1


### PR DESCRIPTION
Identifiers can contain the @ symbol, a typical example is
```
put @resources << /ColorSpace @pgfcolorspaces >>
```
as found in documents created with LaTeX package pgf and colorspaces.

At the moment a pdf containing the above will trigger an error:
```
pdfminer.psparser.PSSyntaxError: Invalid dictionary construct: [/'ColorSpace', /b'@', /b'pgfcolorspaces']
```
since @ is parsed as separate token.

The PR was tested against about 20 different PDf papers from the arXiv corpus.

**Checklist**

- [x] I have read [CONTRIBUTING.md](https://github.com/pdfminer/pdfminer.six/blob/master/CONTRIBUTING.md). 
- [x] I have added a concise human-readable description of the change to [CHANGELOG.md](https://github.com/pdfminer/pdfminer.six/blob/master/CHANGELOG.md).
- [x] I have tested that this fix is effective or that this feature works.
- [x] I have added docstrings to newly created methods and classes.
- [x] I have updated the [README.md](https://github.com/pdfminer/pdfminer.six/blob/master/README.md) and the [readthedocs](https://github.com/pdfminer/pdfminer.six/tree/master/docs/source) documentation. Or verified that this is not necessary.
