### PR TITLE
Safely cast object id to integer in PDFParser to prevert TypeError and ValueError.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes in pdfminer.six will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Fixed
+
+- `TypeError` when PDF object reference cannot be parsed as int ([#972](https://github.com/pdfminer/pdfminer.six/pull/972))])
+
 ## [20240706]
 
 ### Added

--- a/pdfminer/casting.py
+++ b/pdfminer/casting.py
@@ -1,0 +1,8 @@
+from typing import Optional, Any
+
+
+def safe_int(o: Any) -> Optional[int]:
+    try:
+        return int(o)
+    except (TypeError, ValueError):
+        return None

--- a/pdfminer/pdftypes.py
+++ b/pdfminer/pdftypes.py
@@ -13,6 +13,7 @@ from typing import (
     Tuple,
     cast,
 )
+from warnings import warn
 
 from . import settings, pdfexceptions
 from .ascii85 import ascii85decode
@@ -66,12 +67,30 @@ PDFValueError = pdfexceptions.PDFValueError
 PDFObjectNotFound = pdfexceptions.PDFObjectNotFound
 PDFNotImplementedError = pdfexceptions.PDFNotImplementedError
 
+_DEFAULT = object()
+
 
 class PDFObjRef(PDFObject):
-    def __init__(self, doc: Optional["PDFDocument"], objid: int, _: object) -> None:
+    def __init__(
+        self, doc: Optional["PDFDocument"], objid: int, _: Any = _DEFAULT
+    ) -> None:
+        """Reference to a PDF object.
+
+        :param doc: The PDF document.
+        :param objid: The object number.
+        :param _: Unused argument for backwards compatibility.
+        """
+        if _ is not _DEFAULT:
+            warn(
+                "The third argument of PDFObjRef is unused and will be removed after "
+                "2024",
+                DeprecationWarning,
+            )
+
         if objid == 0:
             if settings.STRICT:
                 raise PDFValueError("PDF object id cannot be 0.")
+
         self.doc = doc
         self.objid = objid
 


### PR DESCRIPTION
**Pull request**

Fixes #971. 

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=70071

Not assume that object can be converted to `int`. But use try-except in `safe_int` and return `None` if it can't be converted to `int`. Simply ignore the object if that is the case. 

**How Has This Been Tested?**

With the nox tests. And with the fuzz blob. 

**Checklist**

- [x] I have read [CONTRIBUTING.md](https://github.com/pdfminer/pdfminer.six/blob/master/CONTRIBUTING.md). 
- [x] I have added a concise human-readable description of the change to [CHANGELOG.md](https://github.com/pdfminer/pdfminer.six/blob/master/CHANGELOG.md).
- [x] I have tested that this fix is effective or that this feature works.
- [x] I have added docstrings to newly created methods and classes.
- [x] I have updated the [README.md](https://github.com/pdfminer/pdfminer.six/blob/master/README.md) and the [readthedocs](https://github.com/pdfminer/pdfminer.six/tree/master/docs/source) documentation. Or verified that this is not necessary.
