### PR TITLE
Fix: safely parse font bbox and fallback to zeros if not specified correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `TypeError` when parsing font width with indirect object references ([#1098](https://github.com/pdfminer/pdfminer.six/pull/1098))
 - `ValueError` when loading xref with invalid position or generation numbers that cannot be parsed as int ([#1099](https://github.com/pdfminer/pdfminer.six/pull/1099))
 - Safely converting PDF stack objects to float or int in PDFInterpreter ([#1100](https://github.com/pdfminer/pdfminer.six/pull/1100))
+- `TypeError` when parsing font bbox with incorrect values ([#1103](https://github.com/pdfminer/pdfminer.six/pull/1103))
 
 ## [20250327]
 

--- a/pdfminer/casting.py
+++ b/pdfminer/casting.py
@@ -1,6 +1,10 @@
-from typing import Any, Optional, Tuple
+import itertools
+from typing import Any, Optional, Tuple, TypeAlias
 
-from pdfminer.utils import Matrix
+from pdfminer.utils import Matrix, Rect
+
+_FloatTriple: TypeAlias = Tuple[float, float, float]
+_FloatQuadruple: TypeAlias = Tuple[float, float, float, float]
 
 
 def safe_int(o: Any) -> Optional[int]:
@@ -39,25 +43,49 @@ def safe_matrix(a: Any, b: Any, c: Any, d: Any, e: Any, f: Any) -> Optional[Matr
 
 
 def safe_rgb(r: Any, g: Any, b: Any) -> Optional[Tuple[float, float, float]]:
-    r_f = safe_float(r)
-    g_f = safe_float(g)
-    b_f = safe_float(b)
-
-    if r_f is None or g_f is None or b_f is None:
-        return None
-
-    return r_f, g_f, b_f
+    return _safe_float_triple(r, g, b)
 
 
 def safe_cmyk(
     c: Any, m: Any, y: Any, k: Any
 ) -> Optional[Tuple[float, float, float, float]]:
-    c_f = safe_float(c)
-    m_f = safe_float(m)
-    y_f = safe_float(y)
-    k_f = safe_float(k)
+    return _safe_float_quadruple(c, m, y, k)
 
-    if c_f is None or m_f is None or y_f is None or k_f is None:
+
+def safe_rect_list(value: Any) -> Optional[Rect]:
+    try:
+        values = list(itertools.islice(value, 4))
+    except TypeError:
         return None
 
-    return (c_f, m_f, y_f, k_f)
+    if len(values) != 4:
+        return None
+
+    return safe_rect(*values)
+
+
+def safe_rect(a: Any, b: Any, c: Any, d: Any) -> Optional[Rect]:
+    return _safe_float_quadruple(a, b, c, d)
+
+
+def _safe_float_triple(a: Any, b: Any, c: Any) -> Optional[_FloatTriple]:
+    a_f = safe_float(a)
+    b_f = safe_float(b)
+    c_f = safe_float(c)
+
+    if a_f is None or b_f is None or c_f is None:
+        return None
+
+    return a_f, b_f, c_f
+
+
+def _safe_float_quadruple(a: Any, b: Any, c: Any, d: Any) -> Optional[_FloatQuadruple]:
+    a_f = safe_float(a)
+    b_f = safe_float(b)
+    c_f = safe_float(c)
+    d_f = safe_float(d)
+
+    if a_f is None or b_f is None or c_f is None or d_f is None:
+        return None
+
+    return a_f, b_f, c_f, d_f

--- a/pdfminer/pdffont.py
+++ b/pdfminer/pdffont.py
@@ -963,7 +963,9 @@ class PDFFont:
         font_bbox = resolve_all(descriptor.get("FontBBox"))
         bbox = safe_rect_list(font_bbox)
         if bbox is None:
-            log.warning(f"Could get FontBBox from font descriptor because {font_bbox!r} cannot be parsed as 4 floats")
+            log.warning(
+                f"Could get FontBBox from font descriptor because {font_bbox!r} cannot be parsed as 4 floats"
+            )
             return 0.0, 0.0, 0.0, 0.0
         return bbox
 

--- a/tests/test_casting.py
+++ b/tests/test_casting.py
@@ -1,0 +1,24 @@
+from typing import Any, Optional
+
+import pytest
+
+from pdfminer.casting import safe_rect_list
+from pdfminer.utils import Rect
+
+
+@pytest.mark.parametrize(
+    ("arg", "expected"),
+    [
+        ([0, 0, 0, 0], (0.0, 0.0, 0.0, 0.0)),
+        ([1, 2, 3, 4], (1.0, 2.0, 3.0, 4.0)),
+        ([0, 0, 0, None], None),
+        ([0, 0, 0, "0"], (0.0, 0.0, 0.0, 0.0)),
+        ([], None),
+        ([0, 0, 0], None),
+        ([1, 2, 3, 4, 5], (1.0, 2.0, 3.0, 4.0)),
+        (None, None),
+        (object(), None),
+    ],
+)
+def test_safe_rect_list(arg: Any, expected: Optional[Rect]) -> None:
+    assert safe_rect_list(arg) == expected


### PR DESCRIPTION
**Pull request**

Relates to #1102 

**How Has This Been Tested?**

Added tests for new methods, and the it fixes the issue in #1102 

**Checklist**

- [x] I have read [CONTRIBUTING.md](https://github.com/pdfminer/pdfminer.six/blob/master/CONTRIBUTING.md). 
- [x] I have added a concise human-readable description of the change to [CHANGELOG.md](https://github.com/pdfminer/pdfminer.six/blob/master/CHANGELOG.md).
- [x] I have tested that this fix is effective or that this feature works.
- [x] I have added docstrings to newly created methods and classes.
- [x] I have updated the [README.md](https://github.com/pdfminer/pdfminer.six/blob/master/README.md) and the [readthedocs](https://github.com/pdfminer/pdfminer.six/tree/master/docs/source) documentation. Or verified that this is not necessary.
