### PR TITLE
Remove unnecessary return statements

### DIFF
--- a/pdfminer/ccitt.py
+++ b/pdfminer/ccitt.py
@@ -352,7 +352,6 @@ class CCITTG4Parser(BitParser):
         self.width = width
         self.bytealign = bytealign
         self.reset()
-        return
 
     def feedbytes(self, data: bytes) -> None:
         for byte in get_bytes(data):
@@ -364,7 +363,6 @@ class CCITTG4Parser(BitParser):
                 self._state = self.MODE
             except self.EOFB:
                 break
-        return
 
     def _parse_mode(self, mode: object) -> BitParserState:
         if mode == "p":
@@ -453,18 +451,15 @@ class CCITTG4Parser(BitParser):
         self._reset_line()
         self._accept = self._parse_mode
         self._state = self.MODE
-        return
 
     def output_line(self, y: int, bits: Sequence[int]) -> None:
         print(y, "".join(str(b) for b in bits))
-        return
 
     def _reset_line(self) -> None:
         self._refline = self._curline
         self._curline = array.array("b", [1] * self.width)
         self._curpos = -1
         self._color = 1
-        return
 
     def _flush_line(self) -> None:
         if self.width <= self._curpos:
@@ -473,7 +468,6 @@ class CCITTG4Parser(BitParser):
             self._reset_line()
             if self.bytealign:
                 raise self.ByteSkip
-        return
 
     def _do_vertical(self, dx: int) -> None:
         x1 = self._curpos + 1
@@ -500,7 +494,6 @@ class CCITTG4Parser(BitParser):
                 self._curline[x] = self._color
         self._curpos = x1
         self._color = 1 - self._color
-        return
 
     def _do_pass(self) -> None:
         x1 = self._curpos + 1
@@ -531,7 +524,6 @@ class CCITTG4Parser(BitParser):
         for x in range(self._curpos, x1):
             self._curline[x] = self._color
         self._curpos = x1
-        return
 
     def _do_horizontal(self, n1: int, n2: int) -> None:
         if self._curpos < 0:
@@ -548,14 +540,12 @@ class CCITTG4Parser(BitParser):
             self._curline[x] = 1 - self._color
             x += 1
         self._curpos = x
-        return
 
     def _do_uncompressed(self, bits: str) -> None:
         for c in bits:
             self._curline[self._curpos] = int(c)
             self._curpos += 1
             self._flush_line()
-        return
 
 
 class CCITTFaxDecoder(CCITTG4Parser):
@@ -565,7 +555,6 @@ class CCITTFaxDecoder(CCITTG4Parser):
         CCITTG4Parser.__init__(self, width, bytealign=bytealign)
         self.reversed = reversed
         self._buf = b""
-        return
 
     def close(self) -> bytes:
         return self._buf
@@ -578,7 +567,6 @@ class CCITTFaxDecoder(CCITTG4Parser):
             if b:
                 arr[i // 8] += (128, 64, 32, 16, 8, 4, 2, 1)[i % 8]
         self._buf += arr.tobytes()
-        return
 
 
 def ccittfaxdecode(data: bytes, params: Dict[str, object]) -> bytes:
@@ -608,7 +596,6 @@ def main(argv: List[str]) -> None:
 
             CCITTG4Parser.__init__(self, width, bytealign=bytealign)
             self.img = pygame.Surface((self.width, 1000))
-            return
 
         def output_line(self, y: int, bits: Sequence[int]) -> None:
             for (x, b) in enumerate(bits):
@@ -616,13 +603,11 @@ def main(argv: List[str]) -> None:
                     self.img.set_at((x, y), (255, 255, 255))
                 else:
                     self.img.set_at((x, y), (0, 0, 0))
-            return
 
         def close(self) -> None:
             import pygame
 
             pygame.image.save(self.img, "out.bmp")
-            return
 
     for path in argv[1:]:
         fp = open(path, "rb")
@@ -631,4 +616,3 @@ def main(argv: List[str]) -> None:
         parser.feedbytes(fp.read())
         parser.close()
         fp.close()
-    return

--- a/pdfminer/cmapdb.py
+++ b/pdfminer/cmapdb.py
@@ -292,14 +292,12 @@ class CMapParser(PSStackParser[PSKeyword]):
         # some ToUnicode maps don't have "begincmap" keyword.
         self._in_cmap = True
         self._warnings: Set[str] = set()
-        return
 
     def run(self) -> None:
         try:
             self.nextobject()
         except PSEOF:
             pass
-        return
 
     KEYWORD_BEGINCMAP = KWD(b"begincmap")
     KEYWORD_ENDCMAP = KWD(b"endcmap")

--- a/pdfminer/converter.py
+++ b/pdfminer/converter.py
@@ -357,10 +357,8 @@ class TextConverter(PDFConverter[AnyIO]):
     # is text.  This stops all the image and drawing output from being
     # recorded and taking up RAM.
     def render_image(self, name: str, stream: PDFStream) -> None:
-        if self.imagewriter is None:
-            return
-        PDFConverter.render_image(self, name, stream)
-        return
+        if self.imagewriter is not None:
+            PDFConverter.render_image(self, name, stream)
 
     def paint_path(
         self,
@@ -370,7 +368,7 @@ class TextConverter(PDFConverter[AnyIO]):
         evenodd: bool,
         path: Sequence[PathSegment],
     ) -> None:
-        return
+        pass
 
 
 class HTMLConverter(PDFConverter[AnyIO]):
@@ -435,14 +433,12 @@ class HTMLConverter(PDFConverter[AnyIO]):
         self._font: Optional[Tuple[str, float]] = None
         self._fontstack: List[Optional[Tuple[str, float]]] = []
         self.write_header()
-        return
 
     def write(self, text: str) -> None:
         if self.codec:
             cast(BinaryIO, self.outfp).write(text.encode(self.codec))
         else:
             cast(TextIO, self.outfp).write(text)
-        return
 
     def write_header(self) -> None:
         self.write("<html><head>\n")
@@ -455,7 +451,6 @@ class HTMLConverter(PDFConverter[AnyIO]):
             s = '<meta http-equiv="Content-Type" content="text/html">\n'
         self.write(s)
         self.write("</head><body>\n")
-        return
 
     def write_footer(self) -> None:
         page_links = [f'<a href="#{i}">{i}</a>' for i in range(1, self.pageno)]
@@ -464,11 +459,9 @@ class HTMLConverter(PDFConverter[AnyIO]):
         )
         self.write(s)
         self.write("</body></html>\n")
-        return
 
     def write_text(self, text: str) -> None:
         self.write(enc(text))
-        return
 
     def place_rect(
         self, color: str, borderwidth: int, x: float, y: float, w: float, h: float
@@ -488,11 +481,9 @@ class HTMLConverter(PDFConverter[AnyIO]):
                 )
             )
             self.write(s)
-        return
 
     def place_border(self, color: str, borderwidth: int, item: LTComponent) -> None:
         self.place_rect(color, borderwidth, item.x0, item.y1, item.width, item.height)
-        return
 
     def place_image(
         self, item: LTImage, borderwidth: int, x: float, y: float, w: float, h: float
@@ -512,7 +503,6 @@ class HTMLConverter(PDFConverter[AnyIO]):
                 )
             )
             self.write(s)
