### PR TITLE
Handle ICCBased color space with missing or invalid /N

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- `KeyError` on `ICCBased` color spaces whose stream omits the required `/N`; the `/Alternate` color space is used when available, otherwise the color space is skipped ([#1079](https://github.com/pdfminer/pdfminer.six/issues/1079))
 - Reproducibility issue when generating cmap `.json.gz` files ([#1242](https://github.com/pdfminer/pdfminer.six/pull/1242))
 - Switch to `bytearray` in `apply_png_predictor` to avoid out of memory error (and speed it up) ([#1247](https://github.com/pdfminer/pdfminer.six/pull/1247))
 - Check the type of `N` when creating an `ICCBased` color space ([#1252](http3://github.com/pdfminer/pdfminer.six/pull/1253))

--- a/pdfminer/pdfinterp.py
+++ b/pdfminer/pdfinterp.py
@@ -24,7 +24,6 @@ from pdfminer.pdftypes import (
     PDFObjRef,
     PDFStream,
     dict_value,
-    int_value,
     list_value,
     resolve1,
     stream_value,
@@ -335,7 +334,7 @@ class PDFContentParser(PSStackParser[Union[PSKeyword, PDFStream]]):
             self.start_type(pos, "inline")
         elif token is self.KEYWORD_ID:
             try:
-                (_, objs) = self.end_type("inline")
+                _, objs = self.end_type("inline")
                 if len(objs) % 2 != 0:
                     error_msg = f"Invalid dictionary construct: {objs!r}"
                     raise PSTypeError(error_msg)
@@ -347,7 +346,7 @@ class PDFContentParser(PSStackParser[Union[PSKeyword, PDFStream]]):
                         filter = [filter]
                     if filter[0] in LITERALS_ASCII85_DECODE:
                         eos = b"~>"
-                (pos, data) = self.get_inline_data(pos + len(b"ID "), target=eos)
+                pos, data = self.get_inline_data(pos + len(b"ID "), target=eos)
                 if eos != b"EI":  # it may be necessary for decoding
                     data += eos
                 obj = PDFStream(d, data)
@@ -410,7 +409,24 @@ class PDFPageInterpreter:
             else:
                 name = literal_name(spec)
             if name == "ICCBased" and isinstance(spec, list) and len(spec) >= 2:
-                return PDFColorSpace(name, int_value(stream_value(spec[1])["N"]))
+                stream = stream_value(spec[1])
+                n = stream.get("N")
+                if not isinstance(n, int) or n <= 0:
+                    # /N (1, 3 or 4) is required for ICCBased streams (PDF 1.7,
+                    # 8.6.5.5), but some PDFs omit it or give an invalid value.
+                    # Fall back to the /Alternate color space when it is a
+                    # usable (non-ICCBased) space, otherwise skip this color
+                    # space rather than raising or registering a broken,
+                    # zero-component one.
+                    alternate = resolve1(stream.get("Alternate"))
+                    if alternate is not None:
+                        alt_name = literal_name(
+                            alternate[0] if isinstance(alternate, list) else alternate
+                        )
+                        if alt_name != "ICCBased":
+                            return get_colorspace(alternate)
+                    return None
+                return PDFColorSpace(name, n)
             elif name == "DeviceN" and isinstance(spec, list) and len(spec) >= 2:
                 return PDFColorSpace(name, len(list_value(spec[1])))
             else:
@@ -465,7 +481,7 @@ class PDFPageInterpreter:
         self,
         state: tuple[Matrix, PDFTextState, PDFGraphicState],
     ) -> None:
-        (self.ctm, self.textstate, self.graphicstate) = state
+        self.ctm, self.textstate, self.graphicstate = state
         self.device.set_ctm(self.ctm)
 
     def do_q(self) -> None:
@@ -1198,7 +1214,7 @@ class PDFPageInterpreter:
         tx_ = safe_float(tx)
         ty_ = safe_float(ty)
         if tx_ is not None and ty_ is not None:
-            (a, b, c, d, e, f) = self.textstate.matrix
+            a, b, c, d, e, f = self.textstate.matrix
             e_new = tx_ * a + ty_ * c + e
             f_new = tx_ * b + ty_ * d + f
             self.textstate.matrix = (a, b, c, d, e_new, f_new)
@@ -1218,7 +1234,7 @@ class PDFPageInterpreter:
         ty_ = safe_float(ty)
 
         if tx_ is not None and ty_ is not None:
-            (a, b, c, d, e, f) = self.textstate.matrix
+            a, b, c, d, e, f = self.textstate.matrix
             e_new = tx_ * a + ty_ * c + e
             f_new = tx_ * b + ty_ * d + f
             self.textstate.matrix = (a, b, c, d, e_new, f_new)
@@ -1256,7 +1272,7 @@ class PDFPageInterpreter:
 
     def do_T_a(self) -> None:
         """Move to start of next text line"""
-        (a, b, c, d, e, f) = self.textstate.matrix
+        a, b, c, d, e, f = self.textstate.matrix
         self.textstate.matrix = (
             a,
             b,
@@ -1352,7 +1368,7 @@ class PDFPageInterpreter:
 
     def process_page(self, page: PDFPage) -> None:
         log.debug("Processing page: %r", page)
-        (x0, y0, x1, y1) = page.mediabox
+        x0, y0, x1, y1 = page.mediabox
         if page.rotate == 90:
             ctm = (0, -1, 1, 0, -y0, x1)
         elif page.rotate == 180:
@@ -1417,7 +1433,7 @@ class PDFPageInterpreter:
             return
         while True:
             try:
-                (_, obj) = parser.nextobject()
+                _, obj = parser.nextobject()
             except PSEOF:
                 break
             if isinstance(obj, PSKeyword):

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -298,6 +298,40 @@ def get_chars(el):
         pass
 
 
+def _pdf_with_iccbased_colorspace(icc_attrs: bytes) -> io.BytesIO:
+    """Build a one-page PDF whose ColorSpace resource is an ICCBased stream.
+
+    ``icc_attrs`` is injected into the ICC stream's dictionary, e.g. ``b""`` to
+    omit /N entirely or ``b"/Alternate/DeviceRGB"`` to provide an alternate.
+    Built in memory so the test stays self-contained.
+    """
+    icc_data = b"\x00\x00\x00"
+    objs = [
+        b"<</Type/Catalog/Pages 2 0 R>>",
+        b"<</Type/Pages/Kids[3 0 R]/Count 1>>",
+        b"<</Type/Page/Parent 2 0 R/MediaBox[0 0 200 200]"
+        b"/Resources<</ColorSpace<</CS0 5 0 R>>>>/Contents 4 0 R>>",
+        b"<</Length 2>>\nstream\nq\nendstream",
+        b"[/ICCBased 6 0 R]",
+        b"<</Length %d%s>>\nstream\n%s\nendstream"
+        % (len(icc_data), icc_attrs, icc_data),
+    ]
+    out = b"%PDF-1.4\n"
+    offsets = []
+    for i, obj in enumerate(objs, 1):
+        offsets.append(len(out))
+        out += b"%d 0 obj\n%s\nendobj\n" % (i, obj)
+    startxref = len(out)
+    out += b"xref\n0 %d\n0000000000 65535 f \n" % (len(objs) + 1)
+    for offset in offsets:
+        out += b"%010d 00000 n \n" % offset
+    out += b"trailer<</Size %d/Root 1 0 R>>\nstartxref\n%d\n%%%%EOF" % (
+        len(objs) + 1,
+        startxref,
+    )
+    return io.BytesIO(out)
+
+
 class TestColorSpace:
     def test_do_rg(self):
         path = absolute_sample_path("contrib/issue-00352-hash-twos-complement.pdf")
@@ -315,6 +349,31 @@ class TestColorSpace:
                     # Pattern colors should be stored as strings (pattern names)
                     assert isinstance(color, str)
                     assert color.startswith("P")  # Pattern names typically start with P
+
+    def test_iccbased_missing_n(self):
+        """An ICCBased color space whose stream omits /N must not crash.
+
+        /N is required by the spec, but some PDFs omit it. The color space is
+        skipped (or falls back to /Alternate) instead of raising a KeyError.
+        """
+        from pdfminer.pdfdevice import PDFDevice
+        from pdfminer.pdfinterp import PDFPageInterpreter, PDFResourceManager
+        from pdfminer.pdfpage import PDFPage
+
+        def get_csmap(pdf_stream):
+            rsrcmgr = PDFResourceManager()
+            interpreter = PDFPageInterpreter(rsrcmgr, PDFDevice(rsrcmgr))
+            page = next(PDFPage.get_pages(pdf_stream))
+            interpreter.process_page(page)
+            return interpreter.csmap
+
+        # Missing /N, no alternate: the color space is skipped, not registered.
+        csmap = get_csmap(_pdf_with_iccbased_colorspace(b""))
+        assert "CS0" not in csmap
+
+        # Missing /N, with /Alternate /DeviceRGB: falls back to 3 components.
+        csmap = get_csmap(_pdf_with_iccbased_colorspace(b"/Alternate/DeviceRGB"))
+        assert csmap["CS0"].ncomponents == 3
 
     def test_pattern_colors(self):
         """Test that Pattern color spaces are properly handled.


### PR DESCRIPTION
## Summary

Fixes #1079.

`PDFPageInterpreter.init_resources` reads an ICCBased color space's component count with `stream_value(spec[1])["N"]`. When the ICC stream omits the spec-required `/N`, this raised `KeyError` / `PDFKeyError` and aborted extraction (`extract_pages` / `extract_text` both crash). A non-positive or non-integer `/N` additionally produced a broken zero-component color space.

## Change

In `get_colorspace` (inside `init_resources`), `/N` is now validated. When it is missing or invalid:

- the `/Alternate` color space is used when present and itself a usable (non-ICCBased) space — this avoids unbounded recursion on malformed nested ICCBased alternates;
- otherwise the color space is skipped (the existing `if colorspace is not None` guard at the call site handles this), instead of raising or registering a zero-component space.

A valid `/N` (1, 3 or 4) behaves exactly as before.

## Tests

Added `TestColorSpace.test_iccbased_missing_n` in `tests/test_converter.py` (self-contained, building the PDF in-memory via a helper). It asserts:

- missing `/N` with no alternate → the color space is not registered (no crash);
- missing `/N` with `/Alternate /DeviceRGB` → it falls back to a 3-component color space.

`pytest tests/test_converter.py` → 19 passed; `black --check` and `mypy pdfminer/pdfinterp.py` clean. (Two unrelated `test_tools_dumppdf` encryption tests fail locally on Windows due to a temp-file `PermissionError` in the test harness, not touched by this change.)

CHANGELOG.md updated under `[Unreleased] / Fixed`.

---

AI assistance (Claude) was used; I have reviewed every line and run the tests.
