### PR TITLE
Fix description of `line_overlap`

### DIFF
--- a/docs/source/topic/converting_pdf_to_text.rst
+++ b/docs/source/topic/converting_pdf_to_text.rst
@@ -56,7 +56,7 @@ one line. How close they should be is determined by the `char_margin`
 (M in the figure) and the `line_overlap` (not in figure) parameter. The horizontal
 *distance* between the bounding boxes of two characters should be smaller than
 the `char_margin` and the vertical *overlap* between the bounding boxes should
-be smaller than the `line_overlap`.
+be larger than the `line_overlap`.
 
 .. raw:: html
     :file: ../_static/layout_analysis.html


### PR DESCRIPTION
**Pull request**

Fix the description of the `line_overlap` in `LAParams`. A smaller `line_overlap` means the aggregator will merge words with a smaller overlap of bboxs. The current writing would be correct if it referred to `line_offset`. 

**How Has This Been Tested?**

Decrease the value of `line_overlap` will produce less lines.

**Checklist**

- [x] I have read [CONTRIBUTING.md](https://github.com/pdfminer/pdfminer.six/blob/master/CONTRIBUTING.md). 
- [na?] I have added a concise human-readable description of the change to [CHANGELOG.md](https://github.com/pdfminer/pdfminer.six/blob/master/CHANGELOG.md).
- [x] I have tested that this fix is effective or that this feature works.
- [x] I have added docstrings to newly created methods and classes.
- [x] I have updated the [README.md](https://github.com/pdfminer/pdfminer.six/blob/master/README.md) and the [readthedocs](https://github.com/pdfminer/pdfminer.six/tree/master/docs/source) documentation. Or verified that this is not necessary.
