### PR TITLE
Fix: `ValueError` when loading xref with invalid position or generation numbers that cannot be parsed as int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Fix: `TypeError` when parsing font width with indirect object references ([#1098](https://github.com/pdfminer/pdfminer.six/pull/1098))
+- `TypeError` when parsing font width with indirect object references ([#1098](https://github.com/pdfminer/pdfminer.six/pull/1098))
+- `ValueError` when loading xref with invalid position or generation numbers that cannot be parsed as int ([#1099](https://github.com/pdfminer/pdfminer.six/pull/1099))
 
 ## [20250327]
 

--- a/pdfminer/pdfdocument.py
+++ b/pdfminer/pdfdocument.py
@@ -24,6 +24,7 @@ from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 from pdfminer import settings
 from pdfminer.arcfour import Arcfour
+from pdfminer.casting import safe_int
 from pdfminer.data_structures import NumberTree
 from pdfminer.pdfexceptions import (
     PDFException,
@@ -170,7 +171,15 @@ class PDFXRef(PDFBaseXRef):
                 (pos_b, genno_b, use_b) = f
                 if use_b != b"n":
                     continue
-                self.offsets[objid] = (None, int(pos_b), int(genno_b))
+
+                pos = safe_int(pos_b)
+                genno = safe_int(genno_b)
+
+                if pos is not None and genno is not None:
+                    self.offsets[objid] = (None, pos, genno)
+                else:
+                    log.warning(f"Not adding object {objid} to xref because position {pos_b} or genneration number {genno_b} cannot be parsed as an int")
+
         log.debug("xref objects: %r", self.offsets)
         self.load_trailer(parser)
 

--- a/pdfminer/pdfdocument.py
+++ b/pdfminer/pdfdocument.py
@@ -172,13 +172,15 @@ class PDFXRef(PDFBaseXRef):
                 if use_b != b"n":
                     continue
 
-                pos = safe_int(pos_b)
-                genno = safe_int(genno_b)
-
-                if pos is not None and genno is not None:
-                    self.offsets[objid] = (None, pos, genno)
+                pos_i = safe_int(pos_b)
+                genno_i = safe_int(genno_b)
+                if pos_i is not None and genno_i is not None:
+                    self.offsets[objid] = (None, pos_i, genno_i)
                 else:
-                    log.warning(f"Not adding object {objid} to xref because position {pos_b} or genneration number {genno_b} cannot be parsed as an int")
+                    log.warning(
+                        f"Not adding object {objid} to xref because position {pos_b!r} "
+                        f"or generation number {genno_b!r} cannot be parsed as an int"
+                    )
 
         log.debug("xref objects: %r", self.offsets)
         self.load_trailer(parser)


### PR DESCRIPTION
Fix: `ValueError` when loading xref with invalid position or generation numbers that cannot be parsed as int

**Pull request**

Please *remove* this paragraph and replace it with a description of your PR. Also include the issue that it fixes. 

**How Has This Been Tested?**

Will be tested by OSS Fuzz

**Checklist**

- [x] I have read [CONTRIBUTING.md](https://github.com/pdfminer/pdfminer.six/blob/master/CONTRIBUTING.md). 
- [x] I have added a concise human-readable description of the change to [CHANGELOG.md](https://github.com/pdfminer/pdfminer.six/blob/master/CHANGELOG.md).
- [x] I have tested that this fix is effective or that this feature works.
- [x] I have added docstrings to newly created methods and classes.
- [x] I have updated the [README.md](https://github.com/pdfminer/pdfminer.six/blob/master/README.md) and the [readthedocs](https://github.com/pdfminer/pdfminer.six/tree/master/docs/source) documentation. Or verified that this is not necessary.
