### PR TITLE
Fix: flipped R and B channels in extracted bmps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes in pdfminer.six will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [20250516]
+
+### Fixed
+
+- Remove `BMPWriter` and write BMP images with PIL
+- Remove extraneous invert of greyscale images introduced in ([#827](https://github.com/pdfminer/pdfminer.six/pull/827))
+
 ## [20250506]
 
 ## Added


### PR DESCRIPTION
**Pull request**

Fixes https://github.com/pdfminer/pdfminer.six/issues/888.
Also removes an extraneous invert of greyscale image introduced in https://github.com/pdfminer/pdfminer.six/pull/827. This invert was introduced for the image in https://github.com/pdfminer/pdfminer.six/issues/795. However this only seemed correct because this image has an Indexed Colorspace that maps [0, 181] to [white, black].

**How Has This Been Tested?**

Looking at extracted images

**Checklist**

- [x] I have read [CONTRIBUTING.md](https://github.com/pdfminer/pdfminer.six/blob/master/CONTRIBUTING.md). 
- [x] I have added a concise human-readable description of the change to [CHANGELOG.md](https://github.com/pdfminer/pdfminer.six/blob/master/CHANGELOG.md).
- [x] I have tested that this fix is effective or that this feature works.
- [x] I have added docstrings to newly created methods and classes.
- [x] I have updated the [README.md](https://github.com/pdfminer/pdfminer.six/blob/master/README.md) and the [readthedocs](https://github.com/pdfminer/pdfminer.six/tree/master/docs/source) documentation. Or verified that this is not necessary.
