### PR TITLE
Update Python 3.7 syntax to 3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Support for zipped jpeg's ([#938](https://github.com/pdfminer/pdfminer.six/pull/938))
-
 - Fuzzing harnesses for integration into Google's OSS-Fuzz ([949](https://github.com/pdfminer/pdfminer.six/pull/949))
 - Support for setuptools-git-versioning version 2.0.0 ([#957](https://github.com/pdfminer/pdfminer.six/pull/957))
 
@@ -20,6 +19,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Resolve stream filter parameters ([#906](https://github.com/pdfminer/pdfminer.six/pull/906))
 - Reading cmap's with whitespace in the name ([#935](https://github.com/pdfminer/pdfminer.six/pull/935))
 - Optimize `apply_png_predictor` by using lists ([#912](https://github.com/pdfminer/pdfminer.six/pull/912))
+
+### Changed
+
+- Updated Python 3.7 syntax to 3.8 ([#956](https://github.com/pdfminer/pdfminer.six/pull/956))
 
 ## [20231228]
 

--- a/pdfminer/converter.py
+++ b/pdfminer/converter.py
@@ -458,7 +458,7 @@ class HTMLConverter(PDFConverter[AnyIO]):
 
     def write_footer(self) -> None:
         page_links = [
-            '<a href="#{}">{}</a>'.format(i, i) for i in range(1, self.pageno)
+            f'<a href="#{i}">{i}</a>' for i in range(1, self.pageno)
         ]
         s = '<div style="position:absolute; top:0px;">Page: %s</div>\n' % ", ".join(
             page_links
@@ -783,7 +783,7 @@ class XMLConverter(PDFConverter[AnyIO]):
                 )
                 self.write(s)
             elif isinstance(item, LTFigure):
-                s = '<figure name="%s" bbox="%s">\n' % (item.name, bbox2str(item.bbox))
+                s = '<figure name="{}" bbox="{}">\n'.format(item.name, bbox2str(item.bbox))
                 self.write(s)
                 for child in item:
                     render(child)
@@ -974,7 +974,7 @@ class HOCRConverter(PDFConverter[AnyIO]):
                 self.write("</div>\n")
             elif isinstance(item, LTTextLine):
                 self.write(
-                    "<span class='ocr_line' title='%s'>" % ((self.bbox_repr(item.bbox)))
+                    "<span class='ocr_line' title='%s'>" % (self.bbox_repr(item.bbox))
                 )
                 for child_line in item:
                     render(child_line)

--- a/pdfminer/converter.py
+++ b/pdfminer/converter.py
@@ -457,9 +457,7 @@ class HTMLConverter(PDFConverter[AnyIO]):
         return
 
     def write_footer(self) -> None:
-        page_links = [
-            f'<a href="#{i}">{i}</a>' for i in range(1, self.pageno)
-        ]
+        page_links = [f'<a href="#{i}">{i}</a>' for i in range(1, self.pageno)]
         s = '<div style="position:absolute; top:0px;">Page: %s</div>\n' % ", ".join(
             page_links
         )
@@ -783,7 +781,9 @@ class XMLConverter(PDFConverter[AnyIO]):
                 )
                 self.write(s)
             elif isinstance(item, LTFigure):
-                s = '<figure name="{}" bbox="{}">\n'.format(item.name, bbox2str(item.bbox))
+                s = '<figure name="{}" bbox="{}">\n'.format(
+                    item.name, bbox2str(item.bbox)
+                )
                 self.write(s)
                 for child in item:
                     render(child)

--- a/pdfminer/fontmetrics.py
+++ b/pdfminer/fontmetrics.py
@@ -36,7 +36,7 @@ def convert_font_metrics(path: str) -> None:
     See below for the output.
     """
     fonts = {}
-    with open(path, "r") as fileinput:
+    with open(path) as fileinput:
         for line in fileinput.readlines():
             f = line.strip().split(" ")
             if not f:
@@ -66,7 +66,7 @@ def convert_font_metrics(path: str) -> None:
         print("# -*- python -*-")
         print("FONT_METRICS = {")
         for (fontname, (props, chars)) in fonts.items():
-            print(" {!r}: {!r},".format(fontname, (props, chars)))
+            print(f" {fontname!r}: {(props, chars)!r},")
         print("}")
 
 

--- a/pdfminer/glyphlist.py
+++ b/pdfminer/glyphlist.py
@@ -58,7 +58,7 @@ def convert_glyphlist(path: str) -> None:
     See output below.
     """
     state = 0
-    with open(path, "r") as fileinput:
+    with open(path) as fileinput:
         for line in fileinput.readlines():
             line = line.strip()
             if not line or line.startswith("#"):

--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -129,7 +129,7 @@ class LTText:
     """Interface for things that have text"""
 
     def __repr__(self) -> str:
-        return "<%s %r>" % (self.__class__.__name__, self.get_text())
+        return "<{} {!r}>".format(self.__class__.__name__, self.get_text())
 
     def get_text(self) -> str:
         """Text contained in this object"""
@@ -144,7 +144,7 @@ class LTComponent(LTItem):
         self.set_bbox(bbox)
 
     def __repr__(self) -> str:
-        return "<%s %s>" % (self.__class__.__name__, bbox2str(self.bbox))
+        return "<{} {}>".format(self.__class__.__name__, bbox2str(self.bbox))
 
     # Disable comparison.
     def __lt__(self, _: object) -> bool:
@@ -330,7 +330,7 @@ class LTImage(LTComponent):
             self.colorspace = [self.colorspace]
 
     def __repr__(self) -> str:
-        return "<%s(%s) %s %r>" % (
+        return "<{}({}) {} {!r}>".format(
             self.__class__.__name__,
             self.name,
             bbox2str(self.bbox),
@@ -410,7 +410,7 @@ class LTChar(LTComponent, LTText):
         return
 
     def __repr__(self) -> str:
-        return "<%s %s matrix=%s font=%r adv=%s text=%r>" % (
+        return "<{} {} matrix={} font={!r} adv={} text={!r}>".format(
             self.__class__.__name__,
             bbox2str(self.bbox),
             matrix2str(self.matrix),
@@ -503,7 +503,7 @@ class LTTextLine(LTTextContainer[TextLineElement]):
         return
 
     def __repr__(self) -> str:
-        return "<%s %s %r>" % (
+        return "<{} {} {!r}>".format(
             self.__class__.__name__,
             bbox2str(self.bbox),
             self.get_text(),
@@ -674,7 +674,7 @@ class LTTextBox(LTTextContainer[LTTextLine]):
         return
 
     def __repr__(self) -> str:
-        return "<%s(%s) %s %r>" % (
+        return "<{}({}) {} {!r}>".format(
             self.__class__.__name__,
             self.index,
             bbox2str(self.bbox),
@@ -1007,7 +1007,7 @@ class LTFigure(LTLayoutContainer):
         return
 
     def __repr__(self) -> str:
-        return "<%s(%s) %s matrix=%s>" % (
+        return "<{}({}) {} matrix={}>".format(
             self.__class__.__name__,
             self.name,
             bbox2str(self.bbox),
@@ -1035,7 +1035,7 @@ class LTPage(LTLayoutContainer):
         return
 
     def __repr__(self) -> str:
-        return "<%s(%r) %s rotate=%r>" % (
+        return "<{}({!r}) {} rotate={!r}>".format(
             self.__class__.__name__,
             self.pageid,
             bbox2str(self.bbox),

--- a/pdfminer/pdfdevice.py
+++ b/pdfminer/pdfdevice.py
@@ -292,11 +292,11 @@ class TagExtractor(PDFDevice):
         if isinstance(props, dict):
             s = "".join(
                 [
-                    ' {}="{}"'.format(utils.enc(k), utils.make_compat_str(v))
+                    f' {utils.enc(k)}="{utils.make_compat_str(v)}"'
                     for (k, v) in sorted(props.items())
                 ]
             )
-        out_s = "<{}{}>".format(utils.enc(cast(str, tag.name)), s)
+        out_s = f"<{utils.enc(cast(str, tag.name))}{s}>"
         self._write(out_s)
         self._stack.append(tag)
         return

--- a/pdfminer/pdfdocument.py
+++ b/pdfminer/pdfdocument.py
@@ -158,12 +158,12 @@ class PDFXRef(PDFBaseXRef):
                 break
             f = line.split(b" ")
             if len(f) != 2:
-                error_msg = "Trailer not found: {!r}: line={!r}".format(parser, line)
+                error_msg = f"Trailer not found: {parser!r}: line={line!r}"
                 raise PDFNoValidXRef(error_msg)
             try:
                 (start, nobjs) = map(int, f)
             except ValueError:
-                error_msg = "Invalid line: {!r}: line={!r}".format(parser, line)
+                error_msg = f"Invalid line: {parser!r}: line={line!r}"
                 raise PDFNoValidXRef(error_msg)
             for objid in range(start, start + nobjs):
                 try:
@@ -833,7 +833,7 @@ class PDFDocument:
                 objid1 = x[-2]
         # #### end hack around malformed pdf files
         if objid1 != objid:
-            raise PDFSyntaxError("objid mismatch: {!r}={!r}".format(objid1, objid))
+            raise PDFSyntaxError(f"objid mismatch: {objid1!r}={objid!r}")
 
         if kwd != KWD(b"obj"):
             raise PDFSyntaxError("Invalid object spec: offset=%r" % pos)

--- a/pdfminer/pdffont.py
+++ b/pdfminer/pdffont.py
@@ -1063,7 +1063,7 @@ class PDFCIDFont(PDFFont):
         cid_ordering = resolve1(self.cidsysteminfo.get("Ordering", b"unknown")).decode(
             "latin1"
         )
-        self.cidcoding = "{}-{}".format(cid_registry.strip(), cid_ordering.strip())
+        self.cidcoding = f"{cid_registry.strip()}-{cid_ordering.strip()}"
         self.cmap: CMapBase = self.get_cmap_from_spec(spec, strict)
 
         try:

--- a/pdfminer/pdfinterp.py
+++ b/pdfminer/pdfinterp.py
@@ -320,7 +320,7 @@ class PDFContentParser(PSStackParser[Union[PSKeyword, PDFStream]]):
             try:
                 (_, objs) = self.end_type("inline")
                 if len(objs) % 2 != 0:
-                    error_msg = "Invalid dictionary construct: {!r}".format(objs)
+                    error_msg = f"Invalid dictionary construct: {objs!r}"
                     raise PSTypeError(error_msg)
                 d = {literal_name(k): v for (k, v) in choplist(2, objs)}
                 (pos, data) = self.get_inline_data(pos + len(b"ID "))

--- a/pdfminer/pdftypes.py
+++ b/pdfminer/pdftypes.py
@@ -1,7 +1,7 @@
 import io
 import logging
-import sys
 import zlib
+from typing import Protocol
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -44,8 +44,6 @@ LITERALS_JBIG2_DECODE = (LIT("JBIG2Decode"),)
 LITERALS_JPX_DECODE = (LIT("JPXDecode"),)
 
 
-from typing import Protocol
-
 class DecipherCallable(Protocol):
     """Fully typed a decipher callback, with optional parameter."""
 
@@ -57,7 +55,6 @@ class DecipherCallable(Protocol):
         attrs: Optional[Dict[str, Any]] = None,
     ) -> bytes:
         raise NotImplementedError
-
 
 
 class PDFObject(PSObject):

--- a/pdfminer/pdftypes.py
+++ b/pdfminer/pdftypes.py
@@ -44,25 +44,20 @@ LITERALS_JBIG2_DECODE = (LIT("JBIG2Decode"),)
 LITERALS_JPX_DECODE = (LIT("JPXDecode"),)
 
 
-if sys.version_info >= (3, 8):
-    from typing import Protocol
+from typing import Protocol
 
-    class DecipherCallable(Protocol):
-        """Fully typed a decipher callback, with optional parameter."""
+class DecipherCallable(Protocol):
+    """Fully typed a decipher callback, with optional parameter."""
 
-        def __call__(
-            self,
-            objid: int,
-            genno: int,
-            data: bytes,
-            attrs: Optional[Dict[str, Any]] = None,
-        ) -> bytes:
-            raise NotImplementedError
+    def __call__(
+        self,
+        objid: int,
+        genno: int,
+        data: bytes,
+        attrs: Optional[Dict[str, Any]] = None,
+    ) -> bytes:
+        raise NotImplementedError
 
-else:  # Fallback for older Python
-    from typing import Callable
-
-    DecipherCallable = Callable[..., bytes]
 
 
 class PDFObject(PSObject):
@@ -333,7 +328,7 @@ class PDFStream(PDFObject):
 
                 except zlib.error as e:
                     if settings.STRICT:
-                        error_msg = "Invalid zlib bytes: {!r}, {!r}".format(e, data)
+                        error_msg = f"Invalid zlib bytes: {e!r}, {data!r}"
                         raise PDFException(error_msg)
 
                     try:

--- a/pdfminer/psparser.py
+++ b/pdfminer/psparser.py
@@ -132,7 +132,7 @@ KEYWORD_DICT_END = KWD(b">>")
 def literal_name(x: object) -> Any:
     if not isinstance(x, PSLiteral):
         if settings.STRICT:
-            raise PSTypeError("Literal required: {!r}".format(x))
+            raise PSTypeError(f"Literal required: {x!r}")
         else:
             name = x
     else:
@@ -592,7 +592,7 @@ class PSStackParser(PSBaseParser, Generic[ExtraT]):
 
     def end_type(self, type: str) -> Tuple[int, List[PSStackType[ExtraT]]]:
         if self.curtype != type:
-            raise PSTypeError("Type mismatch: {!r} != {!r}".format(self.curtype, type))
+            raise PSTypeError(f"Type mismatch: {self.curtype!r} != {type!r}")
         objs = [obj for (_, obj) in self.curstack]
         (pos, self.curtype, self.curstack) = self.context.pop()
         log.debug("end_type: pos=%r, type=%r, objs=%r", pos, type, objs)

--- a/pdfminer/utils.py
+++ b/pdfminer/utils.py
@@ -39,7 +39,7 @@ FileOrName = Union[pathlib.PurePath, str, io.IOBase]
 AnyIO = Union[TextIO, BinaryIO]
 
 
-class open_filename(object):
+class open_filename:
     """
     Context manager that allows opening a filename
     (str or pathlib.PurePath type is supported) and closes it on exit,
@@ -89,7 +89,7 @@ def shorten_str(s: str, size: int) -> str:
         return s[:size]
     if len(s) > size:
         length = (size - 5) // 2
-        return "{} ... {}".format(s[:length], s[-length:])
+        return f"{s[:length]} ... {s[-length:]}"
     else:
         return s
 
@@ -643,12 +643,12 @@ def enc(x: str) -> str:
 
 def bbox2str(bbox: Rect) -> str:
     (x0, y0, x1, y1) = bbox
-    return "{:.3f},{:.3f},{:.3f},{:.3f}".format(x0, y0, x1, y1)
+    return f"{x0:.3f},{y0:.3f},{x1:.3f},{y1:.3f}"
 
 
 def matrix2str(m: Matrix) -> str:
     (a, b, c, d, e, f) = m
-    return "[{:.2f},{:.2f},{:.2f},{:.2f}, ({:.2f},{:.2f})]".format(a, b, c, d, e, f)
+    return f"[{a:.2f},{b:.2f},{c:.2f},{d:.2f}, ({e:.2f},{f:.2f})]"
 
 
 def vecBetweenBoxes(obj1: "LTComponent", obj2: "LTComponent") -> Point:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from setuptools import setup
 
 root_dir = Path(__file__).parent
-with open(root_dir / "README.md", "rt") as f:
+with open(root_dir / "README.md") as f:
     readme = f.read()
 
 setup(

--- a/tests/test_pdfdocument.py
+++ b/tests/test_pdfdocument.py
@@ -8,7 +8,7 @@ from pdfminer.pdftypes import PDFObjectNotFound, dict_value, int_value
 from tests.helpers import absolute_sample_path
 
 
-class TestPdfDocument(object):
+class TestPdfDocument:
     def test_get_zero_objid_raises_pdfobjectnotfound(self):
         with open(absolute_sample_path("simple1.pdf"), "rb") as in_file:
             parser = PDFParser(in_file)

--- a/tests/test_pdfpage.py
+++ b/tests/test_pdfpage.py
@@ -4,7 +4,7 @@ from pdfminer.pdfparser import PDFParser
 from tests.helpers import absolute_sample_path
 
 
-class TestPdfPage(object):
+class TestPdfPage:
     def test_page_labels(self):
         path = absolute_sample_path("contrib/pagelabels.pdf")
         expected_labels = ["iii", "iv", "1", "2", "1"]

--- a/tests/test_tools_dumppdf.py
+++ b/tests/test_tools_dumppdf.py
@@ -11,9 +11,9 @@ def run(filename, options=None):
     absolute_path = absolute_sample_path(filename)
     with TemporaryFilePath() as output_file_name:
         if options:
-            s = "dumppdf -o %s %s %s" % (output_file_name, options, absolute_path)
+            s = "dumppdf -o {} {} {}".format(output_file_name, options, absolute_path)
         else:
-            s = "dumppdf -o %s %s" % (output_file_name, absolute_path)
+            s = "dumppdf -o {} {}".format(output_file_name, absolute_path)
 
         dumppdf.main(s.split(" ")[1:])
 

--- a/tests/test_tools_pdf2txt.py
+++ b/tests/test_tools_pdf2txt.py
@@ -12,9 +12,9 @@ def run(sample_path, options=None):
     absolute_path = absolute_sample_path(sample_path)
     with TemporaryFilePath() as output_file_name:
         if options:
-            s = "pdf2txt -o{} {} {}".format(output_file_name, options, absolute_path)
+            s = f"pdf2txt -o{output_file_name} {options} {absolute_path}"
         else:
-            s = "pdf2txt -o{} {}".format(output_file_name, absolute_path)
+            s = f"pdf2txt -o{output_file_name} {absolute_path}"
 
         pdf2txt.main(s.split(" ")[1:])
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -71,7 +71,7 @@ class TestPlane:
         return plane, obj
 
 
-class TestFunctions(object):
+class TestFunctions:
     def test_shorten_str(self):
         s = shorten_str("Hello there World", 15)
         assert s == "Hello ... World"

--- a/tools/conv_afm.py
+++ b/tools/conv_afm.py
@@ -36,7 +36,7 @@ def main(argv):
     print("# -*- python -*-")
     print("FONT_METRICS = {")
     for (fontname, (props, chars)) in fonts.items():
-        print(" {!r}: {!r},".format(fontname, (props, chars)))
+        print(f" {fontname!r}: {(props, chars)!r},")
     print("}")
     return 0
 

--- a/tools/dumppdf.py
+++ b/tools/dumppdf.py
@@ -186,7 +186,7 @@ def dumpoutline(
                         dest = resolve_dest(action["D"])
                         pageno = pages[dest[0].objid]
             s = escape(title)
-            outfp.write('<outline level="{!r}" title="{}">\n'.format(level, s))
+            outfp.write(f'<outline level="{level!r}" title="{s}">\n')
             if dest is not None:
                 outfp.write("<dest>")
                 dumpxml(outfp, dest)
@@ -224,7 +224,7 @@ def extractembedded(fname: str, password: str, extractdir: str) -> None:
             )
         path = os.path.join(extractdir, "%.6d-%s" % (objid, filename))
         if os.path.exists(path):
-            raise IOError("file exists: %r" % path)
+            raise OSError("file exists: %r" % path)
         print("extracting: %r" % path)
         os.makedirs(os.path.dirname(path), exist_ok=True)
         out = open(path, "wb")
@@ -300,7 +300,7 @@ def create_parser() -> ArgumentParser:
         "--version",
         "-v",
         action="version",
-        version="pdfminer.six v{}".format(pdfminer.__version__),
+        version=f"pdfminer.six v{pdfminer.__version__}",
     )
     parser.add_argument(
         "--debug",

--- a/tools/pdf2txt.py
+++ b/tools/pdf2txt.py
@@ -21,7 +21,7 @@ def float_or_disabled(x: str) -> Optional[float]:
     try:
         return float(x)
     except ValueError:
-        raise argparse.ArgumentTypeError("invalid float value: {}".format(x))
+        raise argparse.ArgumentTypeError(f"invalid float value: {x}")
 
 
 def extract_text(
@@ -77,7 +77,7 @@ def create_parser() -> argparse.ArgumentParser:
         "--version",
         "-v",
         action="version",
-        version="pdfminer.six v{}".format(pdfminer.__version__),
+        version=f"pdfminer.six v{pdfminer.__version__}",
     )
     parser.add_argument(
         "--debug",

--- a/tools/pdf2txt.py
+++ b/tools/pdf2txt.py
@@ -40,7 +40,7 @@ def extract_text(
     output_dir: Optional[str] = None,
     debug: bool = False,
     disable_caching: bool = False,
-    **kwargs: Any
+    **kwargs: Any,
 ) -> AnyIO:
     if not files:
         raise ValueError("Must provide files to work upon!")


### PR DESCRIPTION
**Pull request**
Filter all code over `pyupgrade --py38-plus`.

**How Has This Been Tested?**
I;m using my typical packaging procedure:
- `python3 -sBm build -w --no-isolation`
- because I'm calling `build` with `--no-isolation` I'm using during all processes only locally installed modules
- install .whl file in </install/prefix> using `installer` module
- run pytest with $PYTHONPATH pointing to sitearch and sitelib inside </install/prefix>
- build is performed in env which is *`cut off from access to the public network`* (pytest is executed with `-m "not network"`)

**Checklist**

- [x] I have read [CONTRIBUTING.md](https://github.com/pdfminer/pdfminer.six/blob/master/CONTRIBUTING.md). 
- [ ] I have added a concise human-readable description of the change to [CHANGELOG.md](https://github.com/pdfminer/pdfminer.six/blob/master/CHANGELOG.md).
- [x] I have tested that this fix is effective or that this feature works.
- [ ] I have added docstrings to newly created methods and classes.
- [ ] I have updated the [README.md](https://github.com/pdfminer/pdfminer.six/blob/master/README.md) and the [readthedocs](https://github.com/pdfminer/pdfminer.six/tree/master/docs/source) documentation. Or verified that this is not necessary.
