### PR TITLE
Parse mediabox and cropbox rectangle explicitly to floats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `TypeError` when corrupt PDF object reference cannot be parsed as int ([#972](https://github.com/pdfminer/pdfminer.six/pull/972))])
 - `TypeError` when corrupt PDF literal cannot be converted to str ([#978](https://github.com/pdfminer/pdfminer.six/pull/978))
 - `ValueError` when corrupt PDF specifies a negative xref location ([#980](http://github.com/pdfminer/pdfminer.six/pull/980))
+- `ValueError` when corrupt PDF specifies an invalid mediabox ([#987](https://github.com/pdfminer/pdfminer.six/pull/987))
 
 ### Removed
 

--- a/pdfminer/utils.py
+++ b/pdfminer/utils.py
@@ -238,6 +238,14 @@ PathSegment = Union[
 MATRIX_IDENTITY: Matrix = (1, 0, 0, 1, 0, 0)
 
 
+def parse_rect(o: Any) -> Rect:
+    try:
+        (x0, y0, x1, y1) = o
+        return float(x0), float(y0), float(x1), float(y1)
+    except ValueError:
+        raise PDFValueError("Could not parse rectangle")
+
+
 def mult_matrix(m1: Matrix, m0: Matrix) -> Matrix:
     (a1, b1, c1, d1, e1, f1) = m1
     (a0, b0, c0, d0, e0, f0) = m0


### PR DESCRIPTION
**Pull request**

Fixes #986

Parse mediabox and cropbox rectangle explicitly to floats. This prevents downstream errors that assume the mediabox is a tuple of 4 floats. 

**How Has This Been Tested?**

With the testcase from #986 and with nox. 

**Checklist**

- [x] I have read [CONTRIBUTING.md](https://github.com/pdfminer/pdfminer.six/blob/master/CONTRIBUTING.md). 
- [x] I have added a concise human-readable description of the change to [CHANGELOG.md](https://github.com/pdfminer/pdfminer.six/blob/master/CHANGELOG.md).
- [x] I have tested that this fix is effective or that this feature works.
- [x] I have added docstrings to newly created methods and classes.
- [x] I have updated the [README.md](https://github.com/pdfminer/pdfminer.six/blob/master/README.md) and the [readthedocs](https://github.com/pdfminer/pdfminer.six/tree/master/docs/source) documentation. Or verified that this is not necessary.
