### PR TITLE
Fix tabbing of else clause in __init__

### DIFF
--- a/pdfminer/pdfdocument.py
+++ b/pdfminer/pdfdocument.py
@@ -748,8 +748,8 @@ class PDFDocument:
                 # Every PDF file must have exactly one /Root dictionary.
                 self.catalog = dict_value(trailer["Root"])
                 break
-        else:
-            raise PDFSyntaxError("No /Root object! - Is this really a PDF?")
+            else:
+                raise PDFSyntaxError("No /Root object! - Is this really a PDF?")
         if self.catalog.get("Type") is not LITERAL_CATALOG:
             if settings.STRICT:
                 raise PDFSyntaxError("Catalog not found!")


### PR DESCRIPTION
**Pull request**

Fixes #1131 

**How Has This Been Tested?**

Applying this fix locally fixed the bug.

**Checklist**

- [X] I have read [CONTRIBUTING.md](https://github.com/pdfminer/pdfminer.six/blob/master/CONTRIBUTING.md). 
- [ ] I have added a concise human-readable description of the change to [CHANGELOG.md](https://github.com/pdfminer/pdfminer.six/blob/master/CHANGELOG.md).
- [X] I have tested that this fix is effective or that this feature works.
- [X] I have added docstrings to newly created methods and classes.
- [X] I have updated the [README.md](https://github.com/pdfminer/pdfminer.six/blob/master/README.md) and the [readthedocs](https://github.com/pdfminer/pdfminer.six/tree/master/docs/source) documentation. Or verified that this is not necessary.
