### PR TITLE
Fix: reproducibility when generating cmap .json.gz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes in pdfminer.six will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Fixed
+
+- Reproducibility issue when generating cmap `.json.gz` files ([#1242](https://github.com/pdfminer/pdfminer.six/pull/1242))
+
 ## [20260107]
 
 ### Added

--- a/tests/test_tools_conv_cmap_reproducibility.py
+++ b/tests/test_tools_conv_cmap_reproducibility.py
@@ -1,0 +1,170 @@
+"""Tests for reproducibility in generating cmap .json.gz files."""
+
+import gzip
+import json
+import pickle
+import time
+from pathlib import Path
+
+from tools import conv_cmap
+from tools.convert_cmaps_to_json import convert_pickle_to_json
+
+
+def read_gzip_mtime(filepath: str) -> int | None:
+    with gzip.GzipFile(filepath, "rb") as gz:
+        # Read a byte to trigger header parsing
+        gz.read(1)
+        return gz.mtime
+
+
+class TestConvCmapReproducibility:
+    """Test suite for conv_cmap.py gzip reproducibility."""
+
+    def test_conv_cmap_gzip_mtime_is_zero(self, tmp_path: Path) -> None:
+        """Verify that conv_cmap.py generates gzip files with mtime=0."""
+        # Create a minimal cid2code.txt input file
+        input_file = tmp_path / "cid2code.txt"
+        input_file.write_text("CID\tH\n0\t00\n1\t01\n")
+
+        # Run conv_cmap main function
+        conv_cmap.main(  # type: ignore[no-untyped-call]
+            [
+                "conv_cmap",
+                str(tmp_path),
+                "test",
+                str(input_file),
+            ]
+        )
+
+        # Check the generated cmap file
+        cmap_file = tmp_path / "H.json.gz"
+        assert cmap_file.exists(), "Expected H.json.gz to be generated"
+        mtime = read_gzip_mtime(str(cmap_file))
+        assert mtime == 0, f"Expected mtime=0 in gzip header, got {mtime}"
+
+        # Check the generated unicode map file
+        unicode_file = tmp_path / "to-unicode-test.json.gz"
+        assert unicode_file.exists(), "Expected to-unicode-test.json.gz to be generated"
+        mtime = read_gzip_mtime(str(unicode_file))
+        assert mtime == 0, f"Expected mtime=0 in gzip header, got {mtime}"
+
+    def test_conv_cmap_produces_identical_files(self, tmp_path: Path) -> None:
+        """Verify that running conv_cmap twice produces identical output."""
+        # Create input file
+        input_file = tmp_path / "cid2code.txt"
+        input_file.write_text("CID\tH\n0\t41\n1\t42\n2\t43\n")
+
+        # Create two output directories
+        outdir1 = tmp_path / "out1"
+        outdir2 = tmp_path / "out2"
+        outdir1.mkdir()
+        outdir2.mkdir()
+
+        # Run conv_cmap twice with same input
+        # Sleep 1 second between runs to ensure gzip timestamps would differ
+        # if mtime=0 fix is not working (gzip mtime has 1-second resolution)
+        conv_cmap.main(  # type: ignore[no-untyped-call]
+            [
+                "conv_cmap",
+                str(outdir1),
+                "test",
+                str(input_file),
+            ]
+        )
+        time.sleep(1)
+        conv_cmap.main(  # type: ignore[no-untyped-call]
+            [
+                "conv_cmap",
+                str(outdir2),
+                "test",
+                str(input_file),
+            ]
+        )
+
+        # Compare cmap files
+        cmap1 = (outdir1 / "H.json.gz").read_bytes()
+        cmap2 = (outdir2 / "H.json.gz").read_bytes()
+        assert cmap1 == cmap2, "CMap files should be identical"
+
+        # Compare unicode map files
+        unicode1 = (outdir1 / "to-unicode-test.json.gz").read_bytes()
+        unicode2 = (outdir2 / "to-unicode-test.json.gz").read_bytes()
+        assert unicode1 == unicode2, "Unicode map files should be identical"
+
+    def test_conv_cmap_output_is_valid_json(self, tmp_path: Path) -> None:
+        """Verify that conv_cmap output contains valid JSON."""
+        input_file = tmp_path / "cid2code.txt"
+        input_file.write_text("CID\tH\n0\t41\n1\t42\n")
+
+        conv_cmap.main(  # type: ignore[no-untyped-call]
+            [
+                "conv_cmap",
+                str(tmp_path),
+                "test",
+                str(input_file),
+            ]
+        )
+
+        # Verify cmap JSON is valid and readable
+        with gzip.open(tmp_path / "H.json.gz", "rt", encoding="utf-8") as f:
+            data = json.load(f)
+        assert "IS_VERTICAL" in data
+        assert "CODE2CID" in data
+
+
+class TestConvertCmapsToJsonReproducibility:
+    """Test suite for convert_cmaps_to_json.py gzip reproducibility."""
+
+    def test_convert_pickle_gzip_mtime_is_zero(self, tmp_path: Path) -> None:
+        """Verify that convert_pickle_to_json generates gzip files with mtime=0."""
+        # Create a test pickle file
+        test_data = {"IS_VERTICAL": False, "CODE2CID": {65: 1, 66: 2}}
+        pickle_file = tmp_path / "test.pickle.gz"
+        with gzip.open(pickle_file, "wb") as f:
+            pickle.dump(test_data, f)
+
+        # Convert pickle to JSON
+        json_file = tmp_path / "test.json.gz"
+        convert_pickle_to_json(str(pickle_file), str(json_file))
+
+        # Verify mtime is 0
+        mtime = read_gzip_mtime(str(json_file))
+        assert mtime == 0, f"Expected mtime=0 in gzip header, got {mtime}"
+
+    def test_convert_pickle_produces_identical_files(self, tmp_path: Path) -> None:
+        """Verify that converting the same pickle twice produces identical output."""
+        # Create test pickle file
+        test_data = {
+            "IS_VERTICAL": True,
+            "CODE2CID": {i: i + 100 for i in range(50)},
+        }
+        pickle_file = tmp_path / "test.pickle.gz"
+        with gzip.open(pickle_file, "wb") as f:
+            pickle.dump(test_data, f)
+
+        # Convert twice to the same output path (to ensure embedded filename matches)
+        # Sleep 1 second between runs to ensure gzip timestamps would differ
+        # if mtime=0 fix is not working (gzip mtime has 1-second resolution)
+        json_file = tmp_path / "test.json.gz"
+        convert_pickle_to_json(str(pickle_file), str(json_file))
+        content1 = json_file.read_bytes()
+
+        time.sleep(1)
+        convert_pickle_to_json(str(pickle_file), str(json_file))
+        content2 = json_file.read_bytes()
+
+        assert content1 == content2, "Converted files should be identical"
+
+    def test_convert_pickle_output_is_valid_json(self, tmp_path: Path) -> None:
+        """Verify that converted output contains valid JSON matching input."""
+        test_data = {"key": "value", "nested": {"a": 1, "b": 2}}
+        pickle_file = tmp_path / "test.pickle.gz"
+        with gzip.open(pickle_file, "wb") as f:
+            pickle.dump(test_data, f)
+
+        json_file = tmp_path / "test.json.gz"
+        convert_pickle_to_json(str(pickle_file), str(json_file))
+
+        with gzip.open(json_file, "rt", encoding="utf-8") as f:
+            loaded_data = json.load(f)
+        assert loaded_data == test_data

--- a/tools/conv_cmap.py
+++ b/tools/conv_cmap.py
@@ -148,6 +148,7 @@ class CMapConverter:
 def main(argv):
     import getopt
     import gzip
+    import io
     import os.path
 
     def usage():
@@ -183,14 +184,22 @@ def main(argv):
         fname = f"{enc}.json.gz"
         path = os.path.join(outdir, fname)
         print(f"writing: {path!r}...")
-        with gzip.open(path, "wt", encoding="utf-8") as fp:
+        with (
+            open(path, "wb") as bfp,
+            gzip.GzipFile(fileobj=bfp, mode="wb", compresslevel=9, mtime=0) as gz,
+            io.TextIOWrapper(gz, encoding="utf-8") as fp,
+        ):
             converter.dump_cmap(fp, enc)
 
     # Write JSON format
     fname = f"to-unicode-{regname}.json.gz"
     path = os.path.join(outdir, fname)
     print(f"writing: {path!r}...")
-    with gzip.open(path, "wt", encoding="utf-8") as fp:
+    with (
+        open(path, "wb") as bfp,
+        gzip.GzipFile(fileobj=bfp, mode="wb", compresslevel=9, mtime=0) as gz,
+        io.TextIOWrapper(gz, encoding="utf-8") as fp,
+    ):
         converter.dump_unicodemap(fp)
 
 

--- a/tools/convert_cmaps_to_json.py
+++ b/tools/convert_cmaps_to_json.py
@@ -12,6 +12,7 @@ Example:
 """
 
 import gzip
+import io
 import json
 import pickle
 import sys
@@ -53,7 +54,11 @@ def convert_pickle_to_json(pickle_path: str, json_path: str) -> None:
         raise ValueError(f"Expected dict from pickle, got {type(data)}")
 
     # Write JSON data
-    with gzip.open(json_path, "wt", encoding="utf-8") as gzfile:
+    with (
+        open(json_path, "wb") as fp,
+        gzip.GzipFile(fileobj=fp, mode="wb", compresslevel=9, mtime=0) as gz,
+        io.TextIOWrapper(gz, encoding="utf-8") as gzfile,
+    ):
         json.dump(data, gzfile, ensure_ascii=False, indent=None, separators=(",", ":"))
 
     print(f"✓ Converted {pickle_path} -> {json_path}")


### PR DESCRIPTION
**Pull request**

https://github.com/pdfminer/pdfminer.six/pull/1172#issuecomment-3570037637 pointed out that gzip reproducibility is current missing due to embedding mtime when generating cmap .json.gz files. The reply in https://github.com/pdfminer/pdfminer.six/pull/1172#issuecomment-3572081599 considered it to be minor, but downstream distributors would benefit from artifact generation reproducibility. See details in issue #1241 .

This commit properly set the generated gzip files' mtime=0, which solves the reproducibility issue. It also explicitly specify the gzip compression level (9 currently) to avoid reproducibility issues that may be triggered due to different values.

This pull request closes #1241 .

**How Has This Been Tested?**

The patch was tested manually, as well as tested in downstream Debian package pdfminer/20260107+dfsg-1 release.

**Checklist**

- [X] I have read [CONTRIBUTING.md](https://github.com/pdfminer/pdfminer.six/blob/master/CONTRIBUTING.md).
- [X] I have added a concise human-readable description of the change to [CHANGELOG.md](https://github.com/pdfminer/pdfminer.six/blob/master/CHANGELOG.md).
- [X] I have tested that this fix is effective or that this feature works.
- [X] I have added docstrings to newly created methods and classes.
- [X] I have updated the [README.md](https://github.com/pdfminer/pdfminer.six/blob/master/README.md) and the [readthedocs](https://github.com/pdfminer/pdfminer.six/tree/master/docs/source) documentation. Or verified that this is not necessary.
