### PR TITLE
fix: color space is not correctly pushed into gstack

### DIFF
--- a/pdfminer/pdfinterp.py
+++ b/pdfminer/pdfinterp.py
@@ -156,7 +156,11 @@ class PDFGraphicState:
         obj.intent = self.intent
         obj.flatness = self.flatness
         obj.scolor = self.scolor
+        obj.scs.name = self.scs.name
+        obj.scs.ncomponents = self.scs.ncomponents
         obj.ncolor = self.ncolor
+        obj.ncs.name = self.ncs.name
+        obj.ncs.ncomponents = self.ncs.ncomponents
         return obj
 
     def __repr__(self) -> str:


### PR DESCRIPTION
Fix #1139 

In [20250506](https://github.com/pdfminer/pdfminer.six/releases/tag/20250506), color spaces are saved into the graphics stack, but `ncs` and `scs` are missing when doing `graphicstate.copy()` and become the default gray color space

**Checklist**

- [x] I have read [CONTRIBUTING.md](https://github.com/pdfminer/pdfminer.six/blob/master/CONTRIBUTING.md). 
- [ ] I have added a concise human-readable description of the change to [CHANGELOG.md](https://github.com/pdfminer/pdfminer.six/blob/master/CHANGELOG.md).
- [x] I have tested that this fix is effective or that this feature works.
- [ ] I have added docstrings to newly created methods and classes.
- [x] I have updated the [README.md](https://github.com/pdfminer/pdfminer.six/blob/master/README.md) and the [readthedocs](https://github.com/pdfminer/pdfminer.six/tree/master/docs/source) documentation. Or verified that this is not necessary.
