### PR TITLE
fix: validate maximum size of xref start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Encapsulate error when failing to get attribute or data from stream ([#1225](https://github.com/pdfminer/pdfminer.six/pull/1225), [#1226](https://github.com/pdfminer/pdfminer.six/pull/1226))
+- Validate maximum size of xref start ([#1227](https://github.com/pdfminer/pdfminer.six/pull/1227))
 
 ## [20251230]
 

--- a/pdfminer/pdfdocument.py
+++ b/pdfminer/pdfdocument.py
@@ -959,12 +959,16 @@ class PDFDocument:
                 log.debug("xref found: pos=%r", prev)
 
                 if not prev.isdigit():
-                    raise PDFNoValidXRef(f"Invalid xref position: {prev!r}")
+                    raise PDFNoValidXRef(f"Invalid xref position, no digit: {prev!r}")
 
                 start = int(prev)
 
                 if not start >= 0:
-                    raise PDFNoValidXRef(f"Invalid negative xref position: {start}")
+                    raise PDFNoValidXRef(f"Invalid xref position, negative: {start}")
+
+                # The xref start needs to fit in a C ssize_t to be a proper file offset
+                if start >= 2**31:
+                    raise PDFNoValidXRef(f"Invalid xref position, too large: {start!r}")
 
                 return start
 


### PR DESCRIPTION
**Pull request**

Please *remove* this paragraph and replace it with a description of your PR. Also include the issue that it fixes.

**How Has This Been Tested?**

Please *remove* this paragraph with a description of how this PR has been tested.

**Checklist**

- [ ] I have read [CONTRIBUTING.md](https://github.com/pdfminer/pdfminer.six/blob/master/CONTRIBUTING.md).
- [ ] I have added a concise human-readable description of the change to [CHANGELOG.md](https://github.com/pdfminer/pdfminer.six/blob/master/CHANGELOG.md).
- [ ] I have tested that this fix is effective or that this feature works.
- [ ] I have added docstrings to newly created methods and classes.
- [ ] I have updated the [README.md](https://github.com/pdfminer/pdfminer.six/blob/master/README.md) and the [readthedocs](https://github.com/pdfminer/pdfminer.six/tree/master/docs/source) documentation. Or verified that this is not necessary.
