### PR TITLE
Fix: explicitly convert all floats and ints from pdf stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Fix: `TypeError` when parsing font width with indirect object references ([#1098](https://github.com/pdfminer/pdfminer.six/pull/1098))
+- `TypeError` when parsing font width with indirect object references ([#1098](https://github.com/pdfminer/pdfminer.six/pull/1098))
+- `ValueError` when loading xref with invalid position or generation numbers that cannot be parsed as int ([#1099](https://github.com/pdfminer/pdfminer.six/pull/1099))
 
 ## [20250327]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - `TypeError` when parsing font width with indirect object references ([#1098](https://github.com/pdfminer/pdfminer.six/pull/1098))
-- `ValueError` when loading xref with invalid position or generation numbers that cannot be parsed as int ([#1099](https://github.com/pdfminer/pdfminer.six/pull/1099))
+- `ValueError` when assuming float or int type in PDFDocument or PDFInterpreter ([#1099](https://github.com/pdfminer/pdfminer.six/pull/1099))
 
 ## [20250327]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - `TypeError` when parsing font width with indirect object references ([#1098](https://github.com/pdfminer/pdfminer.six/pull/1098))
 - `ValueError` when loading xref with invalid position or generation numbers that cannot be parsed as int ([#1099](https://github.com/pdfminer/pdfminer.six/pull/1099))
-- `ValueError` when assuming float or int type in PDFInterpreter ([#1099](https://github.com/pdfminer/pdfminer.six/pull/1099))
+- Safely converting PDF stack objects to float or int in PDFInterpreter ([#1100](https://github.com/pdfminer/pdfminer.six/pull/1100))
 
 ## [20250327]
 

--- a/pdfminer/casting.py
+++ b/pdfminer/casting.py
@@ -1,4 +1,6 @@
-from typing import Any, Optional
+from typing import Any, Optional, Tuple
+
+from pdfminer.utils import Matrix
 
 
 def safe_int(o: Any) -> Optional[int]:
@@ -13,3 +15,49 @@ def safe_float(o: Any) -> Optional[float]:
         return float(o)
     except (TypeError, ValueError):
         return None
+
+
+def safe_matrix(a: Any, b: Any, c: Any, d: Any, e: Any, f: Any) -> Optional[Matrix]:
+    a_f = safe_float(a)
+    b_f = safe_float(b)
+    c_f = safe_float(c)
+    d_f = safe_float(d)
+    e_f = safe_float(e)
+    f_f = safe_float(f)
+
+    if (
+        a_f is None
+        or b_f is None
+        or c_f is None
+        or d_f is None
+        or e_f is None
+        or f_f is None
+    ):
+        return None
+
+    return a_f, b_f, c_f, d_f, e_f, f_f
+
+
+def safe_rgb(r: Any, g: Any, b: Any) -> Optional[Tuple[float, float, float]]:
+    r_f = safe_float(r)
+    g_f = safe_float(g)
+    b_f = safe_float(b)
+
+    if r_f is None or g_f is None or b_f is None:
+        return None
+
+    return r_f, g_f, b_f
+
+
+def safe_cmyk(
+    c: Any, m: Any, y: Any, k: Any
+) -> Optional[Tuple[float, float, float, float]]:
+    c_f = safe_float(c)
+    m_f = safe_float(m)
+    y_f = safe_float(y)
+    k_f = safe_float(k)
+
+    if c_f is None or m_f is None or y_f is None or k_f is None:
+        return None
+
+    return (c_f, m_f, y_f, k_f)

--- a/pdfminer/pdfdevice.py
+++ b/pdfminer/pdfdevice.py
@@ -189,7 +189,7 @@ class PDFTextDevice(PDFDevice):
                     needcharspace = True
             else:
                 logger.warning(
-                    f"Invalid string type. Must by int, float or bytes but is {type(obj)}."
+                    f"Cannot render horizontal string because {obj!r} is not a valid int, float or bytes."
                 )
         return (x, y)
 
@@ -233,7 +233,7 @@ class PDFTextDevice(PDFDevice):
                     needcharspace = True
             else:
                 logger.warning(
-                    f"Invalid string type. Must by int, float or bytes but is {type(obj)}."
+                    f"Cannot render vertical string because {obj!r} is not a valid int, float or bytes."
                 )
         return (x, y)
 

--- a/pdfminer/pdfdocument.py
+++ b/pdfminer/pdfdocument.py
@@ -24,6 +24,7 @@ from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 from pdfminer import settings
 from pdfminer.arcfour import Arcfour
+from pdfminer.casting import safe_int
 from pdfminer.data_structures import NumberTree
 from pdfminer.pdfexceptions import (
     PDFException,
@@ -170,7 +171,15 @@ class PDFXRef(PDFBaseXRef):
                 (pos_b, genno_b, use_b) = f
                 if use_b != b"n":
                     continue
-                self.offsets[objid] = (None, int(pos_b), int(genno_b))
+
+                pos = safe_int(pos_b)
+                genno = safe_int(genno_b)
+
+                if pos is not None and genno is not None:
+                    self.offsets[objid] = (None, pos, genno)
+                else:
+                    log.warning(f"Not adding object {objid} to xref because position {pos_b} or genneration number {genno_b} cannot be parsed as an int")
+
         log.debug("xref objects: %r", self.offsets)
         self.load_trailer(parser)
 

--- a/pdfminer/pdfdocument.py
+++ b/pdfminer/pdfdocument.py
@@ -172,13 +172,15 @@ class PDFXRef(PDFBaseXRef):
                 if use_b != b"n":
                     continue
 
-                pos = safe_int(pos_b)
-                genno = safe_int(genno_b)
-
-                if pos is not None and genno is not None:
-                    self.offsets[objid] = (None, pos, genno)
+                pos_i = safe_int(pos_b)
+                genno_i = safe_int(genno_b)
+                if pos_i is not None and genno_i is not None:
+                    self.offsets[objid] = (None, pos_i, genno_i)
                 else:
-                    log.warning(f"Not adding object {objid} to xref because position {pos_b} or genneration number {genno_b} cannot be parsed as an int")
+                    log.warning(
+                        f"Not adding object {objid} to xref because position {pos_b!r} "
+                        f"or generation number {genno_b!r} cannot be parsed as an int"
+                    )
 
         log.debug("xref objects: %r", self.offsets)
         self.load_trailer(parser)


### PR DESCRIPTION
**Pull request**

Related to #984

**How Has This Been Tested?**

Tested by OSS Fuzz

**Checklist**

- [x] I have read [CONTRIBUTING.md](https://github.com/pdfminer/pdfminer.six/blob/master/CONTRIBUTING.md). 
- [x] I have added a concise human-readable description of the change to [CHANGELOG.md](https://github.com/pdfminer/pdfminer.six/blob/master/CHANGELOG.md).
- [x] I have tested that this fix is effective or that this feature works.
- [x] I have added docstrings to newly created methods and classes.
- [x] I have updated the [README.md](https://github.com/pdfminer/pdfminer.six/blob/master/README.md) and the [readthedocs](https://github.com/pdfminer/pdfminer.six/tree/master/docs/source) documentation. Or verified that this is not necessary.
