### PR TITLE
Remove padding from AES-encrypted strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Correct tightest fitting bounding boxes for rotated content ([#1114](https://github.com/pdfminer/pdfminer.six/pull/1114))
 - `OverflowError` in `safe_float` when input is too large ([#1121](https://github.com/pdfminer/pdfminer.six/pull/1121))
+- Remove padding from AES-encrypted strings([#1123](https://github.com/pdfminer/pdfminer.six/pull/1123))
 
 ## [20250416]
 

--- a/pdfminer/pdfdocument.py
+++ b/pdfminer/pdfdocument.py
@@ -52,6 +52,7 @@ from pdfminer.utils import (
     format_int_alpha,
     format_int_roman,
     nunpack,
+    unpad_aes,
 )
 
 log = logging.getLogger(__name__)
@@ -545,7 +546,8 @@ class PDFStandardSecurityHandlerV4(PDFStandardSecurityHandler):
             modes.CBC(initialization_vector),
             backend=default_backend(),
         )  # type: ignore
-        return cipher.decryptor().update(ciphertext)  # type: ignore
+        plaintext = cipher.decryptor().update(ciphertext)  # type: ignore
+        return unpad_aes(plaintext)
 
 
 class PDFStandardSecurityHandlerV5(PDFStandardSecurityHandlerV4):
@@ -669,7 +671,8 @@ class PDFStandardSecurityHandlerV5(PDFStandardSecurityHandlerV4):
             modes.CBC(initialization_vector),
             backend=default_backend(),
         )  # type: ignore
-        return cipher.decryptor().update(ciphertext)  # type: ignore
+        plaintext = cipher.decryptor().update(ciphertext)  # type: ignore
+        return unpad_aes(plaintext)
 
 
 class PDFDocument:

--- a/pdfminer/utils.py
+++ b/pdfminer/utils.py
@@ -862,3 +862,24 @@ def format_int_alpha(value: int) -> str:
 
     result.reverse()
     return "".join(result)
+
+
+def unpad_aes(padded: bytes) -> bytes:
+    """Remove block padding as described in PDF 1.7 section 7.6.2:
+
+    > For an original message length of M, the pad shall consist of 16 -
+    (M mod 16) bytes whose value shall also be 16 - (M mod 16).
+    > Note that the pad is present when M is evenly divisible by 16;
+    it contains 16 bytes of 0x10.
+    """
+    end = len(padded)
+    if end == 0:
+        return padded
+    if padded[end - 1] <= 16:
+        padding = padded[end - 1]
+        if padding <= end:
+            end -= padding
+            # Validate that it is really padding
+            if all(x == padding for x in padded[end:]):
+                return padded[:end]
+    return padded

--- a/tests/test_pdfminer_crypto.py
+++ b/tests/test_pdfminer_crypto.py
@@ -6,6 +6,7 @@ from pdfminer.arcfour import Arcfour
 from pdfminer.ascii85 import ascii85decode, asciihexdecode
 from pdfminer.lzw import lzwdecode
 from pdfminer.runlength import rldecode
+from pdfminer.utils import unpad_aes
 
 
 def hex(b):
@@ -71,3 +72,15 @@ class TestLzw:
 class TestRunlength:
     def test_rldecode(self):
         assert rldecode(b"\x05123456\xfa7\x04abcde\x80junk") == b"1234567777777abcde"
+
+
+class TestAES:
+    def test_unpad_aes(self):
+        assert unpad_aes(b"\x10" * 16) == b""
+        assert unpad_aes(b"0123456789abcdef" + b"\x10" * 16) == b"0123456789abcdef"
+        assert unpad_aes(b"0123456789abc\x03\x03\x03") == b"0123456789abc"
+        # NOTE: As per the spec these sorts of things should be padded
+        # with b"\x10" * 16, but it seems reasonable to be robust to the
+        # possibility of false padding bytes as well
+        assert unpad_aes(b"0123456789abc\x02\x03\x04") == b"0123456789abc\x02\x03\x04"
+        assert unpad_aes(b"0123456789abc\x05\x05\x05") == b"0123456789abc\x05\x05\x05"


### PR DESCRIPTION
Remove padding bytes as per PDF 1.7 section 7.6.2.  Fixes: #1122 

Tested with unit and regression tests.

**Checklist**

- [x] I have read [CONTRIBUTING.md](https://github.com/pdfminer/pdfminer.six/blob/master/CONTRIBUTING.md). 
- [x] I have added a concise human-readable description of the change to [CHANGELOG.md](https://github.com/pdfminer/pdfminer.six/blob/master/CHANGELOG.md).
- [x] I have tested that this fix is effective or that this feature works.
- [x] I have added docstrings to newly created methods and classes.
- [x] I have updated the [README.md](https://github.com/pdfminer/pdfminer.six/blob/master/README.md) and the [readthedocs](https://github.com/pdfminer/pdfminer.six/tree/master/docs/source) documentation. Or verified that this is not necessary.
