### PR TITLE
Fix: OverflowError in `safe_float` and `safe_int`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Fixed
 
 - Correct tightest fitting bounding boxes for rotated content ([#1114](https://github.com/pdfminer/pdfminer.six/pull/1114))
- 
+- `OverflowError` in `safe_float` and `safe_int` ([#1121](https://github.com/pdfminer/pdfminer.six/pull/1121))
+
 ## [20250416]
 
 ### Fixed
@@ -253,7 +254,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Hiding fallback xref by default from dumppdf.py output ([#431](https://github.com/pdfminer/pdfminer.six/pull/431))
 - Raise a warning instead of an error when extracting text from a non-extractable PDF ([#453](https://github.com/pdfminer/pdfminer.six/pull/453))
 - Switched from pycryptodome to cryptography package for AES decryption ([#456](https://github.com/pdfminer/pdfminer.six/pull/456))
-  
+
 ## [20200517]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Fixed
 
 - Correct tightest fitting bounding boxes for rotated content ([#1114](https://github.com/pdfminer/pdfminer.six/pull/1114))
-- `OverflowError` in `safe_float` and `safe_int` ([#1121](https://github.com/pdfminer/pdfminer.six/pull/1121))
+- `OverflowError` in `safe_float` when input is too large ([#1121](https://github.com/pdfminer/pdfminer.six/pull/1121))
 
 ## [20250416]
 

--- a/pdfminer/casting.py
+++ b/pdfminer/casting.py
@@ -17,7 +17,7 @@ def safe_int(o: Any) -> Optional[int]:
 def safe_float(o: Any) -> Optional[float]:
     try:
         return float(o)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return None
 
 

--- a/tests/test_casting.py
+++ b/tests/test_casting.py
@@ -2,7 +2,7 @@ from typing import Any, Optional
 
 import pytest
 
-from pdfminer.casting import safe_rect_list
+from pdfminer.casting import safe_float, safe_rect_list
 from pdfminer.utils import Rect
 
 
@@ -22,3 +22,19 @@ from pdfminer.utils import Rect
 )
 def test_safe_rect_list(arg: Any, expected: Optional[Rect]) -> None:
     assert safe_rect_list(arg) == expected
+
+
+@pytest.mark.parametrize(
+    ("arg", "expected"),
+    [
+        (0, 0.0),
+        (1, 1.0),
+        ("0", 0.0),
+        ("1.5", 1.5),
+        (None, None),
+        (object(), None),
+        (2**1024, None),  # Integer too large to convert to float
+    ],
+)
+def test_safe_float(arg: Any, expected: Optional[float]) -> None:
+    assert safe_float(arg) == expected


### PR DESCRIPTION
**Pull request**

Catch error and return `None` if raised. 

**How Has This Been Tested?**

Added tests.

**Checklist**

- [x] I have read [CONTRIBUTING.md](https://github.com/pdfminer/pdfminer.six/blob/master/CONTRIBUTING.md). 
- [x] I have added a concise human-readable description of the change to [CHANGELOG.md](https://github.com/pdfminer/pdfminer.six/blob/master/CHANGELOG.md).
- [x] I have tested that this fix is effective or that this feature works.
- [x] I have added docstrings to newly created methods and classes.
- [x] I have updated the [README.md](https://github.com/pdfminer/pdfminer.six/blob/master/README.md) and the [readthedocs](https://github.com/pdfminer/pdfminer.six/tree/master/docs/source) documentation. Or verified that this is not necessary.
