### PR TITLE
fix: strip whitespace and delimiters in ASCII85

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `ValueError` when loading xref with invalid position or generation numbers that cannot be parsed as int ([#1099](https://github.com/pdfminer/pdfminer.six/pull/1099))
 - Safely converting PDF stack objects to float or int in PDFInterpreter ([#1100](https://github.com/pdfminer/pdfminer.six/pull/1100))
 - `TypeError` when parsing font bbox with incorrect values ([#1103](https://github.com/pdfminer/pdfminer.six/pull/1103))
-- `ValueError` on incorrect stream lengths for ASCII85 data
+- `ValueError` on incorrect stream lengths for ASCII85 data ([#1112](https://github.com/pdfminer/pdfminer.six/pull/1112))
 
 ## [20250327]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `ValueError` when loading xref with invalid position or generation numbers that cannot be parsed as int ([#1099](https://github.com/pdfminer/pdfminer.six/pull/1099))
 - Safely converting PDF stack objects to float or int in PDFInterpreter ([#1100](https://github.com/pdfminer/pdfminer.six/pull/1100))
 - `TypeError` when parsing font bbox with incorrect values ([#1103](https://github.com/pdfminer/pdfminer.six/pull/1103))
+- `ValueError` on incorrect stream lengths for ASCII85 data
 
 ## [20250327]
 

--- a/pdfminer/ascii85.py
+++ b/pdfminer/ascii85.py
@@ -4,6 +4,9 @@ import re
 from base64 import a85decode
 from binascii import unhexlify
 
+start_re = re.compile(rb"^\s*<\s*~\s*")
+end_re = re.compile(rb"\s*~\s*>\s*$")
+
 
 def ascii85decode(data: bytes) -> bytes:
     """In ASCII85 encoding, every four bytes are encoded with five ASCII
@@ -18,7 +21,9 @@ def ascii85decode(data: bytes) -> bytes:
     ASCII85 digits in any case.
 
     """
-    return a85decode(data.strip(b"<~> \t\r\n"))
+    data = start_re.sub(b"", data)
+    data = end_re.sub(b"", data)
+    return a85decode(data.strip(b"~"))
 
 
 bws_re = re.compile(rb"\s")

--- a/pdfminer/ascii85.py
+++ b/pdfminer/ascii85.py
@@ -14,11 +14,13 @@ def ascii85decode(data: bytes) -> bytes:
     When the length of the original bytes is not a multiple of 4, a special
     rule is used for round up.
 
-    The Adobe's ASCII85 implementation is slightly different from its
-    original in handling the last characters.  We simply strip out the
-    delimiters and any whitespace (sometimes there's extraneous
-    whitespace even inside the delimiters themselves!).
-
+    Adobe's ASCII85 implementation expects the input to be surrounded
+    by `b"<~"` and `b"~>"`.  We can't reliably expect this to be the
+    case, and often there are off-by-one errors in xref tables or
+    stream lengths which mean we only see `~`.  Worse yet, `<` and `>`
+    are ASCII85 digits (yes, another genius move on Adobe's part), so
+    we can't just strip them out too.  We settle on a compromise where
+    we strip leading `<~` or `~` and trailing `~` or `~>`.
     """
     data = start_re.sub(b"", data)
     data = end_re.sub(b"", data)

--- a/pdfminer/ascii85.py
+++ b/pdfminer/ascii85.py
@@ -11,14 +11,14 @@ def ascii85decode(data: bytes) -> bytes:
     When the length of the original bytes is not a multiple of 4, a special
     rule is used for round up.
 
-    The Adobe's ASCII85 implementation is slightly different from
-    its original in handling the last characters.
+    The Adobe's ASCII85 implementation is slightly different from its
+    original in handling the last characters.  We simply strip out the
+    delimiters and any whitespace (sometimes there's extraneous
+    whitespace even inside the delimiters themselves!) as they are not
+    ASCII85 digits in any case.
 
     """
-    try:
-        return a85decode(data, adobe=True)
-    except ValueError:
-        return a85decode(data)
+    return a85decode(data.strip(b"<~> \t\r\n"))
 
 
 bws_re = re.compile(rb"\s")

--- a/pdfminer/ascii85.py
+++ b/pdfminer/ascii85.py
@@ -17,8 +17,7 @@ def ascii85decode(data: bytes) -> bytes:
     The Adobe's ASCII85 implementation is slightly different from its
     original in handling the last characters.  We simply strip out the
     delimiters and any whitespace (sometimes there's extraneous
-    whitespace even inside the delimiters themselves!) as they are not
-    ASCII85 digits in any case.
+    whitespace even inside the delimiters themselves!).
 
     """
     data = start_re.sub(b"", data)

--- a/pdfminer/ascii85.py
+++ b/pdfminer/ascii85.py
@@ -14,13 +14,13 @@ def ascii85decode(data: bytes) -> bytes:
     When the length of the original bytes is not a multiple of 4, a special
     rule is used for round up.
 
-    Adobe's ASCII85 implementation expects the input to be surrounded
-    by `b"<~"` and `b"~>"`.  We can't reliably expect this to be the
-    case, and often there are off-by-one errors in xref tables or
-    stream lengths which mean we only see `~`.  Worse yet, `<` and `>`
-    are ASCII85 digits (yes, another genius move on Adobe's part), so
-    we can't just strip them out too.  We settle on a compromise where
-    we strip leading `<~` or `~` and trailing `~` or `~>`.
+    Adobe's ASCII85 implementation expects the input to be terminated
+    by `b"~>"`, and (though this is absent from the PDF spec) it can
+    also begin with `b"<~"`.  We can't reliably expect this to be the
+    case, and there can be off-by-one errors in stream lengths which
+    mean we only see `~` at the end.  Worse yet, `<` and `>` are
+    ASCII85 digits, so we can't strip them.  We settle on a compromise
+    where we strip leading `<~` or `~` and trailing `~` or `~>`.
     """
     data = start_re.sub(b"", data)
     data = end_re.sub(b"", data)

--- a/pdfminer/ascii85.py
+++ b/pdfminer/ascii85.py
@@ -4,8 +4,8 @@ import re
 from base64 import a85decode
 from binascii import unhexlify
 
-start_re = re.compile(rb"^\s*<\s*~\s*")
-end_re = re.compile(rb"\s*~\s*>\s*$")
+start_re = re.compile(rb"^\s*<?\s*~\s*")
+end_re = re.compile(rb"\s*~\s*>?\s*$")
 
 
 def ascii85decode(data: bytes) -> bytes:
@@ -22,7 +22,7 @@ def ascii85decode(data: bytes) -> bytes:
     """
     data = start_re.sub(b"", data)
     data = end_re.sub(b"", data)
-    return a85decode(data.strip(b"~"))
+    return a85decode(data)
 
 
 bws_re = re.compile(rb"\s")

--- a/tests/test_pdfminer_crypto.py
+++ b/tests/test_pdfminer_crypto.py
@@ -25,6 +25,7 @@ class TestAscii85:
         """
         assert ascii85decode(b"9jqo^BlbD-BleB1DJ+*+F(f,q") == b"Man is distinguished"
         assert ascii85decode(b"E,9)oF*2M7/c~>") == b"pleasure."
+        assert ascii85decode(b"zE,9)oF*2M7/c~>") == b"\0\0\0\0pleasure."
         # And some bogus cases you may encounter
         assert ascii85decode(b"E,9)oF*2M7/c~") == b"pleasure."
         assert ascii85decode(b"<~E,9)oF*2M7/c~") == b"pleasure."

--- a/tests/test_pdfminer_crypto.py
+++ b/tests/test_pdfminer_crypto.py
@@ -29,6 +29,18 @@ class TestAscii85:
         assert ascii85decode(b"E,9)oF*2M7/c~") == b"pleasure."
         assert ascii85decode(b"<~E,9)oF*2M7/c~") == b"pleasure."
         assert ascii85decode(b"<~E,9)oF*2M7/c~\n>") == b"pleasure."
+        # Ensure that we don't miss actual ASCII85 digits
+        assert (
+            ascii85decode(b"<^BVT:K:=9<E)pd;BS_1:/aSV;ag~>")
+            == b"VARIOUS UTTER NONSENSE"
+        )
+        assert (
+            ascii85decode(b"<~<^BVT:K:=9<E)pd;BS_1:/aSV;ag~>")
+            == b"VARIOUS UTTER NONSENSE"
+        )
+        assert (
+            ascii85decode(b"<^BVT:K:=9<E)pd;BS_1:/aSV;ag~") == b"VARIOUS UTTER NONSENSE"
+        )
 
     def test_asciihexdecode(self):
         assert asciihexdecode(b"61 62 2e6364   65") == b"ab.cde"

--- a/tests/test_pdfminer_crypto.py
+++ b/tests/test_pdfminer_crypto.py
@@ -27,6 +27,7 @@ class TestAscii85:
         assert ascii85decode(b"E,9)oF*2M7/c~>") == b"pleasure."
         assert ascii85decode(b"zE,9)oF*2M7/c~>") == b"\0\0\0\0pleasure."
         # And some bogus cases you may encounter
+        assert ascii85decode(b"E,9)oF*2M7/c") == b"pleasure."
         assert ascii85decode(b"E,9)oF*2M7/c~") == b"pleasure."
         assert ascii85decode(b"<~E,9)oF*2M7/c~") == b"pleasure."
         assert ascii85decode(b"<~E,9)oF*2M7/c~\n>") == b"pleasure."

--- a/tests/test_pdfminer_crypto.py
+++ b/tests/test_pdfminer_crypto.py
@@ -25,6 +25,10 @@ class TestAscii85:
         """
         assert ascii85decode(b"9jqo^BlbD-BleB1DJ+*+F(f,q") == b"Man is distinguished"
         assert ascii85decode(b"E,9)oF*2M7/c~>") == b"pleasure."
+        # And some bogus cases you may encounter
+        assert ascii85decode(b"E,9)oF*2M7/c~") == b"pleasure."
+        assert ascii85decode(b"<~E,9)oF*2M7/c~") == b"pleasure."
+        assert ascii85decode(b"<~E,9)oF*2M7/c~\n>") == b"pleasure."
 
     def test_asciihexdecode(self):
         assert asciihexdecode(b"61 62 2e6364   65") == b"ab.cde"


### PR DESCRIPTION
**Pull request**

To avoid a `ValueError` in the case where an ASCII85 delimiter has been truncated (usually due to incorrect stream length or inline image parsing error), it's safer to just strip the delimiter characters instead of using "Adobe mode" for `a85decode`.

Fixes: #1111 

**How Has This Been Tested?**

Verified with existing test suite, added the edge cases to the unit test.

**Checklist**

- [x] I have read [CONTRIBUTING.md](https://github.com/pdfminer/pdfminer.six/blob/master/CONTRIBUTING.md). 
- [x] I have added a concise human-readable description of the change to [CHANGELOG.md](https://github.com/pdfminer/pdfminer.six/blob/master/CHANGELOG.md).
- [x] I have tested that this fix is effective or that this feature works.
- [x] I have added docstrings to newly created methods and classes.
- [x] I have updated the [README.md](https://github.com/pdfminer/pdfminer.six/blob/master/README.md) and the [readthedocs](https://github.com/pdfminer/pdfminer.six/tree/master/docs/source) documentation. Or verified that this is not necessary.
