### PR TITLE
use method to create `PDFPageInterpreter`'s parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Check the type of `N` when creating an `ICCBased` color space ([#1252](http3://github.com/pdfminer/pdfminer.six/pull/1253))
 - Endless recursion issue with circular or corrupted `Prev` chains in cross-refeerence tables ([#1253](https://github.com/pdfminer/pdfminer.six/pull/1253))
 
+### Added
+
+- Add `PDFPageInterpreter.create_parser` method to allow subclasses to provide their own parser
+
 ## [20260107]
 
 ### Added

--- a/pdfminer/pdfinterp.py
+++ b/pdfminer/pdfinterp.py
@@ -1411,7 +1411,7 @@ class PDFPageInterpreter:
                 valid_streams.append(stream)
                 self.stream_ids.add(stream.objid)
         try:
-            parser = PDFContentParser(valid_streams)
+            parser = self.create_parser(valid_streams)
         except PSEOF:
             # empty page
             return
@@ -1446,3 +1446,7 @@ class PDFPageInterpreter:
                     raise PDFInterpreterError(error_msg)
             else:
                 self.push(obj)
+
+    def create_parser(self, valid_streams: Sequence[PDFStream]) -> PDFContentParser:
+        """Create a PDFContentParser to parse the streams"""
+        return PDFContentParser(valid_streams)


### PR DESCRIPTION
**Pull request**

This PR allows subclasses of `PDFPageInterpreter` to control the initialization of the underlying `PDFContentParser`.

**How Has This Been Tested?**

Existing tests are passing so if nothing else the change does not seem to break anything.

I am using this change for a use-case where I need to correlate low level info (operators in streams) with high level info (graphic state) and therefore need to be able to get a handle on the parser during execution (from the `do_...()` methods). The idea is to do something like this:
```py
class MyPageInterpreter(PDFPageInterpreter):
    def create_parser(self, valid_streams: Sequence[PDFStream]):
        self._parser = MyContentParser(valid_streams)
        return self._parser

    def do_S(self):
        if self.graphicstate.scolor == (1, 0, 0):
            print(f"red stroke at pos {self._parser.current_pos} in {self._parser.current_stream}")

class MyContentParser(PDFContentParser):
    @property
    def current_pos(self):
        return self.bufpos + self.charpos

    @property
    def current_stream(self):
        stream = self.streams[self.istream - 1]
        assert isinstance(stream, PDFStream)
        return stream
```
I can provide a full minimal example and/or add it as a proper test if needed.

**Checklist**

- [x] I have read [CONTRIBUTING.md](https://github.com/pdfminer/pdfminer.six/blob/master/CONTRIBUTING.md).
- [x] I have added a concise human-readable description of the change to [CHANGELOG.md](https://github.com/pdfminer/pdfminer.six/blob/master/CHANGELOG.md).
- [x] I have tested that this fix is effective or that this feature works.
- [x] I have added docstrings to newly created methods and classes.
- [x] I have updated the [README.md](https://github.com/pdfminer/pdfminer.six/blob/master/README.md) and the [readthedocs](https://github.com/pdfminer/pdfminer.six/tree/master/docs/source) documentation. Or verified that this is not necessary.
