### PR TITLE
Remove: log.warning when CropBox is not specified

### DIFF
--- a/pdfminer/pdfpage.py
+++ b/pdfminer/pdfpage.py
@@ -199,7 +199,7 @@ class PDFPage:
 
     def _parse_cropbox(self, value: Any, mediabox: Rect) -> Rect:
         if value is None:
-            log.warning("CropBox missing from /Page, defaulting to MediaBox")
+            # CropBox is optional, and MediaBox is used if not specified. 
             return mediabox
 
         try:

--- a/pdfminer/pdfpage.py
+++ b/pdfminer/pdfpage.py
@@ -199,7 +199,7 @@ class PDFPage:
 
     def _parse_cropbox(self, value: Any, mediabox: Rect) -> Rect:
         if value is None:
-            # CropBox is optional, and MediaBox is used if not specified. 
+            # CropBox is optional, and MediaBox is used if not specified.
             return mediabox
 
         try:


### PR DESCRIPTION
**Pull request**

CropBox is optional in the spec. 

**How Has This Been Tested?**

Please *remove* this paragraph with a description of how this PR has been tested.

**Checklist**

- [x] I have read [CONTRIBUTING.md](https://github.com/pdfminer/pdfminer.six/blob/master/CONTRIBUTING.md). 
- [ ] I have added a concise human-readable description of the change to [CHANGELOG.md](https://github.com/pdfminer/pdfminer.six/blob/master/CHANGELOG.md).
- [x] I have tested that this fix is effective or that this feature works.
- [x] I have added docstrings to newly created methods and classes.
- [x] I have updated the [README.md](https://github.com/pdfminer/pdfminer.six/blob/master/README.md) and the [readthedocs](https://github.com/pdfminer/pdfminer.six/tree/master/docs/source) documentation. Or verified that this is not necessary.
