### PR TITLE
Remove unused pred parameter from apply_png_predictor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Switch to `bytearray` in `apply_png_predictor` to avoid out of memory error (and speed it up) ([#1247](https://github.com/pdfminer/pdfminer.six/pull/1247))
 - Check the type of `N` when creating an `ICCBased` color space ([#1252](http3://github.com/pdfminer/pdfminer.six/pull/1253))
 - Endless recursion issue with circular or corrupted `Prev` chains in cross-refeerence tables ([#1253](https://github.com/pdfminer/pdfminer.six/pull/1253))
+- Remove the unused `pred` parameter from `apply_png_predictor` (the PNG filter type is read per scanline from the data) ([#970](https://github.com/pdfminer/pdfminer.six/issues/970))
 
 ## [20260107]
 

--- a/pdfminer/pdftypes.py
+++ b/pdfminer/pdftypes.py
@@ -384,7 +384,6 @@ class PDFStream(PDFObject):
                     raw_bits_per_component = params.get("BitsPerComponent", 8)
                     bitspercomponent = int_value(raw_bits_per_component)
                     data = apply_png_predictor(
-                        pred,
                         colors,
                         columns,
                         bitspercomponent,

--- a/pdfminer/utils.py
+++ b/pdfminer/utils.py
@@ -151,13 +151,16 @@ def apply_tiff_predictor(
 
 
 def apply_png_predictor(
-    pred: int,
     colors: int,
     columns: int,
     bitspercomponent: int,
     data: bytes,
 ) -> bytes:
     """Reverse the effect of the PNG predictor
+
+    The PNG predictor type (``/Predictor`` >= 10) is not needed here: each
+    scanline carries its own filter-type byte as its first byte, so the filter
+    is selected per row from the data itself.
 
     Documentation: http://www.libpng.org/pub/png/spec/1.2/PNG-Filters.html
     """

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,7 @@ import pathlib
 import pytest
 
 from pdfminer.layout import LTComponent
+from pdfminer.pdfexceptions import PDFValueError
 from pdfminer.utils import (
     Matrix,
     Plane,
@@ -11,6 +12,7 @@ from pdfminer.utils import (
     Rect,
     apply_matrix_pt,
     apply_matrix_rect,
+    apply_png_predictor,
     format_int_alpha,
     format_int_roman,
     mult_matrix,
@@ -246,3 +248,27 @@ def test_apply_matrix_pt(m0: Matrix, p0: Point, expected: Point) -> None:
 def test_apply_matrix_rect_outside(m0: Matrix, r0: Rect, expected: Rect) -> None:
     """Test rotation examples based on PDF reference 4.2.2 Common Transformations"""
     assert apply_matrix_rect(m0, r0) == expected
+
+
+class TestApplyPngPredictor:
+    """The filter type is the first byte of each scanline (colors=1, columns=3,
+    bitspercomponent=8 -> 3 data bytes per row)."""
+
+    def test_filter_none(self) -> None:
+        # Filter type 0 (None): bytes pass through unchanged.
+        data = b"\x00\x10\x20\x30"
+        assert apply_png_predictor(1, 3, 8, data) == b"\x10\x20\x30"
+
+    def test_filter_sub(self) -> None:
+        # Filter type 1 (Sub): Raw(x) = Sub(x) + Raw(x - bpp), bpp = 1.
+        data = b"\x01\x05\x01\x01"
+        assert apply_png_predictor(1, 3, 8, data) == b"\x05\x06\x07"
+
+    def test_filter_up(self) -> None:
+        # Filter type 2 (Up): Raw(x) = Up(x) + Prior(x) across two scanlines.
+        data = b"\x00\x10\x20\x30" + b"\x02\x01\x01\x01"
+        assert apply_png_predictor(1, 3, 8, data) == b"\x10\x20\x30\x11\x21\x31"
+
+    def test_unsupported_bitspercomponent(self) -> None:
+        with pytest.raises(PDFValueError):
+            apply_png_predictor(1, 3, 4, b"\x00\x00")


### PR DESCRIPTION
## Summary

Fixes #970.

`apply_png_predictor` declared a `pred` parameter (the PDF `/Predictor` value) but never used it. As @jbbqqf confirmed in the issue, the function reads the per-scanline filter byte regardless of the predictor value.

This is correct behaviour: for PNG predictors (`/Predictor >= 10`) the filter type is encoded as the first byte of each scanline, so the `/Predictor` value carries no additional information at decode time. (The distinct TIFF Predictor 2 is already routed to `apply_tiff_predictor` in `pdftypes.py`.) The `pred` argument was therefore dead.

## Changes

- Remove the unused `pred` parameter from `pdfminer.utils.apply_png_predictor`.
- Update the single caller in `pdfminer/pdftypes.py`.
- Document in the docstring why the predictor value is not needed.
- Add unit tests for `apply_png_predictor` (None / Sub / Up filters and the unsupported `bitspercomponent` path), which the function previously lacked.
- CHANGELOG entry.

## Notes

`apply_png_predictor` is an internal helper (not exported in `__init__` or any `__all__`). No public behaviour changes; the existing image-extraction tests still pass.

## Test plan

- `pytest tests/test_utils.py` — passes (incl. new tests)
- `ruff check` / `ruff format --check` — clean
- `mypy pdfminer/utils.py pdfminer/pdftypes.py` — clean
