### PR TITLE
perf: use lazy %-style logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Encapsulate error when failing to get attribute or data from stream ([#1225](https://github.com/pdfminer/pdfminer.six/pull/1225), [#1226](https://github.com/pdfminer/pdfminer.six/pull/1226))
 - Validate maximum size of xref start ([#1227](https://github.com/pdfminer/pdfminer.six/pull/1227))
+- Use lazy %-style formatting for logging ([#1234](https://github.com/pdfminer/pdfminer.six/pull/1234))
 
 ### Removed
 

--- a/pdfminer/cmapdb.py
+++ b/pdfminer/cmapdb.py
@@ -504,4 +504,4 @@ class CMapParser(PSStackParser[PSKeyword]):
                 "does not conform to the format. This could result in "
                 "(cid) values in the output. "
             )
-            log.warning(base_msg + msg)
+            log.warning("%s%s", base_msg, msg)

--- a/pdfminer/converter.py
+++ b/pdfminer/converter.py
@@ -264,7 +264,7 @@ class PDFLayoutAnalyzer(PDFTextDevice):
         return item.adv
 
     def handle_undefined_char(self, font: PDFFont, cid: int) -> str:
-        log.debug(f"undefined: {font!r}, {cid!r}")
+        log.debug("undefined: %r, %r", font, cid)
         return f"(cid:{cid})"
 
     def receive_layout(self, ltpage: LTPage) -> None:

--- a/pdfminer/pdfdevice.py
+++ b/pdfminer/pdfdevice.py
@@ -186,8 +186,9 @@ class PDFTextDevice(PDFDevice):
                     needcharspace = True
             else:
                 logger.warning(
-                    f"Cannot render horizontal string because "
-                    f"{obj!r} is not a valid int, float or bytes."
+                    "Cannot render horizontal string because "
+                    "%r is not a valid int, float or bytes.",
+                    obj,
                 )
         return (x, y)
 
@@ -231,8 +232,9 @@ class PDFTextDevice(PDFDevice):
                     needcharspace = True
             else:
                 logger.warning(
-                    f"Cannot render vertical string because {obj!r} is not a valid "
-                    f"int, float or bytes."
+                    "Cannot render vertical string because %r is not a valid "
+                    "int, float or bytes.",
+                    obj,
                 )
         return (x, y)
 

--- a/pdfminer/pdfdocument.py
+++ b/pdfminer/pdfdocument.py
@@ -170,8 +170,11 @@ class PDFXRef(PDFBaseXRef):
                     self.offsets[objid] = (None, pos_i, genno_i)
                 else:
                     log.warning(
-                        f"Not adding object {objid} to xref because position {pos_b!r} "
-                        f"or generation number {genno_b!r} cannot be parsed as an int"
+                        "Not adding object %s to xref because position %r "
+                        "or generation number %r cannot be parsed as an int",
+                        objid,
+                        pos_b,
+                        genno_b,
                     )
 
         log.debug("xref objects: %r", self.offsets)

--- a/pdfminer/pdffont.py
+++ b/pdfminer/pdffont.py
@@ -72,14 +72,17 @@ def get_widths(seq: Iterable[object]) -> dict[str | int, float]:
                         widths[i] = w
                 else:
                     log.warning(
-                        f"Skipping invalid font width specification for {char1} to "
-                        f"{char2} because either of them is not an int"
+                        "Skipping invalid font width specification for %s to "
+                        "%s because either of them is not an int",
+                        char1,
+                        char2,
                     )
                 r = []
         else:
             log.warning(
-                f"Skipping invalid font width specification for {v} "
-                f"because it is not a number or a list"
+                "Skipping invalid font width specification for %s "
+                "because it is not a number or a list",
+                v,
             )
     return cast(dict[str | int, float], widths)
 
@@ -786,13 +789,13 @@ class TrueTypeFont:
     def parse_cmap_format_0(self, fp: BinaryIO, char2gid: dict[int, int]) -> None:
         """Parse cmap subtable format 0"""
         fmtlen, fmtlang = struct.unpack(">HH", fp.read(4))
-        log.debug(f"parse_cmap_format: {fmtlen=}, {fmtlang=}")
+        log.debug("parse_cmap_format: fmtlen=%s, fmtlang=%s", fmtlen, fmtlang)
         char2gid.update(enumerate(struct.unpack(">256B", fp.read(256))))
 
     def parse_cmap_format_2(self, fp: BinaryIO, char2gid: dict[int, int]) -> None:
         """Parse cmap subtable format 2"""
         fmtlen, fmtlang = struct.unpack(">HH", fp.read(4))
-        log.debug(f"parse_cmap_format: {fmtlen=}, {fmtlang=}")
+        log.debug("parse_cmap_format: fmtlen=%s, fmtlang=%s", fmtlen, fmtlang)
         subheaderkeys = struct.unpack(">256H", fp.read(512))
         firstbytes = [0] * 8192
         for i, k in enumerate(subheaderkeys):
@@ -816,7 +819,7 @@ class TrueTypeFont:
     def parse_cmap_format_4(self, fp: BinaryIO, char2gid: dict[int, int]) -> None:
         """Parse cmap subtable format 4"""
         fmtlen, fmtlang = struct.unpack(">HH", fp.read(4))
-        log.debug(f"parse_cmap_format: {fmtlen=}, {fmtlang=}")
+        log.debug("parse_cmap_format: fmtlen=%s, fmtlang=%s", fmtlen, fmtlang)
         (segcount, _1, _2, _3) = struct.unpack(">HHHH", fp.read(8))
         segcount //= 2
         ecs = struct.unpack(f">{segcount}H", fp.read(2 * segcount))
@@ -838,7 +841,7 @@ class TrueTypeFont:
     def parse_cmap_format_6(self, fp: BinaryIO, char2gid: dict[int, int]) -> None:
         """Parse cmap subtable format 6"""
         fmtlen, fmtlang = struct.unpack(">HH", fp.read(4))
-        log.debug(f"parse_cmap_format: {fmtlen=}, {fmtlang=}")
+        log.debug("parse_cmap_format: fmtlen=%s, fmtlang=%s", fmtlen, fmtlang)
         firstcode, entcount = struct.unpack(">HH", fp.read(4))
         gids = struct.unpack(f">{entcount}H", fp.read(2 * entcount))
         for i in range(entcount):
@@ -847,7 +850,9 @@ class TrueTypeFont:
     def parse_cmap_format_10(self, fp: BinaryIO, char2gid: dict[int, int]) -> None:
         """Parse cmap subtable format 10"""
         rsv, fmtlen, fmtlang = struct.unpack(">HII", fp.read(10))
-        log.debug(f"parse_cmap_format: {rsv=}, {fmtlen=}, {fmtlang=}")
+        log.debug(
+            "parse_cmap_format: rsv=%s, fmtlen=%s, fmtlang=%s", rsv, fmtlen, fmtlang
+        )
         startcode, numchars = struct.unpack(">II", fp.read(8))
         gids = struct.unpack(f">{numchars}H", fp.read(2 * numchars))
         for i in range(numchars):
@@ -856,7 +861,9 @@ class TrueTypeFont:
     def parse_cmap_format_12(self, fp: BinaryIO, char2gid: dict[int, int]) -> None:
         """Parse cmap subtable format 12"""
         rsv, fmtlen, fmtlang = struct.unpack(">HII", fp.read(10))
-        log.debug(f"parse_cmap_format: {rsv=}, {fmtlen=}, {fmtlang=}")
+        log.debug(
+            "parse_cmap_format: rsv=%s, fmtlen=%s, fmtlang=%s", rsv, fmtlen, fmtlang
+        )
         numgroups = struct.unpack(">I", fp.read(4))[0]
         for _i in range(numgroups):
             sc, ec, sgid = struct.unpack(">III", fp.read(12))
@@ -980,8 +987,9 @@ class PDFFont:
         bbox = safe_rect_list(font_bbox)
         if bbox is None:
             log.warning(
-                f"Could not get FontBBox from font descriptor because "
-                f"{font_bbox!r} cannot be parsed as 4 floats"
+                "Could not get FontBBox from font descriptor because "
+                "%r cannot be parsed as 4 floats",
+                font_bbox,
             )
             return 0.0, 0.0, 0.0, 0.0
         return bbox

--- a/pdfminer/pdfinterp.py
+++ b/pdfminer/pdfinterp.py
@@ -491,8 +491,8 @@ class PDFPageInterpreter:
         if matrix is None:
             log.warning(
                 "Cannot concatenate matrix to current transformation matrix "
-                f"because not all values in {(a1, b1, c1, d1, e1, f1)!r} "
-                "can be parsed as floats"
+                "because not all values in %r can be parsed as floats",
+                (a1, b1, c1, d1, e1, f1),
             )
         else:
             self.ctm = mult_matrix(matrix, self.ctm)
@@ -503,7 +503,8 @@ class PDFPageInterpreter:
         linewidth_f = safe_float(linewidth)
         if linewidth_f is None:
             log.warning(
-                f"Cannot set line width because {linewidth!r} is an invalid float value"
+                "Cannot set line width because %r is an invalid float value",
+                linewidth,
             )
         else:
             scale = (self.ctm[0] ** 2 + self.ctm[1] ** 2) ** 0.5
@@ -546,7 +547,8 @@ class PDFPageInterpreter:
             point = ("m", x, y)
             log.warning(
                 "Cannot start new subpath because not all values "
-                f"in {point!r} can be parsed as floats"
+                "in %r can be parsed as floats",
+                point,
             )
         else:
             point = ("m", x_f, y_f)
@@ -560,7 +562,8 @@ class PDFPageInterpreter:
             point = ("l", x, y)
             log.warning(
                 "Cannot append straight line segment to path "
-                f"because not all values in {point!r} can be parsed as floats"
+                "because not all values in %r can be parsed as floats",
+                point,
             )
         else:
             point = ("l", x_f, y_f)
@@ -593,7 +596,8 @@ class PDFPageInterpreter:
             point = ("c", x1, y1, x2, y2, x3, y3)
             log.warning(
                 "Cannot append curved segment to path "
-                f"because not all values in {point!r} can be parsed as floats"
+                "because not all values in %r can be parsed as floats",
+                point,
             )
         else:
             point = ("c", x1_f, y1_f, x2_f, y2_f, x3_f, y3_f)
@@ -609,7 +613,8 @@ class PDFPageInterpreter:
             point = ("v", x2, y2, x3, y3)
             log.warning(
                 "Cannot append curved segment to path "
-                f"because not all values in {point!r} can be parsed as floats"
+                "because not all values in %r can be parsed as floats",
+                point,
             )
         else:
             point = ("v", x2_f, y2_f, x3_f, y3_f)
@@ -625,7 +630,8 @@ class PDFPageInterpreter:
             point = ("y", x1, y1, x3, y3)
             log.warning(
                 "Cannot append curved segment to path "
-                f"because not all values in {point!r} can be parsed as floats"
+                "because not all values in %r can be parsed as floats",
+                point,
             )
         else:
             point = ("y", x1_f, y1_f, x3_f, y3_f)
@@ -646,7 +652,8 @@ class PDFPageInterpreter:
             values = (x, y, w, h)
             log.warning(
                 "Cannot append rectangle to path "
-                f"because not all values in {values!r} can be parsed as floats"
+                "because not all values in %r can be parsed as floats",
+                values,
             )
         else:
             self.curpath.append(("m", x_f, y_f))
@@ -733,7 +740,8 @@ class PDFPageInterpreter:
 
         if gray_f is None:
             log.warning(
-                f"Cannot set gray level because {gray!r} is an invalid float value"
+                "Cannot set gray level because %r is an invalid float value",
+                gray,
             )
         else:
             self.graphicstate.scolor = gray_f
@@ -745,7 +753,8 @@ class PDFPageInterpreter:
 
         if gray_f is None:
             log.warning(
-                f"Cannot set gray level because {gray!r} is an invalid float value"
+                "Cannot set gray level because %r is an invalid float value",
+                gray,
             )
         else:
             self.graphicstate.ncolor = gray_f
@@ -758,7 +767,8 @@ class PDFPageInterpreter:
         if rgb is None:
             log.warning(
                 "Cannot set RGB stroke color "
-                f"because not all values in {(r, g, b)!r} can be parsed as floats"
+                "because not all values in %r can be parsed as floats",
+                (r, g, b),
             )
         else:
             self.graphicstate.scolor = rgb
@@ -771,7 +781,8 @@ class PDFPageInterpreter:
         if rgb is None:
             log.warning(
                 "Cannot set RGB non-stroke color "
-                f"because not all values in {(r, g, b)!r} can be parsed as floats"
+                "because not all values in %r can be parsed as floats",
+                (r, g, b),
             )
         else:
             self.graphicstate.ncolor = rgb
@@ -784,7 +795,8 @@ class PDFPageInterpreter:
         if cmyk is None:
             log.warning(
                 "Cannot set CMYK stroke color "
-                f"because not all values in {(c, m, y, k)!r} can be parsed as floats"
+                "because not all values in %r can be parsed as floats",
+                (c, m, y, k),
             )
         else:
             self.graphicstate.scolor = cmyk
@@ -797,7 +809,8 @@ class PDFPageInterpreter:
         if cmyk is None:
             log.warning(
                 "Cannot set CMYK non-stroke color "
-                f"because not all values in {(c, m, y, k)!r} can be parsed as floats"
+                "because not all values in %r can be parsed as floats",
+                (c, m, y, k),
             )
         else:
             self.graphicstate.ncolor = cmyk
@@ -819,8 +832,9 @@ class PDFPageInterpreter:
             gray = safe_float(components[0])
             if gray is None:
                 log.warning(
-                    f"Cannot set {context} color: "
-                    f"{components[0]!r} is an invalid float value"
+                    "Cannot set %s color: %r is an invalid float value",
+                    context,
+                    components[0],
                 )
             return gray
 
@@ -828,8 +842,9 @@ class PDFPageInterpreter:
             rgb = safe_rgb(*components)
             if rgb is None:
                 log.warning(
-                    f"Cannot set {context} color: "
-                    f"components {components!r} cannot be parsed as RGB"
+                    "Cannot set %s color: components %r cannot be parsed as RGB",
+                    context,
+                    components,
                 )
             return rgb
 
@@ -837,16 +852,18 @@ class PDFPageInterpreter:
             cmyk = safe_cmyk(*components)
             if cmyk is None:
                 log.warning(
-                    f"Cannot set {context} color: "
-                    f"components {components!r} cannot be parsed as CMYK"
+                    "Cannot set %s color: components %r cannot be parsed as CMYK",
+                    context,
+                    components,
                 )
             return cmyk
 
         else:
             log.warning(
-                f"Cannot set {context} color: "
-                f"{len(components)} components specified, "
-                "but only 1 (grayscale), 3 (RGB), and 4 (CMYK) are supported"
+                "Cannot set %s color: %d components specified, "
+                "but only 1 (grayscale), 3 (RGB), and 4 (CMYK) are supported",
+                context,
+                len(components),
             )
             return None
 
@@ -863,8 +880,9 @@ class PDFPageInterpreter:
         components = self.pop(n)
         if len(components) != n:
             log.warning(
-                "Cannot set stroke color because "
-                f"expected {n} components but got {components!r}"
+                "Cannot set stroke color because expected %d components but got %r",
+                n,
+                components,
             )
 
         elif self.graphicstate.scs.name != "Pattern":
@@ -881,11 +899,13 @@ class PDFPageInterpreter:
             # Per spec: pattern name must be a name object (PSLiteral)
             if not isinstance(pattern_component, PSLiteral):
                 log.warning(
-                    f"Pattern color space requires name object (PSLiteral), "
-                    f"got {type(pattern_component).__name__}: {pattern_component!r}. "
+                    "Pattern color space requires name object (PSLiteral), "
+                    "got %s: %r. "
                     "Per ISO 32000 8.7.3.2, colored patterns use syntax '/name SCN'. "
                     "Per ISO 32000 8.7.3.3, uncolored patterns use "
-                    "syntax 'c1...cn /name SCN'."
+                    "syntax 'c1...cn /name SCN'.",
+                    type(pattern_component).__name__,
+                    pattern_component,
                 )
                 return
 
@@ -894,7 +914,7 @@ class PDFPageInterpreter:
             if len(components) == 1:
                 # Colored tiling pattern (PaintType=1): just pattern name
                 self.graphicstate.scolor = pattern_name
-                log.debug(f"Set stroke pattern (colored): {pattern_name}")
+                log.debug("Set stroke pattern (colored): %s", pattern_name)
             else:
                 # Uncolored tiling pattern (PaintType=2):
                 # color components + pattern name
@@ -910,7 +930,7 @@ class PDFPageInterpreter:
                 # Store as tuple: (base_color, pattern_name)
                 self.graphicstate.scolor = (base_color, pattern_name)
                 log.debug(
-                    f"Set stroke pattern (uncolored): {base_color} + {pattern_name}"
+                    "Set stroke pattern (uncolored): %s + %s", base_color, pattern_name
                 )
 
     def do_scn(self) -> None:
@@ -926,8 +946,9 @@ class PDFPageInterpreter:
         components = self.pop(n)
         if len(components) != n:
             log.warning(
-                "Cannot set non-stroke color because "
-                f"expected {n} components but got {components!r}"
+                "Cannot set non-stroke color because expected %d components but got %r",
+                n,
+                components,
             )
 
         elif self.graphicstate.ncs.name != "Pattern":
@@ -944,11 +965,13 @@ class PDFPageInterpreter:
             # Per spec: pattern name must be a name object (PSLiteral)
             if not isinstance(pattern_component, PSLiteral):
                 log.warning(
-                    f"Pattern color space requires name object (PSLiteral), "
-                    f"got {type(pattern_component).__name__}: {pattern_component!r}. "
+                    "Pattern color space requires name object (PSLiteral), "
+                    "got %s: %r. "
                     "Per ISO 32000 8.7.3.2, colored patterns use syntax '/name scn'. "
                     "Per ISO 32000 8.7.3.3, uncolored patterns use "
-                    "syntax 'c1...cn /name scn'."
+                    "syntax 'c1...cn /name scn'.",
+                    type(pattern_component).__name__,
+                    pattern_component,
                 )
                 return
 
@@ -957,7 +980,7 @@ class PDFPageInterpreter:
             if len(components) == 1:
                 # Colored tiling pattern (PaintType=1): just pattern name
                 self.graphicstate.ncolor = pattern_name
-                log.debug(f"Set non-stroke pattern (colored): {pattern_name}")
+                log.debug("Set non-stroke pattern (colored): %s", pattern_name)
             else:
                 # Uncolored tiling pattern (PaintType=2):
                 # color components + pattern name
@@ -973,7 +996,9 @@ class PDFPageInterpreter:
                 # Store as tuple: (base_color, pattern_name)
                 self.graphicstate.ncolor = (base_color, pattern_name)
                 log.debug(
-                    f"Set non-stroke pattern (uncolored): {base_color} + {pattern_name}"
+                    "Set non-stroke pattern (uncolored): %s + %s",
+                    base_color,
+                    pattern_name,
                 )
 
     def do_SC(self) -> None:
@@ -1011,7 +1036,8 @@ class PDFPageInterpreter:
             self.device.do_tag(tag)
         else:
             log.warning(
-                f"Cannot define marked-content point because {tag!r} is not a PSLiteral"
+                "Cannot define marked-content point because %r is not a PSLiteral",
+                tag,
             )
 
     def do_DP(self, tag: PDFStackT, props: PDFStackT) -> None:
@@ -1021,7 +1047,8 @@ class PDFPageInterpreter:
         else:
             log.warning(
                 "Cannot define marked-content point with property list "
-                f"because {tag!r} is not a PSLiteral"
+                "because %r is not a PSLiteral",
+                tag,
             )
 
     def do_BMC(self, tag: PDFStackT) -> None:
@@ -1030,8 +1057,8 @@ class PDFPageInterpreter:
             self.device.begin_tag(tag)
         else:
             log.warning(
-                "Cannot begin marked-content sequence because "
-                f"{tag!r} is not a PSLiteral"
+                "Cannot begin marked-content sequence because %r is not a PSLiteral",
+                tag,
             )
 
     def do_BDC(self, tag: PDFStackT, props: PDFStackT) -> None:
@@ -1040,8 +1067,9 @@ class PDFPageInterpreter:
             self.device.begin_tag(tag, props)
         else:
             log.warning(
-                f"Cannot begin marked-content sequence with property list "
-                f"because {tag!r} is not a PSLiteral"
+                "Cannot begin marked-content sequence with property list "
+                "because %r is not a PSLiteral",
+                tag,
             )
 
     def do_EMC(self) -> None:
@@ -1058,8 +1086,8 @@ class PDFPageInterpreter:
         charspace = safe_float(space)
         if charspace is None:
             log.warning(
-                "Could not set character spacing because "
-                f"{space!r} is an invalid float value"
+                "Could not set character spacing because %r is an invalid float value",
+                space,
             )
         else:
             self.textstate.charspace = charspace
@@ -1074,8 +1102,8 @@ class PDFPageInterpreter:
         wordspace = safe_float(space)
         if wordspace is None:
             log.warning(
-                "Could not set word spacing because "
-                f"{space!r} is an invalid float value"
+                "Could not set word spacing because %r is an invalid float value",
+                space,
             )
         else:
             self.textstate.wordspace = wordspace
@@ -1089,8 +1117,8 @@ class PDFPageInterpreter:
 
         if scale_f is None:
             log.warning(
-                "Could not set horizontal scaling because "
-                f"{scale!r} is an invalid float value"
+                "Could not set horizontal scaling because %r is an invalid float value",
+                scale,
             )
         else:
             self.textstate.scaling = scale_f
@@ -1105,8 +1133,8 @@ class PDFPageInterpreter:
         leading_f = safe_float(leading)
         if leading_f is None:
             log.warning(
-                "Could not set text leading because "
-                f"{leading!r} is an invalid float value"
+                "Could not set text leading because %r is an invalid float value",
+                leading,
             )
         else:
             self.textstate.leading = -leading_f
@@ -1128,8 +1156,8 @@ class PDFPageInterpreter:
         fontsize_f = safe_float(fontsize)
         if fontsize_f is None:
             log.warning(
-                f"Could not set text font because "
-                f"{fontsize!r} is an invalid float value"
+                "Could not set text font because %r is an invalid float value",
+                fontsize,
             )
         else:
             self.textstate.fontsize = fontsize_f
@@ -1140,8 +1168,8 @@ class PDFPageInterpreter:
 
         if render_i is None:
             log.warning(
-                "Could not set text rendering mode because "
-                f"{render!r} is an invalid int value"
+                "Could not set text rendering mode because %r is an invalid int value",
+                render,
             )
         else:
             self.textstate.render = render_i
@@ -1155,7 +1183,8 @@ class PDFPageInterpreter:
 
         if rise_f is None:
             log.warning(
-                f"Could not set text rise because {rise!r} is an invalid float value"
+                "Could not set text rise because %r is an invalid float value",
+                rise,
             )
         else:
             self.textstate.rise = rise_f
@@ -1216,8 +1245,9 @@ class PDFPageInterpreter:
 
         if matrix is None:
             log.warning(
-                f"Could not set text matrix because "
-                f"not all values in {values!r} can be parsed as floats"
+                "Could not set text matrix because "
+                "not all values in %r can be parsed as floats",
+                values,
             )
         else:
             self.textstate.matrix = matrix

--- a/pdfminer/psparser.py
+++ b/pdfminer/psparser.py
@@ -176,7 +176,7 @@ class PSBaseParser:
 
     def seek(self, pos: int) -> None:
         """Seeks the parser to the given position."""
-        log.debug(f"seek: {pos!r}")
+        log.debug("seek: %r", pos)
         self.fp.seek(pos)
         # reset the status for nextline()
         self.bufpos = pos
@@ -225,7 +225,7 @@ class PSBaseParser:
             else:
                 linebuf += self.buf[self.charpos :]
                 self.charpos = len(self.buf)
-        log.debug(f"nextline: {linepos!r}, {linebuf!r}")
+        log.debug("nextline: %r, %r", linepos, linebuf)
 
         return (linepos, linebuf)
 
@@ -502,7 +502,7 @@ class PSBaseParser:
                 if not self._tokens:
                     raise
         token = self._tokens.pop(0)
-        log.debug(f"nexttoken: {token!r}")
+        log.debug("nexttoken: %r", token)
         return token
 
 
@@ -549,7 +549,7 @@ class PSStackParser(PSBaseParser, Generic[ExtraT]):
 
     def add_results(self, *objs: PSStackEntry[ExtraT]) -> None:
         try:
-            log.debug(f"add_results: {objs!r}")
+            log.debug("add_results: %r", objs)
         except Exception:
             log.debug("add_results: (unprintable object)")
         self.results.extend(objs)
@@ -557,14 +557,14 @@ class PSStackParser(PSBaseParser, Generic[ExtraT]):
     def start_type(self, pos: int, type: str) -> None:
         self.context.append((pos, self.curtype, self.curstack))
         (self.curtype, self.curstack) = (type, [])
-        log.debug(f"start_type: pos={pos!r}, type={type!r}")
+        log.debug("start_type: pos=%r, type=%r", pos, type)
 
     def end_type(self, type: str) -> tuple[int, list[PSStackType[ExtraT]]]:
         if self.curtype != type:
             raise PSTypeError(f"Type mismatch: {self.curtype!r} != {type!r}")
         objs = [obj for (_, obj) in self.curstack]
         (pos, self.curtype, self.curstack) = self.context.pop()
-        log.debug(f"end_type: pos={pos!r}, type={type!r}, objs={objs!r}")
+        log.debug("end_type: pos=%r, type=%r, objs=%r", pos, type, objs)
         return (pos, objs)
 
     def do_keyword(self, pos: int, token: PSKeyword) -> None:
@@ -624,13 +624,18 @@ class PSStackParser(PSBaseParser, Generic[ExtraT]):
                         raise
             elif isinstance(token, PSKeyword):
                 log.debug(
-                    f"do_keyword: pos={pos!r}, token={token!r}, stack={self.curstack!r}"
+                    "do_keyword: pos=%r, token=%r, stack=%r",
+                    pos,
+                    token,
+                    self.curstack,
                 )
                 self.do_keyword(pos, token)
             else:
                 log.error(
-                    f"unknown token: pos={pos!r}, "
-                    f"token={token!r}, stack={self.curstack!r}"
+                    "unknown token: pos=%r, token=%r, stack=%r",
+                    pos,
+                    token,
+                    self.curstack,
                 )
                 self.do_keyword(pos, token)
                 raise PSException
@@ -640,7 +645,7 @@ class PSStackParser(PSBaseParser, Generic[ExtraT]):
                 self.flush()
         obj = self.results.pop(0)
         try:
-            log.debug(f"nextobject: {obj!r}")
+            log.debug("nextobject: %r", obj)
         except Exception:
             log.debug("nextobject: (unprintable object)")
         return obj

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ extend-select = [
     "SIM",  # flake8-simplify
     "C4",  # flake8-comprehensions
     "RUF",  # Ruff-specific rules
+    "G",  # flake8-logging-format
 ]
 extend-ignore = [
     # UP007: Union to | syntax breaks mypy 0.931 in TypeAlias definitions


### PR DESCRIPTION
**Pull request**

This PR converts logs using f strings to use the lazy evaluated % style format to improve performance by avoiding unnecessary evals.

It also adds the [flake8-logging-format](https://docs.astral.sh/ruff/rules/#flake8-logging-format-g) rule to the pyproject.toml to prevent regression

Closes #1233 

**How Has This Been Tested?**

I ran `make check` locally.

**Checklist**

- [X] I have read [CONTRIBUTING.md](https://github.com/pdfminer/pdfminer.six/blob/master/CONTRIBUTING.md).
- [X] I have added a concise human-readable description of the change to [CHANGELOG.md](https://github.com/pdfminer/pdfminer.six/blob/master/CHANGELOG.md).
- [X] I have tested that this fix is effective or that this feature works.
- [X] I have added docstrings to newly created methods and classes.
- [X] I have updated the [README.md](https://github.com/pdfminer/pdfminer.six/blob/master/README.md) and the [readthedocs](https://github.com/pdfminer/pdfminer.six/tree/master/docs/source) documentation. Or verified that this is not necessary.
