### PR TITLE
Fix IndexError in apply_png_predictor for wide scanlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- `IndexError` in `apply_png_predictor` when a scanline is wider than `columns` because of multiple colors or 8-bit components ([#1269](https://github.com/pdfminer/pdfminer.six/issues/1269))
 - Reproducibility issue when generating cmap `.json.gz` files ([#1242](https://github.com/pdfminer/pdfminer.six/pull/1242))
 - Switch to `bytearray` in `apply_png_predictor` to avoid out of memory error (and speed it up) ([#1247](https://github.com/pdfminer/pdfminer.six/pull/1247))
 - Check the type of `N` when creating an `ICCBased` color space ([#1252](http3://github.com/pdfminer/pdfminer.six/pull/1253))

--- a/pdfminer/utils.py
+++ b/pdfminer/utils.py
@@ -168,7 +168,7 @@ def apply_png_predictor(
     nbytes = colors * columns * bitspercomponent // 8
     bpp = colors * bitspercomponent // 8  # number of bytes per complete pixel
     buf = bytearray()
-    line_above = bytearray(columns)
+    line_above = bytearray(nbytes)
     for scanline_i in range(0, len(data), nbytes + 1):
         filter_type = data[scanline_i]
         line_encoded = data[scanline_i + 1 : scanline_i + 1 + nbytes]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,6 +11,7 @@ from pdfminer.utils import (
     Rect,
     apply_matrix_pt,
     apply_matrix_rect,
+    apply_png_predictor,
     format_int_alpha,
     format_int_roman,
     mult_matrix,
@@ -121,6 +122,16 @@ class TestFunctions:
         assert format_int_roman(90) == "xc"
         assert format_int_roman(91) == "xci"
         assert format_int_roman(100) == "c"
+
+    def test_apply_png_predictor_multibyte_pixels(self):
+        # colors=3, columns=2 -> a scanline is 6 bytes wide, wider than
+        # `columns`. The first scanline's prior row must be a full-width zero
+        # row, otherwise filter types 3 (Average) and 4 (Paeth) index past it.
+        data = bytes([3]) + bytes([10, 20, 30, 40, 50, 60])
+        result = apply_png_predictor(
+            pred=10, colors=3, columns=2, bitspercomponent=8, data=data
+        )
+        assert result == bytes([10, 20, 30, 45, 60, 75])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Pull request**

Fixes #1269. `apply_png_predictor` seeds the prior row with `line_above = bytearray(columns)`, but a scanline is `nbytes = colors * columns * bitspercomponent // 8` bytes wide. When that is wider than `columns` (multiple colors, or 8-bit components), the first scanline with filter type 3 (Average) or 4 (Paeth) indexes `line_above[j]` past its end and raises `IndexError: list index out of range`. Seeding it with `bytearray(nbytes)` gives the spec-mandated full-width zero prior row, matching the width of the `raw` rows used for every later scanline.

**How Has This Been Tested?**

Added `test_apply_png_predictor_multibyte_pixels` in `tests/test_utils.py`, which decodes a 3-color scanline (6 bytes wide, columns=2) with the Average filter and checks the output. It raises the reported `IndexError` without the fix and passes with it. The full `tests/test_utils.py` suite passes and `ruff` is clean.

**Checklist**

- [x] I have read [CONTRIBUTING.md](https://github.com/pdfminer/pdfminer.six/blob/master/CONTRIBUTING.md).
- [x] I have added a concise human-readable description of the change to [CHANGELOG.md](https://github.com/pdfminer/pdfminer.six/blob/master/CHANGELOG.md).
- [x] I have tested that this fix is effective or that this feature works.
- [ ] I have added docstrings to newly created methods and classes.
- [x] I have updated the [README.md](https://github.com/pdfminer/pdfminer.six/blob/master/README.md) and the [readthedocs](https://github.com/pdfminer/pdfminer.six/tree/master/docs/source) documentation. Or verified that this is not necessary.