### PR TITLE
Fix: TypeError when passing wrong number of arguments to safe_rgb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Fixed
 
 - Correct tightest fitting bounding boxes for rotated content ([#1114](https://github.com/pdfminer/pdfminer.six/pull/1114))
+- `TypeError` when passing wrong number of arguments to `safe_rgb` ([#1118](https://github.com/pdfminer/pdfminer.six/pull/1118))
  
 ## [20250416]
 

--- a/pdfminer/pdfinterp.py
+++ b/pdfminer/pdfinterp.py
@@ -781,8 +781,14 @@ class PDFPageInterpreter:
                 raise PDFInterpreterError("No colorspace specified!")
             n = 1
 
-        if n == 1:
-            gray = self.pop(1)[0]
+        components = self.pop(n)
+        if len(components) != n:
+            log.warning(
+                f"Cannot set stroke color because expected {n} components but got {components:!r}"
+            )
+
+        elif len(components) == 1:
+            gray = components[0]
             gray_f = safe_float(gray)
             if gray_f is None:
                 log.warning(
@@ -791,28 +797,22 @@ class PDFPageInterpreter:
             else:
                 self.graphicstate.scolor = gray_f
 
-        elif n == 3:
-            values = self.pop(3)
-            rgb = None
-            if len(values) == 3:
-                rgb = safe_rgb(*values)
+        elif len(components) == 3:
+            rgb = safe_rgb(*components)
 
             if rgb is None:
                 log.warning(
-                    f"Cannot set RGB stroke color because values {values!r} cannot be parsed as RGB"
+                    f"Cannot set RGB stroke color because components {components!r} cannot be parsed as RGB"
                 )
             else:
                 self.graphicstate.scolor = rgb
 
         elif n == 4:
-            values = self.pop(4)
-            cmyk = None
-            if len(values) == 4:
-                cmyk = safe_cmyk(*values)
+            cmyk = safe_cmyk(*components)
 
             if cmyk is None:
                 log.warning(
-                    f"Cannot set CMYK stroke color because values {values!r} cannot be parsed as CMYK"
+                    f"Cannot set CMYK stroke color because components {components!r} cannot be parsed as CMYK"
                 )
             else:
                 self.graphicstate.scolor = cmyk
@@ -831,8 +831,14 @@ class PDFPageInterpreter:
                 raise PDFInterpreterError("No colorspace specified!")
             n = 1
 
-        if n == 1:
-            gray = self.pop(1)[0]
+        components = self.pop(n)
+        if len(components) != n:
+            log.warning(
+                f"Cannot set non-stroke color because expected {n} components but got {components:!r}"
+            )
+
+        elif len(components) == 1:
+            gray = components[0]
             gray_f = safe_float(gray)
             if gray_f is None:
                 log.warning(
@@ -841,28 +847,22 @@ class PDFPageInterpreter:
             else:
                 self.graphicstate.ncolor = gray_f
 
-        elif n == 3:
-            values = self.pop(3)
-            rgb = None
-            if len(values) == 3:
-                rgb = safe_rgb(*values)
+        elif len(components) == 3:
+            rgb = safe_rgb(*components)
 
             if rgb is None:
                 log.warning(
-                    f"Cannot set RGB non-stroke color because values {values!r} cannot be parsed as RGB"
+                    f"Cannot set RGB non-stroke color because components {components!r} cannot be parsed as RGB"
                 )
             else:
                 self.graphicstate.ncolor = rgb
 
-        elif n == 4:
-            values = self.pop(4)
-            cmyk = None
-            if len(values) == 4:
-                cmyk = safe_cmyk(*values)
+        elif len(components) == 4:
+            cmyk = safe_cmyk(*components)
 
             if cmyk is None:
                 log.warning(
-                    f"Cannot set CMYK non-stroke color because values {values!r} cannot be parsed as CMYK"
+                    f"Cannot set CMYK non-stroke color because components {components!r} cannot be parsed as CMYK"
                 )
             else:
                 self.graphicstate.ncolor = cmyk

--- a/pdfminer/pdfinterp.py
+++ b/pdfminer/pdfinterp.py
@@ -793,10 +793,13 @@ class PDFPageInterpreter:
 
         elif n == 3:
             values = self.pop(3)
-            rgb = safe_rgb(*values)
+            rgb = None
+            if len(values) == 3:
+                rgb = safe_rgb(*values)
+
             if rgb is None:
                 log.warning(
-                    f"Cannot set RGB stroke color because not all values in {values!r} can be parsed as floats"
+                    f"Cannot set RGB stroke color because values {values!r} cannot be parsed as RGB"
                 )
             else:
                 self.graphicstate.scolor = rgb
@@ -838,11 +841,13 @@ class PDFPageInterpreter:
 
         elif n == 3:
             values = self.pop(3)
-            rgb = safe_rgb(*values)
+            rgb = None
+            if len(values) == 3:
+                rgb = safe_rgb(*values)
 
             if rgb is None:
                 log.warning(
-                    f"Cannot set RGB non-stroke color because not all values in {values!r} can be parsed as floats"
+                    f"Cannot set RGB non-stroke color because values {values!r} cannot be parsed as RGB"
                 )
             else:
                 self.graphicstate.ncolor = rgb

--- a/pdfminer/pdfinterp.py
+++ b/pdfminer/pdfinterp.py
@@ -807,7 +807,7 @@ class PDFPageInterpreter:
             else:
                 self.graphicstate.scolor = rgb
 
-        elif n == 4:
+        elif len(components) == 4:
             cmyk = safe_cmyk(*components)
 
             if cmyk is None:
@@ -819,7 +819,7 @@ class PDFPageInterpreter:
 
         else:
             log.warning(
-                f"Cannot set stroke color because {n} components are specified but only 1 (grayscale), 3 (rgb) and 4 (cmyk) are supported"
+                f"Cannot set stroke color because {len(components)} components are specified but only 1 (grayscale), 3 (rgb) and 4 (cmyk) are supported"
             )
 
     def do_scn(self) -> None:
@@ -869,7 +869,7 @@ class PDFPageInterpreter:
 
         else:
             log.warning(
-                f"Cannot set non-stroke color because {n} components are specified but only 1 (grayscale), 3 (rgb) and 4 (cmyk) are supported"
+                f"Cannot set non-stroke color because {len(components)} components are specified but only 1 (grayscale), 3 (rgb) and 4 (cmyk) are supported"
             )
 
     def do_SC(self) -> None:

--- a/pdfminer/pdfinterp.py
+++ b/pdfminer/pdfinterp.py
@@ -806,11 +806,13 @@ class PDFPageInterpreter:
 
         elif n == 4:
             values = self.pop(4)
-            cmyk = safe_cmyk(*values)
+            cmyk = None
+            if len(values) == 4:
+                cmyk = safe_cmyk(*values)
 
             if cmyk is None:
                 log.warning(
-                    f"Cannot set CMYK stroke color because not all values in {values!r} can be parsed as floats"
+                    f"Cannot set CMYK stroke color because values {values!r} cannot be parsed as CMYK"
                 )
             else:
                 self.graphicstate.scolor = cmyk
@@ -854,11 +856,13 @@ class PDFPageInterpreter:
 
         elif n == 4:
             values = self.pop(4)
-            cmyk = safe_cmyk(*values)
+            cmyk = None
+            if len(values) == 4:
+                cmyk = safe_cmyk(*values)
 
             if cmyk is None:
                 log.warning(
-                    f"Cannot set CMYK non-stroke color because not all values in {values!r} can be parsed as floats"
+                    f"Cannot set CMYK non-stroke color because values {values!r} cannot be parsed as CMYK"
                 )
             else:
                 self.graphicstate.ncolor = cmyk


### PR DESCRIPTION
**Pull request**

Check how many arguments are actually popped of the stack before calling `safe_rgb` or `safe_cmyk` with it. Raise a warning for the wrong number of arguments. 

**How Has This Been Tested?**

With the test cases in #1110.

**Checklist**

- [x] I have read [CONTRIBUTING.md](https://github.com/pdfminer/pdfminer.six/blob/master/CONTRIBUTING.md). 
- [x] I have added a concise human-readable description of the change to [CHANGELOG.md](https://github.com/pdfminer/pdfminer.six/blob/master/CHANGELOG.md).
- [x] I have tested that this fix is effective or that this feature works.
- [x] I have added docstrings to newly created methods and classes.
- [x] I have updated the [README.md](https://github.com/pdfminer/pdfminer.six/blob/master/README.md) and the [readthedocs](https://github.com/pdfminer/pdfminer.six/tree/master/docs/source) documentation. Or verified that this is not necessary.
