### PR TITLE
Honor default V4 crypt filter values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Honor default V4 crypt-filter entries and reject missing methods with `PDFEncryptionError` ([#1283](https://github.com/pdfminer/pdfminer.six/issues/1283))
 - Reproducibility issue when generating cmap `.json.gz` files ([#1242](https://github.com/pdfminer/pdfminer.six/pull/1242))
 - Switch to `bytearray` in `apply_png_predictor` to avoid out of memory error (and speed it up) ([#1247](https://github.com/pdfminer/pdfminer.six/pull/1247))
 - Check the type of `N` when creating an `ICCBased` color space ([#1252](http3://github.com/pdfminer/pdfminer.six/pull/1253))

--- a/pdfminer/pdfdocument.py
+++ b/pdfminer/pdfdocument.py
@@ -479,15 +479,16 @@ class PDFStandardSecurityHandlerV4(PDFStandardSecurityHandler):
         super().init_params()
         self.length = 128
         self.cf = dict_value(self.param.get("CF"))
-        self.stmf = literal_name(self.param["StmF"])
-        self.strf = literal_name(self.param["StrF"])
+        self.stmf = literal_name(self.param.get("StmF", LIT("Identity")))
+        self.strf = literal_name(self.param.get("StrF", LIT("Identity")))
         self.encrypt_metadata = bool(self.param.get("EncryptMetadata", True))
         if self.stmf != self.strf:
             error_msg = f"Unsupported crypt filter: param={self.param!r}"
             raise PDFEncryptionError(error_msg)
         self.cfm = {}
         for k, v in self.cf.items():
-            f = self.get_cfm(literal_name(v["CFM"]))
+            params = dict_value(v)
+            f = self.get_cfm(literal_name(params.get("CFM", LIT("None"))))
             if f is None:
                 error_msg = f"Unknown crypt filter method: param={self.param!r}"
                 raise PDFEncryptionError(error_msg)
@@ -498,12 +499,11 @@ class PDFStandardSecurityHandlerV4(PDFStandardSecurityHandler):
             raise PDFEncryptionError(error_msg)
 
     def get_cfm(self, name: str) -> Callable[[int, int, bytes], bytes] | None:
-        if name == "V2":
-            return self.decrypt_rc4
-        elif name == "AESV2":
-            return self.decrypt_aes128
-        else:
-            return None
+        return {
+            "None": self.decrypt_identity,
+            "V2": self.decrypt_rc4,
+            "AESV2": self.decrypt_aes128,
+        }.get(name)
 
     def decrypt(
         self,

--- a/tests/test_pdfdocument.py
+++ b/tests/test_pdfdocument.py
@@ -2,11 +2,16 @@ import itertools
 
 import pytest
 
-from pdfminer.pdfdocument import PDFDocument, PDFNoPageLabels
+from pdfminer.pdfdocument import (
+    PDFDocument,
+    PDFNoPageLabels,
+    PDFStandardSecurityHandlerV4,
+)
 from pdfminer.pdfexceptions import PDFObjectNotFound
 from pdfminer.pdfpage import PDFPage
 from pdfminer.pdfparser import PDFParser
 from pdfminer.pdftypes import dict_value, int_value
+from pdfminer.psparser import LIT
 from tests.helpers import absolute_sample_path
 
 
@@ -27,6 +32,40 @@ class TestPdfDocument:
             parser = PDFParser(fp)
             doc = PDFDocument(parser)
             assert doc.info == [{"Producer": b"European Patent Office"}]
+
+    def test_crypt_filter_without_cfm_uses_identity(self):
+        handler = PDFStandardSecurityHandlerV4.__new__(PDFStandardSecurityHandlerV4)
+        handler.param = {
+            "V": 4,
+            "R": 4,
+            "P": -4,
+            "O": b"",
+            "U": b"",
+            "CF": {"StdCF": {"Length": 16}},
+            "StmF": LIT("StdCF"),
+            "StrF": LIT("StdCF"),
+        }
+
+        handler.init_params()
+
+        assert handler.cfm["StdCF"](0, 0, b"ciphertext") == b"ciphertext"
+
+    def test_missing_default_crypt_filters_use_identity(self):
+        handler = PDFStandardSecurityHandlerV4.__new__(PDFStandardSecurityHandlerV4)
+        handler.param = {
+            "V": 4,
+            "R": 4,
+            "P": -4,
+            "O": b"",
+            "U": b"",
+            "CF": {},
+        }
+
+        handler.init_params()
+
+        assert handler.stmf == "Identity"
+        assert handler.strf == "Identity"
+        assert handler.cfm["Identity"](0, 0, b"ciphertext") == b"ciphertext"
 
     def test_page_labels(self):
         path = absolute_sample_path("contrib/pagelabels.pdf")


### PR DESCRIPTION
Fixes #1283.

## Root cause

`PDFStandardSecurityHandlerV4.init_params()` treated `StmF`, `StrF`, and each crypt filter's `CFM` as mandatory. PDF 32000 defines those entries as optional: `StmF` and `StrF` default to `Identity`, and `CFM` defaults to the pass-through `None` method. A PDF that omitted `CFM` consequently escaped the parser's expected exception boundary as `KeyError: 'CFM'` in the public OSS-Fuzz testcase.

## Fix

- Apply the standards-defined defaults for `StmF`, `StrF`, and `CFM`.
- Treat `CFM /None` as an identity/pass-through method.
- Normalize crypt-filter values before reading their entries.
- Keep rejecting genuinely unknown methods with `PDFEncryptionError`.
- Add focused regression coverage for both default paths.

## Verification

- Reproduced OSS-Fuzz testcase `6676856465326080` against current `master`: exit 77 with uncaught `KeyError: 'CFM'`.
- Ran the same target and testcase after the patch: exit 0.
- `make check`: pass.
- Ruff: pass.
- Mypy: pass, 65 source files.
- Pytest: 251 passed.

## AI assistance

Prepared with AI assistance. I independently reviewed and tested the change, understand the crypt-filter behavior, and take responsibility for the contribution. The commit includes an `Assisted-by: OpenAI Codex` trailer.
