### PR TITLE
Update Adobe CMAP resource github page URL

### DIFF
--- a/pdfminer/cmapdb.py
+++ b/pdfminer/cmapdb.py
@@ -3,9 +3,9 @@
 CMaps provide the mapping between character codes and Unicode
 code-points to character ids (CIDs).
 
-More information is available on the Adobe website:
+More information is available on:
 
-  http://opensource.adobe.com/wiki/display/cmap/CMap+Resources
+  https://github.com/adobe-type-tools/cmap-resources
 
 """
 


### PR DESCRIPTION
I was trying to make a clone of PDF Miner on Go that is why I was looking into source code. The link given in the docstring was broken. Updated with current CMAP github resource page.

**Pull request**

Please *remove* this paragraph and replace it with a description of your PR. Also include the issue that it fixes. 

**How Has This Been Tested?**

Please *remove* this paragraph with a description of how this PR has been tested.

**Checklist**

- [x] I have read [CONTRIBUTING.md](https://github.com/pdfminer/pdfminer.six/blob/master/CONTRIBUTING.md). 
- [x] I have added a concise human-readable description of the change to [CHANGELOG.md](https://github.com/pdfminer/pdfminer.six/blob/master/CHANGELOG.md).
- [x] I have tested that this fix is effective or that this feature works.
- [x] I have added docstrings to newly created methods and classes.
- [x] I have updated the [README.md](https://github.com/pdfminer/pdfminer.six/blob/master/README.md) and the [readthedocs](https://github.com/pdfminer/pdfminer.six/tree/master/docs/source) documentation. Or verified that this is not necessary.
