### PR TITLE
feat: add API demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Support for zipped jpeg's ([#938](https://github.com/pdfminer/pdfminer.six/pull/938))
+- pdfminer.six demo API ([#961](https://github.com/pdfminer/pdfminer.six/pull/961))
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ interpreter or rendering device that uses the power of pdfminer.six for other pu
 Check out the full documentation on
 [Read the Docs](https://pdfminersix.readthedocs.io).
 
+Try out a deployed API [here](https://pdftojson.vercel.app/).
+
 
 Features
 --------


### PR DESCRIPTION
**Pull request**

I've built an API for pdfminer.six that is freely available to use, with short ratelimits, and unlimited usage.
I would like to share that with the pdfminer.six community, and allow people to test out your library without installing anything.

**How Has This Been Tested?**

No testing is needed due to the change only being a README change.

**Checklist**

- [x] I have read [CONTRIBUTING.md](https://github.com/pdfminer/pdfminer.six/blob/master/CONTRIBUTING.md). 
- [x] I have added a concise human-readable description of the change to [CHANGELOG.md](https://github.com/pdfminer/pdfminer.six/blob/master/CHANGELOG.md).
- [ ] I have tested that this fix is effective or that this feature works.
- [ ] I have added docstrings to newly created methods and classes.
- [x] I have updated the [README.md](https://github.com/pdfminer/pdfminer.six/blob/master/README.md) and the [readthedocs](https://github.com/pdfminer/pdfminer.six/tree/master/docs/source) documentation. Or verified that this is not necessary.
