### PR TITLE
Use full row width for PNG predictor prior rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Reproducibility issue when generating cmap `.json.gz` files ([#1242](https://github.com/pdfminer/pdfminer.six/pull/1242))
 - Switch to `bytearray` in `apply_png_predictor` to avoid out of memory error (and speed it up) ([#1247](https://github.com/pdfminer/pdfminer.six/pull/1247))
+- Initialize PNG predictor prior rows with the full decoded row width ([#1269](https://github.com/pdfminer/pdfminer.six/issues/1269))
 - Check the type of `N` when creating an `ICCBased` color space ([#1252](http3://github.com/pdfminer/pdfminer.six/pull/1253))
 - Endless recursion issue with circular or corrupted `Prev` chains in cross-refeerence tables ([#1253](https://github.com/pdfminer/pdfminer.six/pull/1253))
 

--- a/pdfminer/utils.py
+++ b/pdfminer/utils.py
@@ -168,7 +168,7 @@ def apply_png_predictor(
     nbytes = colors * columns * bitspercomponent // 8
     bpp = colors * bitspercomponent // 8  # number of bytes per complete pixel
     buf = bytearray()
-    line_above = bytearray(columns)
+    line_above = bytearray(nbytes)
     for scanline_i in range(0, len(data), nbytes + 1):
         filter_type = data[scanline_i]
         line_encoded = data[scanline_i + 1 : scanline_i + 1 + nbytes]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,6 +11,7 @@ from pdfminer.utils import (
     Rect,
     apply_matrix_pt,
     apply_matrix_rect,
+    apply_png_predictor,
     format_int_alpha,
     format_int_roman,
     mult_matrix,
@@ -121,6 +122,12 @@ class TestFunctions:
         assert format_int_roman(90) == "xc"
         assert format_int_roman(91) == "xci"
         assert format_int_roman(100) == "c"
+
+
+def test_png_predictor_average_first_rgb_row() -> None:
+    data = bytes([3, 1, 2, 3, 4, 5, 6])
+
+    assert apply_png_predictor(12, 3, 2, 8, data) == bytes([1, 2, 3, 4, 6, 7])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #1269.

The PNG predictor keeps the previously decoded row in `line_above`. For multi-byte rows, the initial value was only `columns` bytes long, so the first decoded row could index past it when an Average or Paeth filter needed prior-row bytes. That matches the `dumppdf -at` traceback from the attached PDF.

This initializes the prior row with the decoded row width instead. The new unit test covers an RGB first row using the Average filter, which used to raise `IndexError` before any PDF-level code could recover.

Validated with:

- `python -m pytest tests\test_utils.py tests\test_tools_dumppdf.py -k "not encryption"`
- `python -m ruff check pdfminer\utils.py tests\test_utils.py`
- `python -m ruff format --check pdfminer\utils.py tests\test_utils.py`
- `python -m py_compile pdfminer\utils.py tests\test_utils.py`
- downloaded the issue attachment locally and ran `python tools\dumppdf.py -a -t <attachment>` with `PYTHONPATH=.`

I left the two encryption dumppdf cases out of the targeted pytest command because they fail on this Windows checkout when the test reopens an already-open `NamedTemporaryFile`; the predictor change is outside that path.
