### PR TITLE
Fix corpora naming

### DIFF
--- a/fuzzing/build.sh
+++ b/fuzzing/build.sh
@@ -6,5 +6,5 @@ for fuzzer in $(find fuzzing -name '*_fuzzer.py');do
   compile_python_fuzzer "$fuzzer" --collect-all charset_normalizer --hidden-import=_cffi_backend
   base_name=$(basename "$fuzzer")
   base_name_no_ext=${base_name%.*}
-  zip -q $OUT/"$base_name_no_ext".zip $SRC/corpus/*
+  zip -q $OUT/"${base_name_no_ext}_seed_corpus".zip $SRC/corpus/*
 done


### PR DESCRIPTION
**Pull request**

This Pull-Request includes the necessary changes to integrate fuzzing into pdfminer.six for OSS-Fuzz continuous fuzzing, as discussed in [Issue 918](https://github.com/pdfminer/pdfminer.six/issues/918).

In short, this PR adds atheris (the fuzzing framework) as a development dependency, and a new fuzzing directory containing a corpus, some initial harnesses, the necessary CI file to integrate the project into OSSFuzz, and a build script to be used by ClusterFuzz to prepare for nightly fuzzing.

In addition to the above, two simple bug-fixes are resolved to address crashes that were occurring too early into fuzzing, preventing progress. 

**How Has This Been Tested?**

The fuzzing harnesses are tests in and of themselves, so they were tested via coverage analysis and allowing them to run. 

NOTE: The CIFuzz.yml job will fail until Google merges the necessary pdfminer Dockerfile into their OSS-Fuzz repository. This can only be done after this PR is merged.

**Checklist**

- [x] I have read [CONTRIBUTING.md](https://github.com/pdfminer/pdfminer.six/blob/master/CONTRIBUTING.md). 
- [x] I have added a concise human-readable description of the change to [CHANGELOG.md](https://github.com/pdfminer/pdfminer.six/blob/master/CHANGELOG.md).
- [x] I have tested that this fix is effective or that this feature works.
- [x] I have added docstrings to newly created methods and classes.
- [x] I have updated the [README.md](https://github.com/pdfminer/pdfminer.six/blob/master/README.md) and the [readthedocs](https://github.com/pdfminer/pdfminer.six/tree/master/docs/source) documentation. Or verified that this is not necessary.
