### PR TITLE
fix: encapsulate errors when failing to get attribute from stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Support cmap types 6, 10 and 12 ([#598](https://github.com/pdfminer/pdfminer.six/pull/1213))
 
+### Fixed
+
+- Encapsulate errors when failing to get attribute from stream ([#1181](https://github.com/pdfminer/pdfminer.six/pull/1181))
+
 ## [20251230]
 
 ### Security

--- a/pdfminer/pdftypes.py
+++ b/pdfminer/pdftypes.py
@@ -15,6 +15,7 @@ from pdfminer import pdfexceptions, settings
 from pdfminer.ascii85 import ascii85decode, asciihexdecode
 from pdfminer.ccitt import ccittfaxdecode
 from pdfminer.lzw import lzwdecode
+from pdfminer.pdfexceptions import PDFKeyError
 from pdfminer.psparser import LIT, PSObject
 from pdfminer.runlength import rldecode
 from pdfminer.utils import apply_png_predictor, apply_tiff_predictor
@@ -272,7 +273,12 @@ class PDFStream(PDFObject):
         return name in self.attrs
 
     def __getitem__(self, name: str) -> Any:
-        return self.attrs[name]
+        try:
+            return self.attrs[name]
+        except KeyError as e:
+            raise PDFKeyError(
+                f"PDF stream object {self.objid} does not have attribute '{name}'"
+            ) from e
 
     def get(self, name: str, default: object = None) -> Any:
         return self.attrs.get(name, default)


### PR DESCRIPTION
**Pull request**

Related to #1181

Please *remove* this paragraph and replace it with a description of your PR. Also include the issue that it fixes.

**How Has This Been Tested?**

Please *remove* this paragraph with a description of how this PR has been tested.

**Checklist**

- [ ] I have read [CONTRIBUTING.md](https://github.com/pdfminer/pdfminer.six/blob/master/CONTRIBUTING.md).
- [ ] I have added a concise human-readable description of the change to [CHANGELOG.md](https://github.com/pdfminer/pdfminer.six/blob/master/CHANGELOG.md).
- [ ] I have tested that this fix is effective or that this feature works.
- [ ] I have added docstrings to newly created methods and classes.
- [ ] I have updated the [README.md](https://github.com/pdfminer/pdfminer.six/blob/master/README.md) and the [readthedocs](https://github.com/pdfminer/pdfminer.six/tree/master/docs/source) documentation. Or verified that this is not necessary.
