### PR TITLE
Handle malformed LZW streams without raising IndexError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Switch to `bytearray` in `apply_png_predictor` to avoid out of memory error (and speed it up) ([#1247](https://github.com/pdfminer/pdfminer.six/pull/1247))
 - Check the type of `N` when creating an `ICCBased` color space ([#1252](http3://github.com/pdfminer/pdfminer.six/pull/1253))
 - Endless recursion issue with circular or corrupted `Prev` chains in cross-refeerence tables ([#1253](https://github.com/pdfminer/pdfminer.six/pull/1253))
+- `IndexError` when decoding a malformed LZW stream that omits the initial clear code ([#1276](https://github.com/pdfminer/pdfminer.six/pull/1276))
 
 ## [20260107]
 

--- a/pdfminer/lzw.py
+++ b/pdfminer/lzw.py
@@ -58,6 +58,13 @@ class LZWDecoder:
         elif code == 257:
             pass
         elif not self.prevbuf:
+            # First code after a clear (or at the very start) must be a literal
+            # already present in the table. A malformed stream that omits the
+            # initial clear code, or sends an out-of-range code here, would
+            # otherwise raise IndexError; treat it as corrupt data so run()
+            # stops gracefully instead.
+            if code >= len(self.table):
+                raise CorruptDataError
             x = self.prevbuf = cast(bytes, self.table[code])  # assume not None
         else:
             if code < len(self.table):

--- a/tests/test_pdfminer_lzw.py
+++ b/tests/test_pdfminer_lzw.py
@@ -1,0 +1,29 @@
+from pdfminer.lzw import lzwdecode
+
+
+def _pack(codes, width=9):
+    """Pack a sequence of codes MSB-first at a fixed bit width, matching
+    LZWDecoder.readbits."""
+    bits = "".join(format(c, "0{}b".format(width)) for c in codes)
+    while len(bits) % 8:
+        bits += "0"
+    return bytes(int(bits[i : i + 8], 2) for i in range(0, len(bits), 8))
+
+
+class TestLZWDecoder:
+    def test_valid_stream_decodes(self):
+        # clear(256), 'A'(65), 'B'(66), end-of-data(257)
+        data = _pack([256, 65, 66, 257])
+        assert lzwdecode(data) == b"AB"
+
+    def test_missing_clear_code_is_not_fatal(self):
+        # A stream that never sends the clear code (256) leaves the table
+        # uninitialised. This must degrade gracefully rather than raising an
+        # uncaught IndexError from table[code].
+        assert lzwdecode(b"\x00\x00") == b""
+
+    def test_out_of_range_first_code_is_not_fatal(self):
+        # First code after an initial clear must be a literal in the table; an
+        # out-of-range code here is corrupt data, not an IndexError.
+        data = _pack([256, 300])
+        assert lzwdecode(data) == b""


### PR DESCRIPTION
### Problem

`LZWDecoder.feed()` indexes `self.table[code]` in the branch that handles the first code after a clear code (or the very start of the stream):

```python
elif not self.prevbuf:
    x = self.prevbuf = cast(bytes, self.table[code])  # assume not None
```

A malformed LZW stream that omits the initial clear code (256) leaves `self.table` empty, so `table[code]` raises `IndexError`. A stream that sends an out-of-range code right after a clear also lands here with the same result. `run()` only stops on `CorruptDataError`/`EOFError`, so this `IndexError` propagates out of `lzwdecode()` uncaught.

Reproduce:

```python
from pdfminer.lzw import lzwdecode
lzwdecode(b'\x00\x00')   # IndexError: list index out of range
```

### Fix

Raise `CorruptDataError` when `code` is not already present in the table, so `run()` stops decoding gracefully, exactly as it does for other corrupt data. Valid streams are unaffected.

### Tests

Added `tests/test_pdfminer_lzw.py`: a valid stream still decodes correctly, and malformed streams (missing clear code, out-of-range first code) now return `b''` instead of raising. The two malformed cases fail with `IndexError` before this change and pass after. The full `tests/test_tools_pdf2txt.py` suite (which exercises real LZW-encoded PDFs) still passes (41 tests).