### PR TITLE
Fix: image export with no filters

### DIFF
--- a/pdfminer/image.py
+++ b/pdfminer/image.py
@@ -109,10 +109,10 @@ class ImageWriter:
 
         filters = image.stream.get_filters()
 
-        if filters[-1][0] in LITERALS_DCT_DECODE:
+        if filters and filters[-1][0] in LITERALS_DCT_DECODE:
             name = self._save_jpeg(image)
 
-        elif filters[-1][0] in LITERALS_JPX_DECODE:
+        elif filters and filters[-1][0] in LITERALS_JPX_DECODE:
             name = self._save_jpeg2000(image)
 
         elif self._is_jbig2_iamge(image):


### PR DESCRIPTION
**Pull request**
Fixes #1151.

**How Has This Been Tested?**
Locally with the PDF that was failing with the MRE I provided in the #1151.

**Checklist**

- [x] I have read [CONTRIBUTING.md](https://github.com/pdfminer/pdfminer.six/blob/master/CONTRIBUTING.md). 
- [x] I have added a concise human-readable description of the change to [CHANGELOG.md](https://github.com/pdfminer/pdfminer.six/blob/master/CHANGELOG.md).
- [x] I have tested that this fix is effective or that this feature works.
- [x] I have added docstrings to newly created methods and classes.
- [x] I have updated the [README.md](https://github.com/pdfminer/pdfminer.six/blob/master/README.md) and the [readthedocs](https://github.com/pdfminer/pdfminer.six/tree/master/docs/source) documentation. Or verified that this is not necessary.
