### PR TITLE
Fix: remove invalid licence classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ classifiers = [
     "Environment :: Console",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
-    "License-Expression :: MIT",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
Fix: remove invalid licence classifier, since it is already set by licence = "MIT"

See: https://packaging.python.org/en/latest/guides/licensing-examples-and-user-scenarios/#basic-example

**Pull request**

Please *remove* this paragraph and replace it with a description of your PR. Also include the issue that it fixes. 

**How Has This Been Tested?**

Please *remove* this paragraph with a description of how this PR has been tested.

**Checklist**

- [x] I have read [CONTRIBUTING.md](https://github.com/pdfminer/pdfminer.six/blob/master/CONTRIBUTING.md). 
- [x] I have added a concise human-readable description of the change to [CHANGELOG.md](https://github.com/pdfminer/pdfminer.six/blob/master/CHANGELOG.md).
- [x] I have tested that this fix is effective or that this feature works.
- [x] I have added docstrings to newly created methods and classes.
- [x] I have updated the [README.md](https://github.com/pdfminer/pdfminer.six/blob/master/README.md) and the [readthedocs](https://github.com/pdfminer/pdfminer.six/tree/master/docs/source) documentation. Or verified that this is not necessary.
