### PR TITLE
Allow setuptools-git-versioning 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Support for zipped jpeg's ([#938](https://github.com/pdfminer/pdfminer.six/pull/938))
+- Support for setuptools-git-versioning version 2.0.0 ([#957](https://github.com/pdfminer/pdfminer.six/pull/957))
 
 ### Fixed
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     setuptools_git_versioning={
         "enabled": True,
     },
-    setup_requires=["setuptools-git-versioning<2"],
+    setup_requires=["setuptools-git-versioning<3"],
     packages=["pdfminer"],
     package_data={"pdfminer": ["cmap/*.pickle.gz", "py.typed"]},
     install_requires=[


### PR DESCRIPTION
**Pull request**

Allow the current release of `setuptools-git-versioning` (2.0.0) by raising the version bound from `<2` to `<3`. (I did not file an issue for this.)

Version 2.0.0 has several breaking changes, described in https://setuptools-git-versioning.readthedocs.io/en/stable/changelog.html#change-2.0.0, but none of them appear relevant for this project.

**How Has This Been Tested?**

```
$ python3 -m build
$ cd dist
$ ls -1
pdfminer.six-20221105.post23+git.f02a1b80-py3-none-any.whl
pdfminer.six-20221105.post23+git.f02a1b80.tar.gz
$ python3 -m wheel unpack pdfminer.six-20221105.post23+git.f02a1b80-py3-none-any.whl
$ grep -E '^Version:' pdfminer.six-20221105.post23+git.f02a1b80/pdfminer.six-20221105.post23+git.f02a1b80.dist-info/METADATA 
Version: 20221105.post23+git.f02a1b80
```
https://setuptools-git-versioning.readthedocs.io/en/stable/changelog.html#change-2.0.0


**Checklist**

- [x] I have read [CONTRIBUTING.md](https://github.com/pdfminer/pdfminer.six/blob/master/CONTRIBUTING.md). 
- [x] I have added a concise human-readable description of the change to [CHANGELOG.md](https://github.com/pdfminer/pdfminer.six/blob/master/CHANGELOG.md).
- [x] I have tested that this fix is effective or that this feature works.
- [x] I have added docstrings to newly created methods and classes. **N/A, no code changes**
- [x] I have updated the [README.md](https://github.com/pdfminer/pdfminer.six/blob/master/README.md) and the [readthedocs](https://github.com/pdfminer/pdfminer.six/tree/master/docs/source) documentation. Or verified that this is not necessary.
