### PR TITLE
Warn when saving an image with undetermined encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Restore `cmap` and `cmap_clean` targets to `Makefile ([#1256](https://github.com/pdfminer/pdfminer.six/pull/1256))
 
+### Added
+
+- Warn when an image is written to disk as raw bytes because its encoding could not be determined ([#433](https://github.com/pdfminer/pdfminer.six/issues/433))
+
 ### Fixed
 
 - Reproducibility issue when generating cmap `.json.gz` files ([#1242](https://github.com/pdfminer/pdfminer.six/pull/1242))

--- a/pdfminer/image.py
+++ b/pdfminer/image.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import os.path
 import struct
@@ -20,6 +21,8 @@ from pdfminer.pdftypes import (
     LITERALS_JBIG2_DECODE,
     LITERALS_JPX_DECODE,
 )
+
+logger = logging.getLogger(__name__)
 
 PIL_ERROR_MESSAGE = (
     "Could not import Pillow. This dependency of pdfminer.six is not "
@@ -270,6 +273,17 @@ class ImageWriter:
         """Save an image with unknown encoding"""
         ext = f".{image.bits}.{image.srcsize[0]}x{image.srcsize[1]}.img"
         name, path = self._create_unique_image_name(image, ext)
+
+        # The encoding of this image could not be determined, so the raw bytes
+        # are written to disk as-is. These .img files cannot be opened by most
+        # image viewers, so warn the user that the output needs attention.
+        logger.warning(
+            "Could not determine the image encoding of %r, writing raw image "
+            "data to %r instead. This file is unlikely to be viewable by most "
+            "image viewers.",
+            image.name,
+            name,
+        )
 
         with open(path, "wb") as fp:
             fp.write(image.stream.get_data())

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,0 +1,35 @@
+import logging
+from tempfile import TemporaryDirectory
+
+from pdfminer.image import ImageWriter
+
+
+class _FakeStream:
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    def get_data(self) -> bytes:
+        return self._data
+
+
+class _FakeImage:
+    """Minimal stand-in for LTImage with the attributes _save_raw uses."""
+
+    def __init__(self) -> None:
+        self.name = "img-unknown"
+        self.bits = 8
+        self.srcsize = (2, 2)
+        self.stream = _FakeStream(b"\x00\x01\x02\x03")
+
+
+def test_save_raw_warns_about_unknown_encoding(caplog):
+    with TemporaryDirectory() as outdir:
+        writer = ImageWriter(outdir)
+        with caplog.at_level(logging.WARNING, logger="pdfminer.image"):
+            name = writer._save_raw(_FakeImage())
+
+    assert name.endswith(".img")
+    assert any(
+        record.levelno == logging.WARNING and "img-unknown" in record.getMessage()
+        for record in caplog.records
+    )


### PR DESCRIPTION
Fixes #433.

When `ImageWriter` cannot work out an image's encoding it falls back to `_save_raw`, which writes the raw stream bytes to a `.img` file. Those files can't be opened by most image viewers, and right now nothing tells the user that happened, so the output just looks broken. This adds a warning that names the image and the file that was written, so it's clear the encoding wasn't recognised rather than the extraction being wrong.

The default output is unchanged, it only adds a log message on the raw fallback path.

**How Has This Been Tested?**

`make check` passes. I also added a test in `tests/test_image.py` that runs an image with unknown encoding through `_save_raw` and asserts the warning is emitted.

**Checklist**

- [x] I have read [CONTRIBUTING.md](https://github.com/pdfminer/pdfminer.six/blob/master/CONTRIBUTING.md).
- [x] I have added a concise human-readable description of the change to [CHANGELOG.md](https://github.com/pdfminer/pdfminer.six/blob/master/CHANGELOG.md).
- [x] I have tested that this fix is effective or that this feature works.
- [x] I have added docstrings to newly created methods and classes.
- [x] I have updated the README.md and the readthedocs documentation. Or verified that this is not necessary.
