### PR TITLE
Fix typo in FontBBox parsing warning message

### DIFF
--- a/pdfminer/pdffont.py
+++ b/pdfminer/pdffont.py
@@ -965,7 +965,7 @@ class PDFFont:
         bbox = safe_rect_list(font_bbox)
         if bbox is None:
             log.warning(
-                f"Could get FontBBox from font descriptor because {font_bbox!r} cannot be parsed as 4 floats"
+                f"Could not get FontBBox from font descriptor because {font_bbox!r} cannot be parsed as 4 floats"
             )
             return 0.0, 0.0, 0.0, 0.0
         return bbox


### PR DESCRIPTION
Changed "Could get" to "Could not get" in the warning message when FontBBox cannot be parsed as 4 floats.

The previous message was incorrect ("Could get... because it cannot be parsed"). This change corrects the phrasing to accurately reflect that the FontBBox value could not be obtained due to a parsing error.