-        return
 
     def place_text(
         self, color: str, text: str, x: float, y: float, size: float
@@ -532,7 +522,6 @@ class HTMLConverter(PDFConverter[AnyIO]):
             self.write(s)
             self.write_text(text)
             self.write("</span>\n")
-        return
 
     def begin_div(
         self,
@@ -561,14 +550,12 @@ class HTMLConverter(PDFConverter[AnyIO]):
             )
         )
         self.write(s)
-        return
 
     def end_div(self, color: str) -> None:
         if self._font is not None:
             self.write("</span>")
         self._font = self._fontstack.pop()
         self.write("</div>")
-        return
 
     def put_text(self, text: str, fontname: str, fontsize: float) -> None:
         font = (fontname, fontsize)
@@ -583,11 +570,9 @@ class HTMLConverter(PDFConverter[AnyIO]):
             )
             self._font = font
         self.write_text(text)
-        return
 
     def put_newline(self) -> None:
         self.write("<br>")
-        return
 
     def receive_layout(self, ltpage: LTPage) -> None:
         def show_group(item: Union[LTTextGroup, TextGroupElement]) -> None:
@@ -595,7 +580,6 @@ class HTMLConverter(PDFConverter[AnyIO]):
                 self.place_border("textgroup", 1, item)
                 for child in item:
                     show_group(child)
-            return
 
         def render(item: LTItem) -> None:
             child: LTItem
@@ -668,15 +652,12 @@ class HTMLConverter(PDFConverter[AnyIO]):
                         self.put_text(item.get_text(), fontname, item.size)
                     elif isinstance(item, LTText):
                         self.write_text(item.get_text())
-            return
 
         render(ltpage)
         self._yoffset += self.pagemargin
-        return
 
     def close(self) -> None:
         self.write_footer()
-        return
 
 
 class XMLConverter(PDFConverter[AnyIO]):
@@ -704,14 +685,12 @@ class XMLConverter(PDFConverter[AnyIO]):
         self.imagewriter = imagewriter
         self.stripcontrol = stripcontrol
         self.write_header()
-        return
 
     def write(self, text: str) -> None:
         if self.codec:
             cast(BinaryIO, self.outfp).write(text.encode(self.codec))
         else:
             cast(TextIO, self.outfp).write(text)
-        return
 
     def write_header(self) -> None:
         if self.codec:
@@ -719,17 +698,14 @@ class XMLConverter(PDFConverter[AnyIO]):
         else:
             self.write('<?xml version="1.0" ?>\n')
         self.write("<pages>\n")
-        return
 
     def write_footer(self) -> None:
         self.write("</pages>\n")
-        return
 
     def write_text(self, text: str) -> None:
         if self.stripcontrol:
             text = self.CONTROL.sub("", text)
         self.write(enc(text))
-        return
 
     def receive_layout(self, ltpage: LTPage) -> None:
         def show_group(item: LTItem) -> None:
@@ -743,7 +719,6 @@ class XMLConverter(PDFConverter[AnyIO]):
                 for child in item:
                     show_group(child)
                 self.write("</textgroup>\n")
-            return
 
         def render(item: LTItem) -> None:
             child: LTItem
@@ -837,14 +812,11 @@ class XMLConverter(PDFConverter[AnyIO]):
                     )
             else:
                 assert False, str(("Unhandled", item))
-            return
 
         render(ltpage)
-        return
 
     def close(self) -> None:
         self.write_footer()
-        return
 
 
 class HOCRConverter(PDFConverter[AnyIO]):

--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -349,7 +349,6 @@ class LTAnno(LTItem, LTText):
 
     def __init__(self, text: str) -> None:
         self._text = text
-        return
 
     def get_text(self) -> str:
         return self._text
@@ -408,7 +407,6 @@ class LTChar(LTComponent, LTText):
             self.size = self.width
         else:
             self.size = self.height
-        return
 
     def __repr__(self) -> str:
         return "<{} {} matrix={} font={!r} adv={} text={!r}>".format(
@@ -433,7 +431,6 @@ class LTContainer(LTComponent, Generic[LTItemT]):
     def __init__(self, bbox: Rect) -> None:
         LTComponent.__init__(self, bbox)
         self._objs: List[LTItemT] = []
-        return
 
     def __iter__(self) -> Iterator[LTItemT]:
         return iter(self._objs)
@@ -443,23 +440,19 @@ class LTContainer(LTComponent, Generic[LTItemT]):
 
     def add(self, obj: LTItemT) -> None:
         self._objs.append(obj)
-        return
 
     def extend(self, objs: Iterable[LTItemT]) -> None:
         for obj in objs:
             self.add(obj)
-        return
 
     def analyze(self, laparams: LAParams) -> None:
         for obj in self._objs:
             obj.analyze(laparams)
-        return
 
 
 class LTExpandableContainer(LTContainer[LTItemT]):
     def __init__(self) -> None:
         LTContainer.__init__(self, (+INF, +INF, -INF, -INF))
-        return
 
     # Incompatible override: we take an LTComponent (with bounding box), but
     # super() LTContainer only considers LTItem (no bounding box).
@@ -473,14 +466,12 @@ class LTExpandableContainer(LTContainer[LTItemT]):
                 max(self.y1, obj.y1),
             )
         )
-        return
 
 
 class LTTextContainer(LTExpandableContainer[LTItemT], LTText):
     def __init__(self) -> None:
         LTText.__init__(self)
         LTExpandableContainer.__init__(self)
