### PR TITLE
Fix: TypeError when parsing font width with indirect object references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,18 @@ All notable changes in pdfminer.six will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Fixed
+
+- Fix: `TypeError` when parsing font width with indirect object references ([#1098](https://github.com/pdfminer/pdfminer.six/pull/1098))
+
 ## [20250327]
 
 ### Added
 
 - Support for Python 3.13 ([#1092](https://github.com/pdfminer/pdfminer.six/pull/1092))
-- 
+
 ### Changed
 
 - Reduce memory overhead on runlength encoding by using lists ([#1055](https://github.com/pdfminer/pdfminer.six/pull/1055))

--- a/pdfminer/pdffont.py
+++ b/pdfminer/pdffont.py
@@ -62,6 +62,7 @@ def get_widths(seq: Iterable[object]) -> Dict[Union[str, int], float]:
     widths: Dict[int, float] = {}
     r: List[float] = []
     for v in seq:
+        v = resolve1(v)
         if isinstance(v, list):
             if r:
                 char1 = r[-1]
@@ -72,9 +73,18 @@ def get_widths(seq: Iterable[object]) -> Dict[Union[str, int], float]:
             r.append(v)
             if len(r) == 3:
                 (char1, char2, w) = r
-                for i in range(cast(int, char1), cast(int, char2) + 1):
-                    widths[i] = w
+                if isinstance(char1, int) and isinstance(char2, int):
+                    for i in range(cast(int, char1), cast(int, char2) + 1):
+                        widths[i] = w
+                else:
+                    log.warning(
+                        f"Skipping invalid font width specification for {char1} to {char2} because either of them is not an int"
+                    )
                 r = []
+        else:
+            log.warning(
+                f"Skipping invalid font width specification for {v} because it is not a number or a list"
+            )
     return cast(Dict[Union[str, int], float], widths)
 
 

--- a/tests/test_pdffont.py
+++ b/tests/test_pdffont.py
@@ -1,9 +1,10 @@
-from typing import Dict, Union
+from typing import Any, Dict, Union
 
 import pytest
 
-from pdfminer.pdffont import PDFCIDFont, PDFFont
+from pdfminer.pdffont import PDFCIDFont, PDFFont, get_widths
 from pdfminer.pdfinterp import PDFResourceManager
+from pdfminer.pdftypes import PDFObjRef
 from pdfminer.psparser import PSLiteral
 
 
@@ -44,3 +45,19 @@ def test_pdffont_char_width_defaults(
     pdffont = MockPdfFont(descriptor=dict(), widths=widths, default_width=100.0)
 
     assert pdffont.char_width(0) == expected, msg
+
+
+def test_pdffont_get_widths():
+    assert get_widths([0, [1, 2, 3, 4]]) == {0: 1, 1: 2, 2: 3, 3: 4}
+    assert get_widths([0, 4, 3]) == {0: 3, 1: 3, 2: 3, 3: 3, 4: 3}
+
+
+def test_pdffont_get_widths_object_ref():
+    """Regression test for https://github.com/pdfminer/pdfminer.six/issues/629"""
+
+    class MockDoc:
+        def getobj(self, objid: int) -> Any:
+            return [1, 2, 3, 4]
+
+    obj = PDFObjRef(doc=MockDoc(), objid=121)
+    assert get_widths([0, obj]) == {0: 1, 1: 2, 2: 3, 3: 4}


### PR DESCRIPTION
**Pull request**

Please *remove* this paragraph and replace it with a description of your PR. Also include the issue that it fixes. 

**How Has This Been Tested?**

Please *remove* this paragraph with a description of how this PR has been tested.

**Checklist**

- [x] I have read [CONTRIBUTING.md](https://github.com/pdfminer/pdfminer.six/blob/master/CONTRIBUTING.md). 
- [x] I have added a concise human-readable description of the change to [CHANGELOG.md](https://github.com/pdfminer/pdfminer.six/blob/master/CHANGELOG.md).
- [x] I have tested that this fix is effective or that this feature works.
- [x] I have added docstrings to newly created methods and classes.
- [x] I have updated the [README.md](https://github.com/pdfminer/pdfminer.six/blob/master/README.md) and the [readthedocs](https://github.com/pdfminer/pdfminer.six/tree/master/docs/source) documentation. Or verified that this is not necessary.
