### PR TITLE
Always return a `str` from `literal_name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - `TypeError` when PDF object reference cannot be parsed as int ([#972](https://github.com/pdfminer/pdfminer.six/pull/972))])
+- `TypeError` when PDF literal cannot be converted to str ([#978](https://github.com/pdfminer/pdfminer.six/pull/978))
 
 ### Removed
 

--- a/pdfminer/pdfinterp.py
+++ b/pdfminer/pdfinterp.py
@@ -947,7 +947,7 @@ class PDFPageInterpreter:
 
     def do_Do(self, xobjid_arg: PDFStackT) -> None:
         """Invoke named XObject"""
-        xobjid = cast(str, literal_name(xobjid_arg))
+        xobjid = literal_name(xobjid_arg)
         try:
             xobj = stream_value(self.xobjmap[xobjid])
         except KeyError:

--- a/pdfminer/psparser.py
+++ b/pdfminer/psparser.py
@@ -117,20 +117,15 @@ KEYWORD_DICT_BEGIN = KWD(b"<<")
 KEYWORD_DICT_END = KWD(b">>")
 
 
-def literal_name(x: object) -> Any:
-    if not isinstance(x, PSLiteral):
+def literal_name(x: object) -> str:
+    if isinstance(x, PSLiteral):
+        name = x.name
+    else:
         if settings.STRICT:
             raise PSTypeError(f"Literal required: {x!r}")
-        else:
-            name = x
-    else:
-        name = x.name
-        if not isinstance(name, str):
-            try:
-                name = str(name, "utf-8")
-            except Exception:
-                pass
-    return name
+        name = x
+
+    return str(name)
 
 
 def keyword_name(x: object) -> Any:


### PR DESCRIPTION
**Pull request**

This is what happened in practice for correct input (e.g. `PSLiteral`). But now it also always returns a `str` when the object is not a `PSLiteral`. 

This fixes #977 because it makes the literal name object hashable. This sample PDF will now crash with a PDFSyntaxError. That's good.

**How Has This Been Tested?**

With the PDF from #977. And with nox. 

**Checklist**

- [x] I have read [CONTRIBUTING.md](https://github.com/pdfminer/pdfminer.six/blob/master/CONTRIBUTING.md). 
- [x] I have added a concise human-readable description of the change to [CHANGELOG.md](https://github.com/pdfminer/pdfminer.six/blob/master/CHANGELOG.md).
- [x] I have tested that this fix is effective or that this feature works.
- [x] I have added docstrings to newly created methods and classes.
- [x] I have updated the [README.md](https://github.com/pdfminer/pdfminer.six/blob/master/README.md) and the [readthedocs](https://github.com/pdfminer/pdfminer.six/tree/master/docs/source) documentation. Or verified that this is not necessary.
