### PR TITLE
Handle truncated runs in rldecode instead of raising StopIteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- `rldecode` raising `StopIteration`/`RuntimeError` on a truncated RunLength stream ([#1280](https://github.com/pdfminer/pdfminer.six/pull/1280))
 - Reproducibility issue when generating cmap `.json.gz` files ([#1242](https://github.com/pdfminer/pdfminer.six/pull/1242))
 - Switch to `bytearray` in `apply_png_predictor` to avoid out of memory error (and speed it up) ([#1247](https://github.com/pdfminer/pdfminer.six/pull/1247))
 - Check the type of `N` when creating an `ICCBased` color space ([#1252](http3://github.com/pdfminer/pdfminer.six/pull/1253))

--- a/pdfminer/runlength.py
+++ b/pdfminer/runlength.py
@@ -22,15 +22,27 @@ def rldecode(data: bytes) -> bytes:
     decoded_array: list[int] = []
     data_iter = iter(data)
 
+    # A sentinel that cannot be a byte value, so a truncated run (one whose
+    # length byte is not followed by enough data) is detected instead of
+    # letting next() raise StopIteration, which would surface as a bare
+    # StopIteration or, from inside a generator expression, a RuntimeError.
+    _END = -1
+
     while True:
         length = next(data_iter, 128)
         if length == 128:
             break
 
         if 0 <= length < 128:
-            decoded_array.extend(next(data_iter) for _ in range(length + 1))
+            for _ in range(length + 1):
+                value = next(data_iter, _END)
+                if value == _END:
+                    return bytes(decoded_array)
+                decoded_array.append(value)
 
         if length > 128:
-            run = [next(data_iter)] * (257 - length)
-            decoded_array.extend(run)
+            value = next(data_iter, _END)
+            if value == _END:
+                return bytes(decoded_array)
+            decoded_array.extend([value] * (257 - length))
     return bytes(decoded_array)

--- a/tests/test_pdfminer_crypto.py
+++ b/tests/test_pdfminer_crypto.py
@@ -73,6 +73,13 @@ class TestRunlength:
     def test_rldecode(self):
         assert rldecode(b"\x05123456\xfa7\x04abcde\x80junk") == b"1234567777777abcde"
 
+    def test_rldecode_truncated(self):
+        # A run whose length byte is not followed by enough data used to raise
+        # StopIteration (or RuntimeError from the generator expression). It
+        # should return what was decoded so far instead.
+        assert rldecode(b"\x81") == b""  # repeat run with no data byte
+        assert rldecode(b"\x04AB") == b"AB"  # literal run wants 5 bytes, has 2
+
 
 class TestAES:
     def test_unpad_aes(self):


### PR DESCRIPTION
A truncated RunLength stream makes `rldecode` raise instead of returning:

```python
from pdfminer.runlength import rldecode
rldecode(b"\x81")        # StopIteration
rldecode(b"\xfeAB")      # RuntimeError: generator raised StopIteration
```

When a run's length byte isn't followed by enough data, `next(data_iter)` is called with no default, so it raises `StopIteration` (bare, or turned into a `RuntimeError` by PEP 479 when it happens inside the generator expression). I read each byte with a sentinel default and return what was decoded so far when the stream is truncated, which keeps the valid prefix instead of raising.

Added a truncation test next to the existing `test_rldecode`; it raises StopIteration on master and passes with the change, and the existing rldecode test still passes. Found it by fuzzing the stream filters with mutated input.