### PR TITLE
Validate xref position explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- `TypeError` when PDF object reference cannot be parsed as int ([#972](https://github.com/pdfminer/pdfminer.six/pull/972))])
-- `TypeError` when PDF literal cannot be converted to str ([#978](https://github.com/pdfminer/pdfminer.six/pull/978))
+- `TypeError` when corrupt PDF object reference cannot be parsed as int ([#972](https://github.com/pdfminer/pdfminer.six/pull/972))])
+- `TypeError` when corrupt PDF literal cannot be converted to str ([#978](https://github.com/pdfminer/pdfminer.six/pull/978))
+- `ValueError` when corrupt PDF specifies a negative xref location ([#980](http://github.com/pdfminer/pdfminer.six/pull/980))
 
 ### Removed
 

--- a/pdfminer/pdfdocument.py
+++ b/pdfminer/pdfdocument.py
@@ -959,7 +959,7 @@ class PDFDocument:
                 log.debug("xref found: pos=%r", prev)
 
                 if not prev.isdigit():
-                    raise PDFNoValidXRef(f"Invalid xref position: {prev}")
+                    raise PDFNoValidXRef(f"Invalid xref position: {prev!r}")
 
                 start = int(prev)
 

--- a/pdfminer/pdfdocument.py
+++ b/pdfminer/pdfdocument.py
@@ -950,19 +950,28 @@ class PDFDocument:
     def find_xref(self, parser: PDFParser) -> int:
         """Internal function used to locate the first XRef."""
         # search the last xref table by scanning the file backwards.
-        prev = None
+        prev = b""
         for line in parser.revreadlines():
             line = line.strip()
             log.debug("find_xref: %r", line)
+
             if line == b"startxref":
-                break
+                log.debug("xref found: pos=%r", prev)
+
+                if not prev.isdigit():
+                    raise PDFNoValidXRef(f"Invalid xref position: {prev}")
+
+                start = int(prev)
+
+                if not start >= 0:
+                    raise PDFNoValidXRef(f"Invalid negative xref position: {start}")
+
+                return start
+
             if line:
                 prev = line
-        else:
-            raise PDFNoValidXRef("Unexpected EOF")
-        log.debug("xref found: pos=%r", prev)
-        assert prev is not None
-        return int(prev)
+
+        raise PDFNoValidXRef("Unexpected EOF")
 
     # read xref table
     def read_xref_from(

--- a/pdfminer/psparser.py
+++ b/pdfminer/psparser.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import io
 
 # -*- coding: utf-8 -*-
 
@@ -260,7 +261,7 @@ class PSBaseParser:
 
         This is used to locate the trailers at the end of a file.
         """
-        self.fp.seek(0, 2)
+        self.fp.seek(0, io.SEEK_END)
         pos = self.fp.tell()
         buf = b""
         while 0 < pos:


### PR DESCRIPTION
**Pull request**

Fixes #979. 

Validate xref position explicitly. If it cannot be parsed as an integer, or if it is a negative integer a `PDFNoValidXRef` is raised. 

**How Has This Been Tested?**

With the fuzz file from #979 and with nox. 

**Checklist**

- [x] I have read [CONTRIBUTING.md](https://github.com/pdfminer/pdfminer.six/blob/master/CONTRIBUTING.md). 
- [x] I have added a concise human-readable description of the change to [CHANGELOG.md](https://github.com/pdfminer/pdfminer.six/blob/master/CHANGELOG.md).
- [x] I have tested that this fix is effective or that this feature works.
- [x] I have added docstrings to newly created methods and classes.
- [x] I have updated the [README.md](https://github.com/pdfminer/pdfminer.six/blob/master/README.md) and the [readthedocs](https://github.com/pdfminer/pdfminer.six/tree/master/docs/source) documentation. Or verified that this is not necessary.
