### PR TITLE
Tolerate malformed form XObject /BBox instead of crashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Crash (`ValueError: not enough values to unpack`) on form XObjects whose `/BBox` is not a four-number rectangle; the malformed bbox now falls back to a unit rectangle instead ([#1263](https://github.com/pdfminer/pdfminer.six/issues/1263))
 - Reproducibility issue when generating cmap `.json.gz` files ([#1242](https://github.com/pdfminer/pdfminer.six/pull/1242))
 - Switch to `bytearray` in `apply_png_predictor` to avoid out of memory error (and speed it up) ([#1247](https://github.com/pdfminer/pdfminer.six/pull/1247))
 - Check the type of `N` when creating an `ICCBased` color space ([#1252](http3://github.com/pdfminer/pdfminer.six/pull/1253))

--- a/pdfminer/pdfinterp.py
+++ b/pdfminer/pdfinterp.py
@@ -335,7 +335,7 @@ class PDFContentParser(PSStackParser[Union[PSKeyword, PDFStream]]):
             self.start_type(pos, "inline")
         elif token is self.KEYWORD_ID:
             try:
-                (_, objs) = self.end_type("inline")
+                _, objs = self.end_type("inline")
                 if len(objs) % 2 != 0:
                     error_msg = f"Invalid dictionary construct: {objs!r}"
                     raise PSTypeError(error_msg)
@@ -347,7 +347,7 @@ class PDFContentParser(PSStackParser[Union[PSKeyword, PDFStream]]):
                         filter = [filter]
                     if filter[0] in LITERALS_ASCII85_DECODE:
                         eos = b"~>"
-                (pos, data) = self.get_inline_data(pos + len(b"ID "), target=eos)
+                pos, data = self.get_inline_data(pos + len(b"ID "), target=eos)
                 if eos != b"EI":  # it may be necessary for decoding
                     data += eos
                 obj = PDFStream(d, data)
@@ -465,7 +465,7 @@ class PDFPageInterpreter:
         self,
         state: tuple[Matrix, PDFTextState, PDFGraphicState],
     ) -> None:
-        (self.ctm, self.textstate, self.graphicstate) = state
+        self.ctm, self.textstate, self.graphicstate = state
         self.device.set_ctm(self.ctm)
 
     def do_q(self) -> None:
@@ -1198,7 +1198,7 @@ class PDFPageInterpreter:
         tx_ = safe_float(tx)
         ty_ = safe_float(ty)
         if tx_ is not None and ty_ is not None:
-            (a, b, c, d, e, f) = self.textstate.matrix
+            a, b, c, d, e, f = self.textstate.matrix
             e_new = tx_ * a + ty_ * c + e
             f_new = tx_ * b + ty_ * d + f
             self.textstate.matrix = (a, b, c, d, e_new, f_new)
@@ -1218,7 +1218,7 @@ class PDFPageInterpreter:
         ty_ = safe_float(ty)
 
         if tx_ is not None and ty_ is not None:
-            (a, b, c, d, e, f) = self.textstate.matrix
+            a, b, c, d, e, f = self.textstate.matrix
             e_new = tx_ * a + ty_ * c + e
             f_new = tx_ * b + ty_ * d + f
             self.textstate.matrix = (a, b, c, d, e_new, f_new)
@@ -1256,7 +1256,7 @@ class PDFPageInterpreter:
 
     def do_T_a(self) -> None:
         """Move to start of next text line"""
-        (a, b, c, d, e, f) = self.textstate.matrix
+        a, b, c, d, e, f = self.textstate.matrix
         self.textstate.matrix = (
             a,
             b,
@@ -1328,7 +1328,27 @@ class PDFPageInterpreter:
         subtype = xobj.get("Subtype")
         if subtype is LITERAL_FORM and "BBox" in xobj:
             interpreter = self.subinterp()
-            bbox = cast(Rect, list_value(xobj["BBox"]))
+            bbox_raw = list_value(xobj["BBox"])
+            bbox_values = [safe_float(v) for v in bbox_raw]
+            if len(bbox_values) != 4 or any(v is None for v in bbox_values):
+                # The PDF spec (1.7, section 8.10.1) requires a form XObject's
+                # /BBox to be a rectangle of four numbers. Some non-conformant
+                # PDFs provide a different length or non-numeric entries, which
+                # previously raised a ValueError while unpacking the bbox. Fall
+                # back to the unit rectangle used for missing/image bboxes
+                # instead of crashing.
+                if settings.STRICT:
+                    raise PDFInterpreterError(
+                        f"Invalid BBox for xobject {xobjid!r}: {bbox_raw!r}",
+                    )
+                log.warning(
+                    "Invalid BBox %r for xobject %r; using unit rectangle",
+                    bbox_raw,
+                    xobjid,
+                )
+                bbox = (0.0, 0.0, 1.0, 1.0)
+            else:
+                bbox = cast(Rect, tuple(bbox_values))
             matrix = cast(Matrix, list_value(xobj.get("Matrix", MATRIX_IDENTITY)))
             # According to PDF reference 1.7 section 4.9.1, XObjects in
             # earlier PDFs (prior to v1.2) use the page's Resources entry
@@ -1352,7 +1372,7 @@ class PDFPageInterpreter:
 
     def process_page(self, page: PDFPage) -> None:
         log.debug("Processing page: %r", page)
-        (x0, y0, x1, y1) = page.mediabox
+        x0, y0, x1, y1 = page.mediabox
         if page.rotate == 90:
             ctm = (0, -1, 1, 0, -y0, x1)
         elif page.rotate == 180:
@@ -1417,7 +1437,7 @@ class PDFPageInterpreter:
             return
         while True:
             try:
-                (_, obj) = parser.nextobject()
+                _, obj = parser.nextobject()
             except PSEOF:
                 break
             if isinstance(obj, PSKeyword):

--- a/tests/test_highlevel_extracttext.py
+++ b/tests/test_highlevel_extracttext.py
@@ -1,8 +1,49 @@
 import unittest
+from io import BytesIO
 
 from pdfminer.high_level import extract_pages, extract_text
 from pdfminer.layout import LAParams, LTTextContainer
+from pdfminer.pdfexceptions import PDFException
 from tests.helpers import absolute_sample_path
+
+
+def _pdf_with_form_bbox(bbox: bytes) -> BytesIO:
+    """Build a tiny two-page PDF whose second page uses a form XObject /BBox.
+
+    The first page contains the text "Hello"; the second page invokes a form
+    XObject whose /BBox is ``bbox`` (e.g. ``b"[0 0]"`` to exercise a malformed,
+    non-four-number rectangle). Returned as a BytesIO so tests stay
+    self-contained and free of line-ending conversion on a committed binary.
+    """
+    form_stream = b"q Q"
+    text_stream = b"BT /F1 12 Tf 50 100 Td (Hello) Tj ET"
+    objs = [
+        b"<</Type/Catalog/Pages 2 0 R>>",
+        b"<</Type/Pages/Kids[3 0 R 4 0 R]/Count 2>>",
+        b"<</Type/Page/Parent 2 0 R/MediaBox[0 0 200 200]"
+        b"/Resources<</Font<</F1 7 0 R>>>>/Contents 5 0 R>>",
+        b"<</Type/Page/Parent 2 0 R/MediaBox[0 0 200 200]"
+        b"/Resources<</XObject<</Fm0 6 0 R>>>>/Contents 8 0 R>>",
+        b"<</Length %d>>\nstream\n%s\nendstream" % (len(text_stream), text_stream),
+        b"<</Type/XObject/Subtype/Form/FormType 1/BBox %s/Resources<<>>"
+        b"/Length %d>>\nstream\n%s\nendstream" % (bbox, len(form_stream), form_stream),
+        b"<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>",
+        b"<</Length 7>>\nstream\n/Fm0 Do\nendstream",
+    ]
+    out = b"%PDF-1.4\n"
+    offsets = []
+    for i, obj in enumerate(objs, 1):
+        offsets.append(len(out))
+        out += b"%d 0 obj\n%s\nendobj\n" % (i, obj)
+    startxref = len(out)
+    out += b"xref\n0 %d\n0000000000 65535 f \n" % (len(objs) + 1)
+    for offset in offsets:
+        out += b"%010d 00000 n \n" % offset
+    out += b"trailer<</Size %d/Root 1 0 R>>\nstartxref\n%d\n%%%%EOF" % (
+        len(objs) + 1,
+        startxref,
+    )
+    return BytesIO(out)
 
 
 def run_with_string(sample_path, laparams=None):
@@ -152,6 +193,29 @@ class TestExtractText(unittest.TestCase):
         test_file = "contrib/issue-886-xref-stream-widths.pdf"
         s = run_with_file(test_file)
         self.assertEqual(s.strip(), test_strings[test_file])
+
+    def test_invalid_form_bbox_does_not_crash(self):
+        """A form XObject with a non-conformant /BBox must not crash extraction.
+
+        The second page holds a form XObject whose /BBox is [0 0] (two numbers
+        instead of the four required by the spec). Extraction should fall back
+        to a unit rectangle for the bad bbox and still recover the text from the
+        first page rather than raising ValueError.
+        """
+        s = extract_text(_pdf_with_form_bbox(b"[0 0]"))
+        self.assertIn("Hello", s)
+
+    def test_invalid_form_bbox_raises_in_strict_mode(self):
+        """In STRICT mode the invalid /BBox is reported instead of tolerated."""
+        from pdfminer import settings
+
+        original = settings.STRICT
+        settings.STRICT = True
+        try:
+            with self.assertRaises(PDFException):
+                extract_text(_pdf_with_form_bbox(b"[0 0]"))
+        finally:
+            settings.STRICT = original
 
 
 class TestExtractPages(unittest.TestCase):


### PR DESCRIPTION
## Summary

Fixes #1263.

A form XObject whose `/BBox` is not the four-number rectangle required by the spec (for example `/BBox [0 0]`) made `LTFigure.__init__` unpack `(x, y, w, h) = bbox` raise `ValueError: not enough values to unpack (expected 4, got 2)`, aborting the entire extraction. Such non-conformant bboxes occur in PDFs from some generators and also surface in pdfplumber / markitdown.

## Change

`PDFPageInterpreter.do_Do` now validates that a form XObject's `/BBox` has four numeric entries (using `safe_float`). When it does not:

- in non-STRICT mode, a warning is logged and the bbox falls back to the unit rectangle `(0, 0, 1, 1)` — the same default already used for image XObjects and missing bboxes — so the rest of the document is still extracted;
- in STRICT mode, a `PDFInterpreterError` is raised.

## Tests

Added to `tests/test_highlevel_extracttext.py` (self-contained, building the PDF in-memory):

- `test_invalid_form_bbox_does_not_crash` — extraction tolerates `/BBox [0 0]` and still recovers the text from the other page.
- `test_invalid_form_bbox_raises_in_strict_mode` — STRICT mode reports the invalid bbox.

`make check` style run locally: `pytest tests/test_highlevel_extracttext.py` → 22 passed; `black --check` clean.

CHANGELOG.md updated under `[Unreleased] / Fixed`.

---

AI assistance (Claude) was used; I have reviewed every line and run the tests.
