### PR TITLE
Fix Unhandled BrokenPipeError in pdf2txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Switch to `bytearray` in `apply_png_predictor` to avoid out of memory error (and speed it up) ([#1247](https://github.com/pdfminer/pdfminer.six/pull/1247))
 - Check the type of `N` when creating an `ICCBased` color space ([#1252](http3://github.com/pdfminer/pdfminer.six/pull/1253))
 - Endless recursion issue with circular or corrupted `Prev` chains in cross-refeerence tables ([#1253](https://github.com/pdfminer/pdfminer.six/pull/1253))
+- Unhandled BrokenPipeError in pdf2txt ([#875](https://github.com/pdfminer/pdfminer.six/issues/875))
 
 ## [20260107]
 

--- a/pdfminer/converter.py
+++ b/pdfminer/converter.py
@@ -359,7 +359,15 @@ class TextConverter(PDFConverter[AnyIO]):
 
         if self.showpageno:
             self.write_text(f"Page {ltpage.pageid}\n")
-        render(ltpage)
+
+        # catch BrokenPipeError in case text gets piped into a command
+        # which closes the pipe prematurely e.g. `head`
+        try:
+            render(ltpage)
+        except BrokenPipeError as e:
+            # log the trace at debug-lvl to reduce noise
+            log.debug(e, exc_info=True)
+            exit(0)
         self.write_text("\f")
 
     # Some dummy functions to save memory/CPU when all that is wanted

--- a/pdfminer/converter.py
+++ b/pdfminer/converter.py
@@ -359,15 +359,7 @@ class TextConverter(PDFConverter[AnyIO]):
 
         if self.showpageno:
             self.write_text(f"Page {ltpage.pageid}\n")
-
-        # catch BrokenPipeError in case text gets piped into a command
-        # which closes the pipe prematurely e.g. `head`
-        try:
-            render(ltpage)
-        except BrokenPipeError as e:
-            # log the trace at debug-lvl to reduce noise
-            log.debug(e, exc_info=True)
-            exit(0)
+        render(ltpage)
         self.write_text("\f")
 
     # Some dummy functions to save memory/CPU when all that is wanted

--- a/tests/test_tools_pdf2txt.py
+++ b/tests/test_tools_pdf2txt.py
@@ -1,5 +1,7 @@
 import filecmp
 import os
+import shlex
+import subprocess
 from shutil import rmtree
 from tempfile import mkdtemp
 
@@ -222,3 +224,37 @@ class TestDumpImages:
     def test_contrib_issue_1249_evil_xrefs(self):
         """Test for circular xref tables"""
         run(absolute_sample_path("contrib/issue-1249-evil-xrefs.pdf"))
+
+
+class TestShellPipes:
+    def test_contrib_issue_875_broken_pipe(self):
+        """
+        Testing BrokenPipeError in a shell pipe.
+        But using shell=True which is not optimal
+        """
+        absolute_path = absolute_sample_path("nonfree/i1040nr.pdf")
+        pipe_cmd = f"tools/pdf2txt.py {absolute_path} | head -n1"
+        proc = subprocess.run(pipe_cmd, shell=True, capture_output=True)
+        assert not proc.stderr
+
+    def test_contrib_issue_875_broken_pipe_v2(self):
+        """
+        Testing BrokenPipeError v2 without shell=True.
+        But this version does not capture the BrokenPipeError.
+        It seems p2 does not close the pipe to p1
+        when `head` is done reading `-n` lines
+        """
+        absolute_path = absolute_sample_path("nonfree/i1040nr.pdf")
+        cmd = f"tools/pdf2txt.py {absolute_path}"
+        head = "head -n1"
+        p1 = subprocess.Popen(
+            shlex.split(cmd), stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+        p2 = subprocess.Popen(
+            shlex.split(head),
+            stdin=p1.stdout,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        _out, err = p2.communicate()
+        assert not err

--- a/tools/pdf2txt.py
+++ b/tools/pdf2txt.py
@@ -5,6 +5,7 @@ output it to plain text, html, xml or tags.
 
 import argparse
 import logging
+import os
 import sys
 from collections.abc import Container, Iterable
 from typing import Any
@@ -316,8 +317,14 @@ def parse_args(args: list[str] | None) -> argparse.Namespace:
 
 def main(args: list[str] | None = None) -> int:
     parsed_args = parse_args(args)
-    extract_text(**vars(parsed_args))
-    return 0
+    try:
+        extract_text(**vars(parsed_args))
+        return 0
+    except BrokenPipeError:
+        # handling adapted from https://docs.python.org/3/library/signal.html#note-on-sigpipe
+        devnull = os.open(os.devnull, os.O_WRONLY)
+        os.dup2(devnull, sys.stdout.fileno())
+        return 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #875

**Pull request**

Piping a long text extracted with pdf2txt into the `head` command raises a `BrokenPipeError`
The BrokenPipeError is catched in the `TextConverter` class, logged to debug and pdf2txt tool is exited.

**How Has This Been Tested?**

Running `make check` and adding a test checking the stderr of `pdf2txt nonfree/i1040nr.pdf | head -n1` 

**Checklist**

- [x] I have read [CONTRIBUTING.md](https://github.com/pdfminer/pdfminer.six/blob/master/CONTRIBUTING.md).
- [x] I have added a concise human-readable description of the change to [CHANGELOG.md](https://github.com/pdfminer/pdfminer.six/blob/master/CHANGELOG.md).
- [x] I have tested that this fix is effective or that this feature works.
- [x] I have added docstrings to newly created methods and classes.
- [x] I have updated the [README.md](https://github.com/pdfminer/pdfminer.six/blob/master/README.md) and the [readthedocs](https://github.com/pdfminer/pdfminer.six/tree/master/docs/source) documentation. Or verified that this is not necessary.