-        return
 
     def get_text(self) -> str:
         return "".join(
@@ -501,7 +492,6 @@ class LTTextLine(LTTextContainer[TextLineElement]):
     def __init__(self, word_margin: float) -> None:
         super().__init__()
         self.word_margin = word_margin
-        return
 
     def __repr__(self) -> str:
         return "<{} {} {!r}>".format(
@@ -514,7 +504,6 @@ class LTTextLine(LTTextContainer[TextLineElement]):
         for obj in self._objs:
             obj.analyze(laparams)
         LTContainer.add(self, LTAnno("\n"))
-        return
 
     def find_neighbors(
         self, plane: Plane[LTComponentT], ratio: float
@@ -529,7 +518,6 @@ class LTTextLineHorizontal(LTTextLine):
     def __init__(self, word_margin: float) -> None:
         LTTextLine.__init__(self, word_margin)
         self._x1: float = +INF
-        return
 
     # Incompatible override: we take an LTComponent (with bounding box), but
     # LTContainer only considers LTItem (no bounding box).
@@ -540,7 +528,6 @@ class LTTextLineHorizontal(LTTextLine):
                 LTContainer.add(self, LTAnno(" "))
         self._x1 = obj.x1
         super().add(obj)
-        return
 
     def find_neighbors(
         self, plane: Plane[LTComponentT], ratio: float
@@ -597,7 +584,6 @@ class LTTextLineVertical(LTTextLine):
     def __init__(self, word_margin: float) -> None:
         LTTextLine.__init__(self, word_margin)
         self._y0: float = -INF
-        return
 
     # Incompatible override: we take an LTComponent (with bounding box), but
     # LTContainer only considers LTItem (no bounding box).
@@ -608,7 +594,6 @@ class LTTextLineVertical(LTTextLine):
                 LTContainer.add(self, LTAnno(" "))
         self._y0 = obj.y0
         super().add(obj)
-        return
 
     def find_neighbors(
         self, plane: Plane[LTComponentT], ratio: float
@@ -672,7 +657,6 @@ class LTTextBox(LTTextContainer[LTTextLine]):
     def __init__(self) -> None:
         LTTextContainer.__init__(self)
         self.index: int = -1
-        return
 
     def __repr__(self) -> str:
         return "<{}({}) {} {!r}>".format(
@@ -690,7 +674,6 @@ class LTTextBoxHorizontal(LTTextBox):
     def analyze(self, laparams: LAParams) -> None:
         super().analyze(laparams)
         self._objs.sort(key=lambda obj: -obj.y1)
-        return
 
     def get_writing_mode(self) -> str:
         return "lr-tb"
@@ -700,7 +683,6 @@ class LTTextBoxVertical(LTTextBox):
     def analyze(self, laparams: LAParams) -> None:
         super().analyze(laparams)
         self._objs.sort(key=lambda obj: -obj.x1)
-        return
 
     def get_writing_mode(self) -> str:
         return "tb-rl"
@@ -713,7 +695,6 @@ class LTTextGroup(LTTextContainer[TextGroupElement]):
     def __init__(self, objs: Iterable[TextGroupElement]) -> None:
         super().__init__()
         self.extend(objs)
-        return
 
 
 class LTTextGroupLRTB(LTTextGroup):
@@ -726,7 +707,6 @@ class LTTextGroupLRTB(LTTextGroup):
             key=lambda obj: (1 - boxes_flow) * obj.x0
             - (1 + boxes_flow) * (obj.y0 + obj.y1)
         )
-        return
 
 
 class LTTextGroupTBRL(LTTextGroup):
@@ -739,14 +719,12 @@ class LTTextGroupTBRL(LTTextGroup):
             key=lambda obj: -(1 + boxes_flow) * (obj.x0 + obj.x1)
             - (1 - boxes_flow) * obj.y1
         )
-        return
 
 
 class LTLayoutContainer(LTContainer[LTComponent]):
     def __init__(self, bbox: Rect) -> None:
         LTContainer.__init__(self, bbox)
         self.groups: Optional[List[LTTextGroup]] = None
-        return
 
     # group_objects: group text object to textlines.
     def group_objects(
@@ -825,7 +803,6 @@ class LTLayoutContainer(LTContainer[LTComponent]):
             assert obj0 is not None
             line.add(obj0)
         yield line
-        return
 
     def group_textlines(
         self, laparams: LAParams, lines: Iterable[LTTextLine]
@@ -858,7 +835,6 @@ class LTLayoutContainer(LTContainer[LTComponent]):
             done.add(box)
             if not box.is_empty():
                 yield box
-        return
 
     def group_textboxes(
         self, laparams: LAParams, boxes: Sequence[LTTextBox]
@@ -987,7 +963,6 @@ class LTLayoutContainer(LTContainer[LTComponent]):
             + otherobjs
             + cast(List[LTComponent], empties)
         )
-        return
 
 
 class LTFigure(LTLayoutContainer):
@@ -1005,7 +980,6 @@ class LTFigure(LTLayoutContainer):
         bounds = ((x, y), (x + w, y), (x, y + h), (x + w, y + h))
         bbox = get_bound(apply_matrix_pt(matrix, (p, q)) for (p, q) in bounds)
         LTLayoutContainer.__init__(self, bbox)
-        return
 
     def __repr__(self) -> str:
         return "<{}({}) {} matrix={}>".format(
@@ -1019,7 +993,6 @@ class LTFigure(LTLayoutContainer):
         if not laparams.all_texts:
             return
         LTLayoutContainer.analyze(self, laparams)
-        return
 
 
 class LTPage(LTLayoutContainer):
@@ -1033,7 +1006,6 @@ class LTPage(LTLayoutContainer):
         LTLayoutContainer.__init__(self, bbox)
         self.pageid = pageid
         self.rotate = rotate
-        return
 
     def __repr__(self) -> str:
         return "<{}({!r}) {} rotate={!r}>".format(

--- a/pdfminer/pdfdevice.py
+++ b/pdfminer/pdfdevice.py
@@ -280,12 +280,10 @@ class TagExtractor(PDFDevice):
             page.rotate,
         )
         self._write(output)
-        return
 
     def end_page(self, page: PDFPage) -> None:
         self._write("</page>\n")
         self.pageno += 1
-        return
 
     def begin_tag(self, tag: PSLiteral, props: Optional["PDFStackT"] = None) -> None:
         s = ""
@@ -299,19 +297,16 @@ class TagExtractor(PDFDevice):
         out_s = f"<{utils.enc(cast(str, tag.name))}{s}>"
         self._write(out_s)
         self._stack.append(tag)
-        return
 
     def end_tag(self) -> None:
         assert self._stack, str(self.pageno)
         tag = self._stack.pop(-1)
         out_s = "</%s>" % utils.enc(cast(str, tag.name))
         self._write(out_s)
-        return
 
     def do_tag(self, tag: PSLiteral, props: Optional["PDFStackT"] = None) -> None:
         self.begin_tag(tag, props)
         self._stack.pop(-1)
-        return
 
     def _write(self, s: str) -> None:
         self.outfp.write(s.encode(self.codec))

--- a/pdfminer/pdfdocument.py
+++ b/pdfminer/pdfdocument.py
@@ -281,7 +281,6 @@ class PDFXRefStream(PDFBaseXRef):
             self.fl2,
             self.fl3,
         )
-        return
 
     def get_trailer(self) -> Dict[str, Any]:
         return self.trailer
@@ -296,7 +295,6 @@ class PDFXRefStream(PDFBaseXRef):
                 f1 = nunpack(ent[: self.fl1], 1)
                 if f1 == 1 or f1 == 2:
                     yield start + i
-        return
 
     def get_pos(self, objid: int) -> Tuple[Optional[int], int, int]:
         index = 0
@@ -340,7 +338,6 @@ class PDFStandardSecurityHandler:
         self.param = param
         self.password = password
         self.init()
-        return
 
     def init(self) -> None:
         self.init_params()
@@ -348,7 +345,6 @@ class PDFStandardSecurityHandler:
             error_msg = "Unsupported revision: param=%r" % self.param
             raise PDFEncryptionError(error_msg)
         self.init_key()
-        return
 
     def init_params(self) -> None:
         self.v = int_value(self.param.get("V", 0))
@@ -357,13 +353,11 @@ class PDFStandardSecurityHandler:
         self.o = str_value(self.param["O"])
         self.u = str_value(self.param["U"])
         self.length = int_value(self.param.get("Length", 40))
-        return
 
     def init_key(self) -> None:
         self.key = self.authenticate(self.password)
         if self.key is None:
             raise PDFPasswordIncorrect
-        return
 
     def is_printable(self) -> bool:
         return bool(self.p & 4)
@@ -491,7 +485,6 @@ class PDFStandardSecurityHandlerV4(PDFStandardSecurityHandler):
         if self.strf not in self.cfm:
             error_msg = "Undefined crypt filter: param=%r" % self.param
             raise PDFEncryptionError(error_msg)
-        return
 
     def get_cfm(self, name: str) -> Optional[Callable[[int, int, bytes], bytes]]:
         if name == "V2":
@@ -555,7 +548,6 @@ class PDFStandardSecurityHandlerV5(PDFStandardSecurityHandlerV4):
         self.u_hash = self.u[:32]
         self.u_validation_salt = self.u[32:40]
         self.u_key_salt = self.u[40:]
-        return
 
     def get_cfm(self, name: str) -> Optional[Callable[[int, int, bytes], bytes]]:
         if name == "AESV3":
@@ -737,7 +729,6 @@ class PDFDocument:
         if self.catalog.get("Type") is not LITERAL_CATALOG:
             if settings.STRICT:
                 raise PDFSyntaxError("Catalog not found!")
-        return
 
     KEYWORD_OBJ = KWD(b"obj")
 
@@ -759,7 +750,6 @@ class PDFDocument:
         self.is_extractable = handler.is_extractable()
         assert self._parser is not None
         self._parser.fallback = False  # need to read streams with exact length
-        return
 
     def _getobj_objstm(self, stream: PDFStream, index: int, objid: int) -> object:
         if stream.objid in self._parsed_objs:
@@ -882,7 +872,6 @@ class PDFDocument:
                 yield from search(entry["First"], level + 1)
             if "Next" in entry:
                 yield from search(entry["Next"], level)
-            return
 
         return search(self.catalog["Outlines"], 0)
 
@@ -1006,7 +995,6 @@ class PDFDocument:
             # find previous xref
             pos = int_value(trailer["Prev"])
             self.read_xref_from(parser, pos, xrefs)
-        return
 
 
 class PageLabels(NumberTree):

--- a/pdfminer/pdffont.py
+++ b/pdfminer/pdffont.py
@@ -117,7 +117,6 @@ class Type1FontHeaderParser(PSStackParser[int]):
     def __init__(self, data: BinaryIO) -> None:
         PSStackParser.__init__(self, data)
         self._cid2unicode: Dict[int, str] = {}
-        return
 
     def get_encoding(self) -> Dict[int, str]:
         """Parse the font encoding.
@@ -149,7 +148,6 @@ class Type1FontHeaderParser(PSStackParser[int]):
             ((_, key), (_, value)) = self.pop(2)
             if isinstance(key, int) and isinstance(value, PSLiteral):
                 self.add_results((key, literal_name(value)))
-        return
 
 
 NIBBLES = ("0", "1", "2", "3", "4", "5", "6", "7", "8", "9", ".", "e", "e-", None, "-")
@@ -613,7 +611,6 @@ class CFFFont:
                 self.offsets.append(nunpack(self.fp.read(offsize)))
             self.base = self.fp.tell() - 1
             self.fp.seek(self.base + self.offsets[-1])
-            return
 
         def __repr__(self) -> str:
             return "<INDEX: size=%d>" % len(self)
@@ -705,7 +702,6 @@ class CFFFont:
             assert False, str(("Unhandled", format))
         else:
             raise PDFValueError("unsupported charset format: %r" % format)
-        return
 
     def getstr(self, sid: int) -> Union[str, bytes]:
         # This returns str for one of the STANDARD_STRINGS but bytes otherwise,
@@ -738,7 +734,6 @@ class TrueTypeFont:
             # corrupted PDFs we would like to get as much information as
             # possible, so continue.
             pass
-        return
 
     def create_unicode_map(self) -> FileUnicodeMap:
         if b"cmap" not in self.tables:
@@ -885,7 +880,6 @@ class PDFFont:
         # descent to negative.
         if self.descent > 0:
             self.descent = -self.descent
-        return
 
     def __repr__(self) -> str:
         return "<PDFFont>"
@@ -968,7 +962,6 @@ class PDFSimpleFont(PDFFont):
             self.unicode_map = FileUnicodeMap()
             CMapParser(self.unicode_map, BytesIO(strm.get_data())).run()
         PDFFont.__init__(self, descriptor, widths)
-        return
 
     def to_unichr(self, cid: int) -> str:
         if self.unicode_map:
@@ -1009,7 +1002,6 @@ class PDFType1Font(PDFSimpleFont):
             data = self.fontfile.get_data()[:length1]
             parser = Type1FontHeaderParser(BytesIO(data))
             self.cid2unicode = parser.get_encoding()
-        return
 
     def __repr__(self) -> str:
         return "<PDFType1Font: basefont=%r>" % self.basefont
@@ -1034,7 +1026,6 @@ class PDFType3Font(PDFSimpleFont):
         self.matrix = cast(Matrix, tuple(list_value(spec.get("FontMatrix"))))
         (_, self.descent, _, self.ascent) = self.bbox
         (self.hscale, self.vscale) = apply_matrix_norm(self.matrix, (1, 1))
-        return
 
     def __repr__(self) -> str:
         return "<PDFType3Font>"
@@ -1120,7 +1111,6 @@ class PDFCIDFont(PDFFont):
             widths = get_widths(list_value(spec.get("W", [])))
             default_width = spec.get("DW", 1000)
         PDFFont.__init__(self, descriptor, widths, default_width=default_width)
-        return
 
     def get_cmap_from_spec(self, spec: Mapping[str, Any], strict: bool) -> CMapBase:
         """Get cmap from font specification

--- a/pdfminer/pdfinterp.py
+++ b/pdfminer/pdfinterp.py
@@ -347,7 +347,6 @@ class PDFPageInterpreter:
     def __init__(self, rsrcmgr: PDFResourceManager, device: PDFDevice) -> None:
         self.rsrcmgr = rsrcmgr
         self.device = device
-        return
 
     def dup(self) -> "PDFPageInterpreter":
         return self.__class__(self.rsrcmgr, self.device)
@@ -392,7 +391,6 @@ class PDFPageInterpreter:
             elif k == "XObject":
                 for (xobjid, xobjstrm) in dict_value(v).items():
                     self.xobjmap[xobjid] = xobjstrm
-        return
 
     def init_state(self, ctm: Matrix) -> None:
         """Initialize the text and graphic states for rendering a page."""
@@ -410,11 +408,9 @@ class PDFPageInterpreter:
         self.ncs: Optional[PDFColorSpace] = None
         if self.csmap:
             self.scs = self.ncs = next(iter(self.csmap.values()))
-        return
 
     def push(self, obj: PDFStackT) -> None:
         self.argstack.append(obj)
-        return
 
     def pop(self, n: int) -> List[PDFStackT]:
         if n == 0:
@@ -431,18 +427,15 @@ class PDFPageInterpreter:
     ) -> None:
         (self.ctm, self.textstate, self.graphicstate) = state
         self.device.set_ctm(self.ctm)
-        return
 
     def do_q(self) -> None:
         """Save graphics state"""
         self.gstack.append(self.get_current_state())
-        return
 
     def do_Q(self) -> None:
         """Restore graphics state"""
         if self.gstack:
             self.set_current_state(self.gstack.pop())
-        return
 
     def do_cm(
         self,
@@ -456,57 +449,46 @@ class PDFPageInterpreter:
         """Concatenate matrix to current transformation matrix"""
         self.ctm = mult_matrix(cast(Matrix, (a1, b1, c1, d1, e1, f1)), self.ctm)
         self.device.set_ctm(self.ctm)
-        return
 
     def do_w(self, linewidth: PDFStackT) -> None:
         """Set line width"""
         self.graphicstate.linewidth = cast(float, linewidth)
-        return
 
     def do_J(self, linecap: PDFStackT) -> None:
         """Set line cap style"""
         self.graphicstate.linecap = linecap
-        return
 
     def do_j(self, linejoin: PDFStackT) -> None:
         """Set line join style"""
         self.graphicstate.linejoin = linejoin
-        return
 
     def do_M(self, miterlimit: PDFStackT) -> None:
         """Set miter limit"""
         self.graphicstate.miterlimit = miterlimit
-        return
 
     def do_d(self, dash: PDFStackT, phase: PDFStackT) -> None:
         """Set line dash pattern"""
         self.graphicstate.dash = (dash, phase)
-        return
 
     def do_ri(self, intent: PDFStackT) -> None:
         """Set color rendering intent"""
         self.graphicstate.intent = intent
-        return
 
     def do_i(self, flatness: PDFStackT) -> None:
         """Set flatness tolerance"""
         self.graphicstate.flatness = flatness
-        return
 
     def do_gs(self, name: PDFStackT) -> None:
         """Set parameters from graphics state parameter dictionary"""
         # todo
-        return
 
     def do_m(self, x: PDFStackT, y: PDFStackT) -> None:
         """Begin new subpath"""
         self.curpath.append(("m", cast(float, x), cast(float, y)))
-        return
 
     def do_l(self, x: PDFStackT, y: PDFStackT) -> None:
         """Append straight line segment to path"""
         self.curpath.append(("l", cast(float, x), cast(float, y)))
-        return
 
     def do_c(
         self,
@@ -529,26 +511,22 @@ class PDFPageInterpreter:
                 cast(float, y3),
             )
         )
-        return
 
     def do_v(self, x2: PDFStackT, y2: PDFStackT, x3: PDFStackT, y3: PDFStackT) -> None:
         """Append curved segment to path (initial point replicated)"""
         self.curpath.append(
             ("v", cast(float, x2), cast(float, y2), cast(float, x3), cast(float, y3))
         )
-        return
 
     def do_y(self, x1: PDFStackT, y1: PDFStackT, x3: PDFStackT, y3: PDFStackT) -> None:
         """Append curved segment to path (final point replicated)"""
         self.curpath.append(
             ("y", cast(float, x1), cast(float, y1), cast(float, x3), cast(float, y3))
         )
-        return
 
     def do_h(self) -> None:
         """Close subpath"""
         self.curpath.append(("h",))
-        return
 
     def do_re(self, x: PDFStackT, y: PDFStackT, w: PDFStackT, h: PDFStackT) -> None:
         """Append rectangle to path"""
@@ -561,72 +539,59 @@ class PDFPageInterpreter:
         self.curpath.append(("l", x + w, y + h))
         self.curpath.append(("l", x, y + h))
         self.curpath.append(("h",))
-        return
 
     def do_S(self) -> None:
         """Stroke path"""
         self.device.paint_path(self.graphicstate, True, False, False, self.curpath)
         self.curpath = []
-        return
 
     def do_s(self) -> None:
         """Close and stroke path"""
         self.do_h()
         self.do_S()
-        return
 
     def do_f(self) -> None:
         """Fill path using nonzero winding number rule"""
         self.device.paint_path(self.graphicstate, False, True, False, self.curpath)
         self.curpath = []
-        return
 
     def do_F(self) -> None:
         """Fill path using nonzero winding number rule (obsolete)"""
-        return self.do_f()
 
     def do_f_a(self) -> None:
         """Fill path using even-odd rule"""
         self.device.paint_path(self.graphicstate, False, True, True, self.curpath)
         self.curpath = []
-        return
 
     def do_B(self) -> None:
         """Fill and stroke path using nonzero winding number rule"""
         self.device.paint_path(self.graphicstate, True, True, False, self.curpath)
         self.curpath = []
-        return
 
     def do_B_a(self) -> None:
         """Fill and stroke path using even-odd rule"""
         self.device.paint_path(self.graphicstate, True, True, True, self.curpath)
         self.curpath = []
-        return
 
     def do_b(self) -> None:
         """Close, fill, and stroke path using nonzero winding number rule"""
         self.do_h()
         self.do_B()
-        return
 
     def do_b_a(self) -> None:
         """Close, fill, and stroke path using even-odd rule"""
         self.do_h()
         self.do_B_a()
-        return
 
     def do_n(self) -> None:
         """End path without filling or stroking"""
         self.curpath = []
-        return
 
     def do_W(self) -> None:
         """Set clipping path using nonzero winding number rule"""
-        return
 
     def do_W_a(self) -> None:
         """Set clipping path using even-odd rule"""
-        return
 
     def do_CS(self, name: PDFStackT) -> None:
         """Set color space for stroking operations
@@ -638,7 +603,6 @@ class PDFPageInterpreter:
         except KeyError:
             if settings.STRICT:
                 raise PDFInterpreterError("Undefined ColorSpace: %r" % name)
-        return
 
     def do_cs(self, name: PDFStackT) -> None:
         """Set color space for nonstroking operations"""
@@ -647,31 +611,26 @@ class PDFPageInterpreter:
         except KeyError:
             if settings.STRICT:
                 raise PDFInterpreterError("Undefined ColorSpace: %r" % name)
-        return
 
     def do_G(self, gray: PDFStackT) -> None:
         """Set gray level for stroking operations"""
         self.graphicstate.scolor = cast(float, gray)
         self.scs = self.csmap["DeviceGray"]
-        return
 
     def do_g(self, gray: PDFStackT) -> None:
         """Set gray level for nonstroking operations"""
         self.graphicstate.ncolor = cast(float, gray)
         self.ncs = self.csmap["DeviceGray"]
-        return
 
     def do_RG(self, r: PDFStackT, g: PDFStackT, b: PDFStackT) -> None:
         """Set RGB color for stroking operations"""
         self.graphicstate.scolor = (cast(float, r), cast(float, g), cast(float, b))
         self.scs = self.csmap["DeviceRGB"]
-        return
 
     def do_rg(self, r: PDFStackT, g: PDFStackT, b: PDFStackT) -> None:
         """Set RGB color for nonstroking operations"""
         self.graphicstate.ncolor = (cast(float, r), cast(float, g), cast(float, b))
         self.ncs = self.csmap["DeviceRGB"]
-        return
 
     def do_K(self, c: PDFStackT, m: PDFStackT, y: PDFStackT, k: PDFStackT) -> None:
         """Set CMYK color for stroking operations"""
@@ -682,7 +641,6 @@ class PDFPageInterpreter:
             cast(float, k),
         )
         self.scs = self.csmap["DeviceCMYK"]
-        return
 
     def do_k(self, c: PDFStackT, m: PDFStackT, y: PDFStackT, k: PDFStackT) -> None:
         """Set CMYK color for nonstroking operations"""
@@ -693,7 +651,6 @@ class PDFPageInterpreter:
             cast(float, k),
         )
         self.ncs = self.csmap["DeviceCMYK"]
-        return
 
     def do_SCN(self) -> None:
         """Set color for stroking operations."""
@@ -704,7 +661,6 @@ class PDFPageInterpreter:
                 raise PDFInterpreterError("No colorspace specified!")
             n = 1
         self.graphicstate.scolor = cast(Color, self.pop(n))
-        return
 
     def do_scn(self) -> None:
         """Set color for nonstroking operations"""
@@ -715,21 +671,17 @@ class PDFPageInterpreter:
                 raise PDFInterpreterError("No colorspace specified!")
             n = 1
         self.graphicstate.ncolor = cast(Color, self.pop(n))
-        return
 
     def do_SC(self) -> None:
         """Set color for stroking operations"""
         self.do_SCN()
-        return
 
     def do_sc(self) -> None:
         """Set color for nonstroking operations"""
         self.do_scn()
-        return
 
     def do_sh(self, name: object) -> None:
         """Paint area defined by shading pattern"""
-        return
 
     def do_BT(self) -> None:
         """Begin text object
@@ -739,44 +691,35 @@ class PDFPageInterpreter:
         appear before an ET.
         """
         self.textstate.reset()
-        return
 
     def do_ET(self) -> None:
         """End a text object"""
-        return
 
     def do_BX(self) -> None:
         """Begin compatibility section"""
-        return
 
     def do_EX(self) -> None:
         """End compatibility section"""
-        return
 
     def do_MP(self, tag: PDFStackT) -> None:
         """Define marked-content point"""
         self.device.do_tag(cast(PSLiteral, tag))
-        return
 
     def do_DP(self, tag: PDFStackT, props: PDFStackT) -> None:
         """Define marked-content point with property list"""
         self.device.do_tag(cast(PSLiteral, tag), props)
-        return
 
     def do_BMC(self, tag: PDFStackT) -> None:
         """Begin marked-content sequence"""
         self.device.begin_tag(cast(PSLiteral, tag))
-        return
 
     def do_BDC(self, tag: PDFStackT, props: PDFStackT) -> None:
         """Begin marked-content sequence with property list"""
         self.device.begin_tag(cast(PSLiteral, tag), props)
-        return
 
     def do_EMC(self) -> None:
         """End marked-content sequence"""
         self.device.end_tag()
-        return
 
     def do_Tc(self, space: PDFStackT) -> None:
         """Set character spacing.
@@ -786,7 +729,6 @@ class PDFPageInterpreter:
         :param space: a number expressed in unscaled text space units.
         """
         self.textstate.charspace = cast(float, space)
-        return
 
     def do_Tw(self, space: PDFStackT) -> None:
         """Set the word spacing.
@@ -796,7 +738,6 @@ class PDFPageInterpreter:
         :param space: a number expressed in unscaled text space units
         """
         self.textstate.wordspace = cast(float, space)
-        return
 
     def do_Tz(self, scale: PDFStackT) -> None:
         """Set the horizontal scaling.
@@ -804,7 +745,6 @@ class PDFPageInterpreter:
         :param scale: is a number specifying the percentage of the normal width
         """
         self.textstate.scaling = cast(float, scale)
-        return
 
     def do_TL(self, leading: PDFStackT) -> None:
         """Set the text leading.
@@ -814,7 +754,6 @@ class PDFPageInterpreter:
         :param leading: a number expressed in unscaled text space units
         """
         self.textstate.leading = -cast(float, leading)
-        return
 
     def do_Tf(self, fontid: PDFStackT, fontsize: PDFStackT) -> None:
         """Set the text font
@@ -830,12 +769,10 @@ class PDFPageInterpreter:
                 raise PDFInterpreterError("Undefined Font id: %r" % fontid)
             self.textstate.font = self.rsrcmgr.get_font(None, {})
         self.textstate.fontsize = cast(float, fontsize)
-        return
 
     def do_Tr(self, render: PDFStackT) -> None:
         """Set the text rendering mode"""
         self.textstate.render = cast(int, render)
-        return
 
     def do_Ts(self, rise: PDFStackT) -> None:
         """Set the text rise
@@ -843,7 +780,6 @@ class PDFPageInterpreter:
         :param rise: a number expressed in unscaled text space units
         """
         self.textstate.rise = cast(float, rise)
-        return
 
     def do_Td(self, tx: PDFStackT, ty: PDFStackT) -> None:
         """Move text position"""
@@ -852,7 +788,6 @@ class PDFPageInterpreter:
         (a, b, c, d, e, f) = self.textstate.matrix
         self.textstate.matrix = (a, b, c, d, tx * a + ty * c + e, tx * b + ty * d + f)
         self.textstate.linematrix = (0, 0)
-        return
 
     def do_TD(self, tx: PDFStackT, ty: PDFStackT) -> None:
         """Move text position and set leading"""
@@ -862,7 +797,6 @@ class PDFPageInterpreter:
         self.textstate.matrix = (a, b, c, d, tx * a + ty * c + e, tx * b + ty * d + f)
         self.textstate.leading = ty
         self.textstate.linematrix = (0, 0)
-        return
 
     def do_Tm(
         self,
@@ -876,7 +810,6 @@ class PDFPageInterpreter:
         """Set text matrix and text line matrix"""
         self.textstate.matrix = cast(Matrix, (a, b, c, d, e, f))
         self.textstate.linematrix = (0, 0)
-        return
 
     def do_T_a(self) -> None:
         """Move to start of next text line"""
@@ -890,7 +823,6 @@ class PDFPageInterpreter:
             self.textstate.leading * d + f,
         )
         self.textstate.linematrix = (0, 0)
-        return
 
     def do_TJ(self, seq: PDFStackT) -> None:
         """Show text, allowing individual glyph positioning"""
@@ -902,12 +834,10 @@ class PDFPageInterpreter:
         self.device.render_string(
             self.textstate, cast(PDFTextSeq, seq), self.ncs, self.graphicstate.copy()
         )
-        return
 
     def do_Tj(self, s: PDFStackT) -> None:
         """Show text"""
         self.do_TJ([s])
-        return
 
     def do__q(self, s: PDFStackT) -> None:
         """Move to next line and show text
@@ -916,7 +846,6 @@ class PDFPageInterpreter:
         """
         self.do_T_a()
         self.do_TJ([s])
-        return
 
     def do__w(self, aw: PDFStackT, ac: PDFStackT, s: PDFStackT) -> None:
         """Set word and character spacing, move to next line, and show text
@@ -926,15 +855,12 @@ class PDFPageInterpreter:
         self.do_Tw(aw)
         self.do_Tc(ac)
         self.do_TJ([s])
-        return
 
     def do_BI(self) -> None:
         """Begin inline image object"""
-        return
 
     def do_ID(self) -> None:
         """Begin inline image data"""
-        return
 
     def do_EI(self, obj: PDFStackT) -> None:
         """End inline image object"""
@@ -943,7 +869,6 @@ class PDFPageInterpreter:
             self.device.begin_figure(iobjid, (0, 0, 1, 1), MATRIX_IDENTITY)
             self.device.render_image(iobjid, obj)
             self.device.end_figure(iobjid)
-        return
 
     def do_Do(self, xobjid_arg: PDFStackT) -> None:
         """Invoke named XObject"""
@@ -980,7 +905,6 @@ class PDFPageInterpreter:
         else:
             # unsupported xobject type.
             pass
-        return
 
     def process_page(self, page: PDFPage) -> None:
         log.debug("Processing page: %r", page)
@@ -996,7 +920,6 @@ class PDFPageInterpreter:
         self.device.begin_page(page, ctm)
         self.render_contents(page.resources, page.contents, ctm=ctm)
         self.device.end_page(page)
-        return
 
     def render_contents(
         self,
@@ -1014,7 +937,6 @@ class PDFPageInterpreter:
         self.init_resources(resources)
         self.init_state(ctm)
         self.execute(list_value(streams))
-        return
 
     def execute(self, streams: Sequence[object]) -> None:
         try:
@@ -1049,4 +971,3 @@ class PDFPageInterpreter:
                         raise PDFInterpreterError(error_msg)
             else:
                 self.push(obj)
-        return

--- a/pdfminer/pdfpage.py
+++ b/pdfminer/pdfpage.py
@@ -139,7 +139,6 @@ class PDFPage:
                             yield cls(document, objid, obj, next(page_labels))
                     except PDFObjectNotFound:
                         pass
-        return
 
     @classmethod
     def get_pages(
@@ -177,4 +176,3 @@ class PDFPage:
             yield page
             if maxpages and maxpages <= pageno + 1:
                 break
-        return

--- a/pdfminer/pdftypes.py
+++ b/pdfminer/pdftypes.py
@@ -382,7 +382,6 @@ class PDFStream(PDFObject):
                     raise PDFNotImplementedError(error_msg)
         self.data = data
         self.rawdata = None
-        return
 
     def get_data(self) -> bytes:
         if self.data is None:

--- a/pdfminer/psparser.py
+++ b/pdfminer/psparser.py
@@ -183,11 +183,10 @@ class PSBaseParser:
         return "<%s: %r, bufpos=%d>" % (self.__class__.__name__, self.fp, self.bufpos)
 
     def flush(self) -> None:
-        return
+        pass
 
     def close(self) -> None:
         self.flush()
-        return
 
     def tell(self) -> int:
         return self.bufpos + self.charpos
@@ -199,7 +198,6 @@ class PSBaseParser:
         self.fp.seek(pos)
         log.debug("poll(%d): %r", pos, self.fp.read(n))
         self.fp.seek(pos0)
-        return
 
     def seek(self, pos: int) -> None:
         """Seeks the parser to the given position."""
@@ -214,7 +212,6 @@ class PSBaseParser:
         self._curtoken = b""
         self._curtokenpos = 0
         self._tokens: List[Tuple[int, PSBaseParserToken]] = []
-        return
 
     def fillbuf(self) -> None:
         if self.charpos < len(self.buf):
@@ -225,7 +222,6 @@ class PSBaseParser:
         if not self.buf:
             raise PSEOF("Unexpected EOF")
         self.charpos = 0
-        return
 
     def nextline(self) -> Tuple[int, bytes]:
         """Fetches a next line that ends either with \\r or \\n."""
@@ -279,7 +275,6 @@ class PSBaseParser:
                 yield s[n:] + buf
                 s = s[:n]
                 buf = b""
-        return
 
     def _parse_main(self, s: bytes, i: int) -> int:
         m = NONSPC.search(s, i)
@@ -329,7 +324,6 @@ class PSBaseParser:
 
     def _add_token(self, obj: PSBaseParserToken) -> None:
         self._tokens.append((self._curtokenpos, obj))
-        return
 
     def _parse_comment(self, s: bytes, i: int) -> int:
         m = EOL.search(s, i)
@@ -536,23 +530,19 @@ class PSStackParser(PSBaseParser, Generic[ExtraT]):
     def __init__(self, fp: BinaryIO) -> None:
         PSBaseParser.__init__(self, fp)
         self.reset()
-        return
 
     def reset(self) -> None:
         self.context: List[Tuple[int, Optional[str], List[PSStackEntry[ExtraT]]]] = []
         self.curtype: Optional[str] = None
         self.curstack: List[PSStackEntry[ExtraT]] = []
         self.results: List[PSStackEntry[ExtraT]] = []
-        return
 
     def seek(self, pos: int) -> None:
         PSBaseParser.seek(self, pos)
         self.reset()
-        return
 
     def push(self, *objs: PSStackEntry[ExtraT]) -> None:
         self.curstack.extend(objs)
-        return
 
     def pop(self, n: int) -> List[PSStackEntry[ExtraT]]:
         objs = self.curstack[-n:]
@@ -570,13 +560,11 @@ class PSStackParser(PSBaseParser, Generic[ExtraT]):
         except Exception:
             log.debug("add_results: (unprintable object)")
         self.results.extend(objs)
-        return
 
     def start_type(self, pos: int, type: str) -> None:
         self.context.append((pos, self.curtype, self.curstack))
         (self.curtype, self.curstack) = (type, [])
         log.debug("start_type: pos=%r, type=%r", pos, type)
-        return
 
     def end_type(self, type: str) -> Tuple[int, List[PSStackType[ExtraT]]]:
         if self.curtype != type:
@@ -587,7 +575,7 @@ class PSStackParser(PSBaseParser, Generic[ExtraT]):
         return (pos, objs)
 
     def do_keyword(self, pos: int, token: PSKeyword) -> None:
-        return
+        pass
 
     def nextobject(self) -> PSStackEntry[ExtraT]:
         """Yields a list of objects.

--- a/pdfminer/utils.py
+++ b/pdfminer/utils.py
@@ -299,7 +299,6 @@ def uniq(objs: Iterable[_T]) -> Iterator[_T]:
             continue
         done.add(obj)
         yield obj
-    return
 
 
 def fsplit(pred: Callable[[_T], bool], objs: Iterable[_T]) -> Tuple[List[_T], List[_T]]:
@@ -351,7 +350,6 @@ def choplist(n: int, seq: Iterable[_T]) -> Iterator[Tuple[_T, ...]]:
         if len(r) == n:
             yield tuple(r)
             r = []
-    return
 
 
 def nunpack(s: bytes, default: int = 0) -> int:

--- a/tests/test_pdfminer_ccitt.py
+++ b/tests/test_pdfminer_ccitt.py
@@ -12,27 +12,23 @@ class TestCCITTG4Parser:
         parser = self.get_parser("00000")
         parser._do_vertical(0)
         assert parser._curpos == 0
-        return
 
     def test_b2(self):
         parser = self.get_parser("10000")
         parser._do_vertical(-1)
         assert parser._curpos == 0
-        return
 
     def test_b3(self):
         parser = self.get_parser("000111")
         parser._do_pass()
         assert parser._curpos == 3
         assert parser._get_bits() == "111"
-        return
 
     def test_b4(self):
         parser = self.get_parser("00000")
         parser._do_vertical(+2)
         assert parser._curpos == 2
         assert parser._get_bits() == "11"
-        return
 
     def test_b5(self):
         parser = self.get_parser("11111111100")
@@ -41,7 +37,6 @@ class TestCCITTG4Parser:
         parser._do_vertical(1)
         assert parser._curpos == 10
         assert parser._get_bits() == "0001111111"
-        return
 
     def test_e1(self):
         parser = self.get_parser("10000")
@@ -50,7 +45,6 @@ class TestCCITTG4Parser:
         parser._do_vertical(0)
         assert parser._curpos == 5
         assert parser._get_bits() == "10000"
-        return
 
     def test_e2(self):
         parser = self.get_parser("10011")
@@ -59,7 +53,6 @@ class TestCCITTG4Parser:
         parser._do_vertical(2)
         assert parser._curpos == 5
         assert parser._get_bits() == "10000"
-        return
 
     def test_e3(self):
         parser = self.get_parser("011111")
@@ -73,7 +66,6 @@ class TestCCITTG4Parser:
         parser._do_vertical(0)
         assert parser._curpos == 6
         assert parser._get_bits() == "011100"
-        return
 
     def test_e4(self):
         parser = self.get_parser("10000")
@@ -84,7 +76,6 @@ class TestCCITTG4Parser:
         parser._do_vertical(0)
         assert parser._curpos == 5
         assert parser._get_bits() == "10011"
-        return
 
     def test_e5(self):
         parser = self.get_parser("011000")
@@ -94,7 +85,6 @@ class TestCCITTG4Parser:
         parser._do_vertical(3)
         assert parser._curpos == 6
         assert parser._get_bits() == "011111"
-        return
 
     def test_e6(self):
         parser = self.get_parser("11001")
@@ -103,7 +93,6 @@ class TestCCITTG4Parser:
         parser._do_vertical(0)
         assert parser._curpos == 5
         assert parser._get_bits() == "11111"
-        return
 
     def test_e7(self):
         parser = self.get_parser("0000000000")
@@ -112,7 +101,6 @@ class TestCCITTG4Parser:
         parser._do_horizontal(2, 6)
         assert parser._curpos == 10
         assert parser._get_bits() == "1111000000"
-        return
 
     def test_e8(self):
         parser = self.get_parser("001100000")
@@ -123,7 +111,6 @@ class TestCCITTG4Parser:
         parser._do_horizontal(7, 0)
         assert parser._curpos == 9
         assert parser._get_bits() == "101111111"
-        return
 
     def test_m1(self):
         parser = self.get_parser("10101")
@@ -132,7 +119,6 @@ class TestCCITTG4Parser:
         parser._do_pass()
         assert parser._curpos == 4
         assert parser._get_bits() == "1111"
-        return
 
     def test_m2(self):
         parser = self.get_parser("101011")
@@ -141,7 +127,6 @@ class TestCCITTG4Parser:
         parser._do_vertical(1)
         parser._do_horizontal(1, 1)
         assert parser._get_bits() == "011101"
-        return
 
     def test_m3(self):
         parser = self.get_parser("10111011")
@@ -150,7 +135,6 @@ class TestCCITTG4Parser:
         parser._do_vertical(1)
         parser._do_vertical(1)
         assert parser._get_bits() == "00000001"
-        return
 
 
 class TestCCITTFaxDecoder:
@@ -158,4 +142,3 @@ class TestCCITTFaxDecoder:
         decoder = CCITTFaxDecoder(5)
         decoder.output_line(0, b"0")
         assert decoder.close() == b"\x80"
-        return

--- a/tests/test_pdfminer_psparser.py
+++ b/tests/test_pdfminer_psparser.py
@@ -143,13 +143,11 @@ func/a/b{(c)do*}def
         tokens = self.get_tokens(self.TESTDATA)
         logger.info(tokens)
         assert tokens == self.TOKENS
-        return
 
     def test_2(self):
         objs = self.get_objects(self.TESTDATA)
         logger.info(objs)
         assert objs == self.OBJS
-        return
 
     def test_3(self):
         """Regression test for streams that end with a keyword.

--- a/tools/conv_cmap.py
+++ b/tools/conv_cmap.py
@@ -12,7 +12,6 @@ class CMapConverter:
         self.is_vertical = {}
         self.cid2unichr_h = {}  # {cid: unichr}
         self.cid2unichr_v = {}  # {cid: unichr}
-        return
 
     def get_encs(self):
         return self.code2cid.keys()
@@ -63,7 +62,6 @@ class CMapConverter:
                 b = code[-1]
                 if force or ((b not in dmap) or dmap[b] == cid):
                     dmap[b] = cid
-                return
 
             def add(unimap, enc, code):
                 try:
@@ -77,7 +75,6 @@ class CMapConverter:
                     pass
                 except UnicodeError:
                     pass
-                return
 
             def pick(unimap):
                 chars = list(unimap.items())
@@ -130,15 +127,12 @@ class CMapConverter:
             if unimap_v or unimap_h:
                 self.cid2unichr_v[cid] = pick(unimap_v or unimap_h)
 
-        return
-
     def dump_cmap(self, fp, enc):
         data = dict(
             IS_VERTICAL=self.is_vertical.get(enc, False),
             CODE2CID=self.code2cid.get(enc),
         )
         fp.write(pickle.dumps(data, 2))
-        return
 
     def dump_unicodemap(self, fp):
         data = dict(
@@ -146,7 +140,6 @@ class CMapConverter:
             CID2UNICHR_V=self.cid2unichr_v,
         )
         fp.write(pickle.dumps(data, 2))
-        return
 
 
 def main(argv):
@@ -197,7 +190,6 @@ def main(argv):
     fp = gzip.open(path, "wb")
     converter.dump_unicodemap(fp)
     fp.close()
-    return
 
 
 if __name__ == "__main__":

--- a/tools/dumppdf.py
+++ b/tools/dumppdf.py
@@ -121,7 +121,6 @@ def dumptrailers(
             "contains all objects."
         )
         logger.warning(msg)
-    return
 
 
 def dumpallobjs(
@@ -148,7 +147,6 @@ def dumpallobjs(
                 print("not found: %r" % e)
     dumptrailers(out, doc, show_fallback_xref)
     out.write("</pdf>")
-    return
 
 
 def dumpoutline(
@@ -209,7 +207,6 @@ def dumpoutline(
         pass
     parser.close()
     fp.close()
-    return
 
 
 LITERAL_FILESPEC = LIT("Filespec")
@@ -240,7 +237,6 @@ def extractembedded(fname: str, password: str, extractdir: str) -> None:
         out = open(path, "wb")
         out.write(fileobj.get_data())
         out.close()
-        return
 
     with open(fname, "rb") as fp:
         parser = PDFParser(fp)
@@ -256,7 +252,6 @@ def extractembedded(fname: str, password: str, extractdir: str) -> None:
                 ):
                     extracted_objids.add(objid)
                     extract1(objid, obj)
-    return
 
 
 def dumppdf(
@@ -293,7 +288,6 @@ def dumppdf(
     fp.close()
     if codec not in ("raw", "binary"):
         outfp.write("\n")
-    return
 
 
 def create_parser() -> ArgumentParser:


### PR DESCRIPTION
**Pull request**

Fixes #989

Remove unnecessary return statements at the end of functions. 

**How Has This Been Tested?**

Nox.

**Checklist**

- [x] I have read [CONTRIBUTING.md](https://github.com/pdfminer/pdfminer.six/blob/master/CONTRIBUTING.md). 
- [x] I have added a concise human-readable description of the change to [CHANGELOG.md](https://github.com/pdfminer/pdfminer.six/blob/master/CHANGELOG.md).
- [x] I have tested that this fix is effective or that this feature works.
- [x] I have added docstrings to newly created methods and classes.
- [x] I have updated the [README.md](https://github.com/pdfminer/pdfminer.six/blob/master/README.md) and the [readthedocs](https://github.com/pdfminer/pdfminer.six/tree/master/docs/source) documentation. Or verified that this is not necessary.
