### PR TITLE
Correct type annotations for original_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Switch to `bytearray` in `apply_png_predictor` to avoid out of memory error (and speed it up) ([#1247](https://github.com/pdfminer/pdfminer.six/pull/1247))
 - Check the type of `N` when creating an `ICCBased` color space ([#1252](http3://github.com/pdfminer/pdfminer.six/pull/1253))
 - Endless recursion issue with circular or corrupted `Prev` chains in cross-refeerence tables ([#1253](https://github.com/pdfminer/pdfminer.six/pull/1253))
+- Fix the type annotation of `original_path` in `LTLine` and `LTCurve` to reflect the actual data structure ([#1258](https://github.com/pdfminer/pdfminer.six/pull/1258))
 
 ## [20260107]
 

--- a/pdfminer/converter.py
+++ b/pdfminer/converter.py
@@ -33,6 +33,7 @@ from pdfminer.layout import (
     LTTextGroup,
     LTTextLine,
     TextGroupElement,
+    make_path_segment,
 )
 from pdfminer.pdfcolor import PDFColorSpace
 from pdfminer.pdfdevice import PDFTextDevice
@@ -155,7 +156,7 @@ class PDFLayoutAnalyzer(PDFTextDevice):
                 for operation in path
             ]
             transformed_path = [
-                cast(PathSegment, (o, *p))
+                make_path_segment(o, p)
                 for o, p in zip(operators, transformed_points, strict=False)
             ]
 

--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -77,7 +77,7 @@ def make_path_segment(operator: str, points: Sequence[Point]) -> LTPathSegment:
         return LTPathSegment2("y", points[0], points[1])
     if operator == "c":
         return LTPathSegment3("c", points[0], points[1], points[2])
-    raise ValueError(f"Unrecognized path segment: {operator!r} {points!r}")
+    raise PDFValueError(f"Unrecognized path segment: {operator!r} {points!r}")
 
 
 class IndexAssigner:

--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -3,6 +3,8 @@ import logging
 from collections.abc import Iterable, Iterator, Sequence
 from typing import (
     Generic,
+    Literal,
+    NamedTuple,
     TypeVar,
     Union,
     cast,
@@ -17,7 +19,6 @@ from pdfminer.utils import (
     INF,
     LTComponentT,
     Matrix,
-    PathSegment,
     Plane,
     Point,
     Rect,
@@ -30,6 +31,53 @@ from pdfminer.utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+# Type annotations for what we actually return in `original_path`, which
+# is not the same thing as `PathSegment`.
+class LTPathSegment0(NamedTuple):
+    operator: Literal["h"]
+
+
+class LTPathSegment1(NamedTuple):
+    operator: Literal["m", "l"]
+    dest: Point
+
+
+class LTPathSegment2(NamedTuple):
+    operator: Literal["v", "y"]
+    control: Point
+    dest: Point
+
+
+class LTPathSegment3(NamedTuple):
+    operator: Literal["c"]
+    control1: Point
+    control2: Point
+    dest: Point
+
+
+LTPathSegment = Union[LTPathSegment0, LTPathSegment1, LTPathSegment2, LTPathSegment3]
+
+
+def make_path_segment(operator: str, points: Sequence[Point]) -> LTPathSegment:
+    """Construct a type-safe path segment."""
+    # The apparent redundancy below is due to a limitation of mypy,
+    # see https://github.com/python/mypy/issues/12535 and
+    # https://github.com/python/mypy/issues/16819 among others
+    if operator == "h":
+        return LTPathSegment0("h")
+    if operator == "m":
+        return LTPathSegment1("m", points[0])
+    if operator == "l":
+        return LTPathSegment1("l", points[0])
+    if operator == "v":
+        return LTPathSegment2("v", points[0], points[1])
+    if operator == "y":
+        return LTPathSegment2("y", points[0], points[1])
+    if operator == "c":
+        return LTPathSegment3("c", points[0], points[1], points[2])
+    raise ValueError(f"Unrecognized path segment: {operator!r} {points!r}")
 
 
 class IndexAssigner:
@@ -221,7 +269,7 @@ class LTCurve(LTComponent):
         evenodd: bool = False,
         stroking_color: Color | None = None,
         non_stroking_color: Color | None = None,
-        original_path: list[PathSegment] | None = None,
+        original_path: list[LTPathSegment] | None = None,
         dashing_style: tuple[object, object] | None = None,
     ) -> None:
         LTComponent.__init__(self, get_bound(pts))
@@ -255,7 +303,7 @@ class LTLine(LTCurve):
         evenodd: bool = False,
         stroking_color: Color | None = None,
         non_stroking_color: Color | None = None,
-        original_path: list[PathSegment] | None = None,
+        original_path: list[LTPathSegment] | None = None,
         dashing_style: tuple[object, object] | None = None,
     ) -> None:
         LTCurve.__init__(
@@ -287,7 +335,7 @@ class LTRect(LTCurve):
         evenodd: bool = False,
         stroking_color: Color | None = None,
         non_stroking_color: Color | None = None,
-        original_path: list[PathSegment] | None = None,
+        original_path: list[LTPathSegment] | None = None,
         dashing_style: tuple[object, object] | None = None,
     ) -> None:
         (x0, y0, x1, y1) = bbox


### PR DESCRIPTION
Fixes: #1180 

As mentioned in that issue, the type annotation for the `original_path` attribute of `LTCurve` doesn't correspond to the actual data structure.  This is maybe a bad thing for people who use type checkers :wink: 

This makes it *very* type-safe, with actual literals for the operators.  Unfortunately `mypy` doesn't yet know how to narrow this properly, but it may be useful in the future.

**How Has This Been Tested?**

By running `mypy` on the code.

**Checklist**

- [x] I have read [CONTRIBUTING.md](https://github.com/pdfminer/pdfminer.six/blob/master/CONTRIBUTING.md).
- [x] I have added a concise human-readable description of the change to [CHANGELOG.md](https://github.com/pdfminer/pdfminer.six/blob/master/CHANGELOG.md).
- [x] I have tested that this fix is effective or that this feature works.
- [x] I have added docstrings to newly created methods and classes.
- [x] I have updated the [README.md](https://github.com/pdfminer/pdfminer.six/blob/master/README.md) and the [readthedocs](https://github.com/pdfminer/pdfminer.six/tree/master/docs/source) documentation. Or verified that this is not necessary.
